### PR TITLE
Refactor: Simplify dictionary crates to only provide metadata and embedded data

### DIFF
--- a/lindera-cc-cedict/src/lib.rs
+++ b/lindera-cc-cedict/src/lib.rs
@@ -11,37 +11,6 @@ use lindera_dictionary::LinderaResult;
 #[cfg(feature = "embedded-cc-cedict")]
 use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
-#[cfg(feature = "cc-cedict")]
-use lindera_dictionary::dictionary_builder::DictionaryBuilder;
-#[cfg(all(feature = "cc-cedict", not(feature = "embedded-cc-cedict")))]
-use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
-#[cfg(feature = "cc-cedict")]
-use metadata::CcCedictMetadata;
-
-#[cfg(feature = "cc-cedict")]
-pub fn create_builder() -> DictionaryBuilder {
-    DictionaryBuilder::new(CcCedictMetadata::metadata())
-}
-
-#[cfg(all(feature = "cc-cedict", not(feature = "embedded-cc-cedict")))]
-pub fn create_loader() -> StandardDictionaryLoader {
-    StandardDictionaryLoader::new(
-        "CC-CEDICT".to_string(),
-        vec![
-            "./dict/cc-cedict".to_string(),
-            "./lindera-cc-cedict".to_string(),
-            "/usr/local/share/lindera/cc-cedict".to_string(),
-            "/usr/share/lindera/cc-cedict".to_string(),
-        ],
-        "LINDERA_CC_CEDICT_PATH".to_string(),
-    )
-}
-
-#[cfg(feature = "embedded-cc-cedict")]
-pub fn create_loader() -> EmbeddedLoader {
-    EmbeddedLoader
-}
-
 #[cfg(feature = "embedded-cc-cedict")]
 pub struct EmbeddedLoader;
 

--- a/lindera-dictionary/src/dictionary_builder/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_builder/prefix_dictionary.rs
@@ -466,10 +466,10 @@ mod tests {
 
         assert_eq!(builder.schema.name, "IPADIC");
         assert_eq!(builder.schema.version, "2.7.0");
-        assert_eq!(builder.flexible_csv, true);
+        assert!(builder.flexible_csv);
         assert_eq!(builder.encoding, "UTF-8");
-        assert_eq!(builder.normalize_details, false);
-        assert_eq!(builder.skip_invalid_cost_or_id, false);
+        assert!(!builder.normalize_details);
+        assert!(!builder.skip_invalid_cost_or_id);
     }
 
     #[test]

--- a/lindera-ipadic-neologd/src/lib.rs
+++ b/lindera-ipadic-neologd/src/lib.rs
@@ -11,37 +11,6 @@ use lindera_dictionary::LinderaResult;
 #[cfg(feature = "embedded-ipadic-neologd")]
 use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
-#[cfg(feature = "ipadic-neologd")]
-use lindera_dictionary::dictionary_builder::DictionaryBuilder;
-#[cfg(all(feature = "ipadic-neologd", not(feature = "embedded-ipadic-neologd")))]
-use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
-#[cfg(feature = "ipadic-neologd")]
-use metadata::IpadicNeologdMetadata;
-
-#[cfg(feature = "ipadic-neologd")]
-pub fn create_builder() -> DictionaryBuilder {
-    DictionaryBuilder::new(IpadicNeologdMetadata::metadata())
-}
-
-#[cfg(all(feature = "ipadic-neologd", not(feature = "embedded-ipadic-neologd")))]
-pub fn create_loader() -> StandardDictionaryLoader {
-    StandardDictionaryLoader::new(
-        "IPADIC-NEologd".to_string(),
-        vec![
-            "./dict/ipadic-neologd".to_string(),
-            "./lindera-ipadic-neologd".to_string(),
-            "/usr/local/share/lindera/ipadic-neologd".to_string(),
-            "/usr/share/lindera/ipadic-neologd".to_string(),
-        ],
-        "LINDERA_IPADIC_NEOLOGD_PATH".to_string(),
-    )
-}
-
-#[cfg(feature = "embedded-ipadic-neologd")]
-pub fn create_loader() -> EmbeddedLoader {
-    EmbeddedLoader
-}
-
 #[cfg(feature = "embedded-ipadic-neologd")]
 pub struct EmbeddedLoader;
 

--- a/lindera-ipadic/src/lib.rs
+++ b/lindera-ipadic/src/lib.rs
@@ -11,37 +11,6 @@ use lindera_dictionary::LinderaResult;
 #[cfg(feature = "embedded-ipadic")]
 use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
-#[cfg(feature = "ipadic")]
-use lindera_dictionary::dictionary_builder::DictionaryBuilder;
-#[cfg(all(feature = "ipadic", not(feature = "embedded-ipadic")))]
-use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
-#[cfg(feature = "ipadic")]
-use metadata::IpadicMetadata;
-
-#[cfg(feature = "ipadic")]
-pub fn create_builder() -> DictionaryBuilder {
-    DictionaryBuilder::new(IpadicMetadata::metadata())
-}
-
-#[cfg(all(feature = "ipadic", not(feature = "embedded-ipadic")))]
-pub fn create_loader() -> StandardDictionaryLoader {
-    StandardDictionaryLoader::new(
-        "IPADIC".to_string(),
-        vec![
-            "./dict/ipadic".to_string(),
-            "./lindera-ipadic".to_string(),
-            "/usr/local/share/lindera/ipadic".to_string(),
-            "/usr/share/lindera/ipadic".to_string(),
-        ],
-        "LINDERA_IPADIC_PATH".to_string(),
-    )
-}
-
-#[cfg(feature = "embedded-ipadic")]
-pub fn create_loader() -> EmbeddedLoader {
-    EmbeddedLoader
-}
-
 #[cfg(feature = "embedded-ipadic")]
 pub struct EmbeddedLoader;
 

--- a/lindera-ko-dic/src/lib.rs
+++ b/lindera-ko-dic/src/lib.rs
@@ -11,37 +11,6 @@ use lindera_dictionary::LinderaResult;
 #[cfg(feature = "embedded-ko-dic")]
 use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
-#[cfg(feature = "ko-dic")]
-use lindera_dictionary::dictionary_builder::DictionaryBuilder;
-#[cfg(all(feature = "ko-dic", not(feature = "embedded-ko-dic")))]
-use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
-#[cfg(feature = "ko-dic")]
-use metadata::KoDicMetadata;
-
-#[cfg(feature = "ko-dic")]
-pub fn create_builder() -> DictionaryBuilder {
-    DictionaryBuilder::new(KoDicMetadata::metadata())
-}
-
-#[cfg(all(feature = "ko-dic", not(feature = "embedded-ko-dic")))]
-pub fn create_loader() -> StandardDictionaryLoader {
-    StandardDictionaryLoader::new(
-        "Ko-Dic".to_string(),
-        vec![
-            "./dict/ko-dic".to_string(),
-            "./lindera-ko-dic".to_string(),
-            "/usr/local/share/lindera/ko-dic".to_string(),
-            "/usr/share/lindera/ko-dic".to_string(),
-        ],
-        "LINDERA_KO_DIC_PATH".to_string(),
-    )
-}
-
-#[cfg(feature = "embedded-ko-dic")]
-pub fn create_loader() -> EmbeddedLoader {
-    EmbeddedLoader
-}
-
 #[cfg(feature = "embedded-ko-dic")]
 pub struct EmbeddedLoader;
 

--- a/lindera-unidic/src/lib.rs
+++ b/lindera-unidic/src/lib.rs
@@ -11,37 +11,6 @@ use lindera_dictionary::LinderaResult;
 #[cfg(feature = "embedded-unidic")]
 use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
-#[cfg(feature = "unidic")]
-use lindera_dictionary::dictionary_builder::DictionaryBuilder;
-#[cfg(all(feature = "unidic", not(feature = "embedded-unidic")))]
-use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
-#[cfg(feature = "unidic")]
-use metadata::UnidicMetadata;
-
-#[cfg(feature = "unidic")]
-pub fn create_builder() -> DictionaryBuilder {
-    DictionaryBuilder::new(UnidicMetadata::metadata())
-}
-
-#[cfg(all(feature = "unidic", not(feature = "embedded-unidic")))]
-pub fn create_loader() -> StandardDictionaryLoader {
-    StandardDictionaryLoader::new(
-        "UniDic".to_string(),
-        vec![
-            "./dict/unidic".to_string(),
-            "./lindera-unidic".to_string(),
-            "/usr/local/share/lindera/unidic".to_string(),
-            "/usr/share/lindera/unidic".to_string(),
-        ],
-        "LINDERA_UNIDIC_PATH".to_string(),
-    )
-}
-
-#[cfg(feature = "embedded-unidic")]
-pub fn create_loader() -> EmbeddedLoader {
-    EmbeddedLoader
-}
-
 #[cfg(feature = "embedded-unidic")]
 pub struct EmbeddedLoader;
 

--- a/lindera/examples/test_all_embedded_features.rs
+++ b/lindera/examples/test_all_embedded_features.rs
@@ -41,7 +41,7 @@ fn main() {
 
     println!("\n=== Dictionary Variants ===");
     let variants = lindera::dictionary::DictionaryKind::contained_variants();
-    println!("contained_variants: {:?}", variants);
+    println!("contained_variants: {variants:?}");
     println!("contained_variants count: {}", variants.len());
 
     println!("\n=== Available Dictionaries ===");

--- a/lindera/examples/test_features.rs
+++ b/lindera/examples/test_features.rs
@@ -8,6 +8,6 @@ fn main() {
     println!("mmap feature: {}", cfg!(feature = "mmap"));
 
     let variants = lindera::dictionary::DictionaryKind::contained_variants();
-    println!("contained_variants: {:?}", variants);
+    println!("contained_variants: {variants:?}");
     println!("contained_variants count: {}", variants.len());
 }

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -7,8 +7,16 @@ use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 use lindera_dictionary::dictionary_builder::DictionaryBuilder;
-use lindera_dictionary::dictionary_loader::DictionaryLoader;
 use lindera_dictionary::dictionary_loader::user_dictionary::UserDictionaryLoader;
+use lindera_dictionary::dictionary_loader::DictionaryLoader;
+#[cfg(any(
+    all(feature = "ipadic", not(feature = "embedded-ipadic")),
+    all(feature = "ipadic-neologd", not(feature = "embedded-ipadic-neologd")),
+    all(feature = "unidic", not(feature = "embedded-unidic")),
+    all(feature = "ko-dic", not(feature = "embedded-ko-dic")),
+    all(feature = "cc-cedict", not(feature = "embedded-cc-cedict"))
+))]
+use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
 
 use crate::LinderaResult;
 use crate::error::{LinderaError, LinderaErrorKind};
@@ -82,27 +90,37 @@ pub type UserDictionaryConfig = Value;
 pub fn resolve_builder(dictionary_type: DictionaryKind) -> LinderaResult<DictionaryBuilder> {
     match dictionary_type {
         #[cfg(feature = "ipadic")]
-        DictionaryKind::IPADIC => Ok(lindera_ipadic::create_builder()),
+        DictionaryKind::IPADIC => Ok(DictionaryBuilder::new(
+            lindera_ipadic::metadata::IpadicMetadata::metadata(),
+        )),
         #[cfg(not(feature = "ipadic"))]
         DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
         #[cfg(feature = "ipadic-neologd")]
-        DictionaryKind::IPADICNEologd => Ok(lindera_ipadic_neologd::create_builder()),
+        DictionaryKind::IPADICNEologd => Ok(DictionaryBuilder::new(
+            lindera_ipadic_neologd::metadata::IpadicNeologdMetadata::metadata(),
+        )),
         #[cfg(not(feature = "ipadic-neologd"))]
         DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
         #[cfg(feature = "unidic")]
-        DictionaryKind::UniDic => Ok(lindera_unidic::create_builder()),
+        DictionaryKind::UniDic => Ok(DictionaryBuilder::new(
+            lindera_unidic::metadata::UnidicMetadata::metadata(),
+        )),
         #[cfg(not(feature = "unidic"))]
         DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("UniDic feature is not enabled"))),
         #[cfg(feature = "ko-dic")]
-        DictionaryKind::KoDic => Ok(lindera_ko_dic::create_builder()),
+        DictionaryKind::KoDic => Ok(DictionaryBuilder::new(
+            lindera_ko_dic::metadata::KoDicMetadata::metadata(),
+        )),
         #[cfg(not(feature = "ko-dic"))]
         DictionaryKind::KoDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("KO-DIC feature is not enabled"))),
         #[cfg(feature = "cc-cedict")]
-        DictionaryKind::CcCedict => Ok(lindera_cc_cedict::create_builder()),
+        DictionaryKind::CcCedict => Ok(DictionaryBuilder::new(
+            lindera_cc_cedict::metadata::CcCedictMetadata::metadata(),
+        )),
         #[cfg(not(feature = "cc-cedict"))]
         DictionaryKind::CcCedict => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("CC-CEDICT feature is not enabled"))),
@@ -111,28 +129,83 @@ pub fn resolve_builder(dictionary_type: DictionaryKind) -> LinderaResult<Diction
 
 pub fn resolve_loader(dictionary_type: DictionaryKind) -> LinderaResult<Box<dyn DictionaryLoader>> {
     match dictionary_type {
-        #[cfg(feature = "ipadic")]
-        DictionaryKind::IPADIC => Ok(Box::new(lindera_ipadic::create_loader())),
+        #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+        DictionaryKind::IPADIC => Ok(Box::new(lindera_ipadic::EmbeddedLoader)),
+        #[cfg(all(feature = "ipadic", not(feature = "embedded-ipadic")))]
+        DictionaryKind::IPADIC => Ok(Box::new(StandardDictionaryLoader::new(
+            "IPADIC".to_string(),
+            vec![
+                "./dict/ipadic".to_string(),
+                "./lindera-ipadic".to_string(),
+                "/usr/local/share/lindera/ipadic".to_string(),
+                "/usr/share/lindera/ipadic".to_string(),
+            ],
+            "LINDERA_IPADIC_PATH".to_string(),
+        ))),
         #[cfg(not(feature = "ipadic"))]
         DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
-        #[cfg(feature = "ipadic-neologd")]
-        DictionaryKind::IPADICNEologd => Ok(Box::new(lindera_ipadic_neologd::create_loader())),
+        #[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
+        DictionaryKind::IPADICNEologd => Ok(Box::new(lindera_ipadic_neologd::EmbeddedLoader)),
+        #[cfg(all(feature = "ipadic-neologd", not(feature = "embedded-ipadic-neologd")))]
+        DictionaryKind::IPADICNEologd => Ok(Box::new(StandardDictionaryLoader::new(
+            "IPADIC-NEologd".to_string(),
+            vec![
+                "./dict/ipadic-neologd".to_string(),
+                "./lindera-ipadic-neologd".to_string(),
+                "/usr/local/share/lindera/ipadic-neologd".to_string(),
+                "/usr/share/lindera/ipadic-neologd".to_string(),
+            ],
+            "LINDERA_IPADIC_NEOLOGD_PATH".to_string(),
+        ))),
         #[cfg(not(feature = "ipadic-neologd"))]
         DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
-        #[cfg(feature = "unidic")]
-        DictionaryKind::UniDic => Ok(Box::new(lindera_unidic::create_loader())),
+        #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
+        DictionaryKind::UniDic => Ok(Box::new(lindera_unidic::EmbeddedLoader)),
+        #[cfg(all(feature = "unidic", not(feature = "embedded-unidic")))]
+        DictionaryKind::UniDic => Ok(Box::new(StandardDictionaryLoader::new(
+            "UniDic".to_string(),
+            vec![
+                "./dict/unidic".to_string(),
+                "./lindera-unidic".to_string(),
+                "/usr/local/share/lindera/unidic".to_string(),
+                "/usr/share/lindera/unidic".to_string(),
+            ],
+            "LINDERA_UNIDIC_PATH".to_string(),
+        ))),
         #[cfg(not(feature = "unidic"))]
         DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("UniDic feature is not enabled"))),
-        #[cfg(feature = "ko-dic")]
-        DictionaryKind::KoDic => Ok(Box::new(lindera_ko_dic::create_loader())),
+        #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+        DictionaryKind::KoDic => Ok(Box::new(lindera_ko_dic::EmbeddedLoader)),
+        #[cfg(all(feature = "ko-dic", not(feature = "embedded-ko-dic")))]
+        DictionaryKind::KoDic => Ok(Box::new(StandardDictionaryLoader::new(
+            "Ko-Dic".to_string(),
+            vec![
+                "./dict/ko-dic".to_string(),
+                "./lindera-ko-dic".to_string(),
+                "/usr/local/share/lindera/ko-dic".to_string(),
+                "/usr/share/lindera/ko-dic".to_string(),
+            ],
+            "LINDERA_KO_DIC_PATH".to_string(),
+        ))),
         #[cfg(not(feature = "ko-dic"))]
         DictionaryKind::KoDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("KO-DIC feature is not enabled"))),
-        #[cfg(feature = "cc-cedict")]
-        DictionaryKind::CcCedict => Ok(Box::new(lindera_cc_cedict::create_loader())),
+        #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
+        DictionaryKind::CcCedict => Ok(Box::new(lindera_cc_cedict::EmbeddedLoader)),
+        #[cfg(all(feature = "cc-cedict", not(feature = "embedded-cc-cedict")))]
+        DictionaryKind::CcCedict => Ok(Box::new(StandardDictionaryLoader::new(
+            "CC-CEDICT".to_string(),
+            vec![
+                "./dict/cc-cedict".to_string(),
+                "./lindera-cc-cedict".to_string(),
+                "/usr/local/share/lindera/cc-cedict".to_string(),
+                "/usr/share/lindera/cc-cedict".to_string(),
+            ],
+            "LINDERA_CC_CEDICT_PATH".to_string(),
+        ))),
         #[cfg(not(feature = "cc-cedict"))]
         DictionaryKind::CcCedict => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("CC-CEDICT feature is not enabled"))),

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -7,7 +7,6 @@ use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 use lindera_dictionary::dictionary_builder::DictionaryBuilder;
-use lindera_dictionary::dictionary_loader::user_dictionary::UserDictionaryLoader;
 use lindera_dictionary::dictionary_loader::DictionaryLoader;
 #[cfg(any(
     all(feature = "ipadic", not(feature = "embedded-ipadic")),
@@ -17,6 +16,7 @@ use lindera_dictionary::dictionary_loader::DictionaryLoader;
     all(feature = "cc-cedict", not(feature = "embedded-cc-cedict"))
 ))]
 use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
+use lindera_dictionary::dictionary_loader::user_dictionary::UserDictionaryLoader;
 
 use crate::LinderaResult;
 use crate::error::{LinderaError, LinderaErrorKind};


### PR DESCRIPTION
Refactor: Simplify dictionary crates to only provide metadata and embedded data

  - Remove create_loader() and create_builder() functions from dictionary crates
  - Consolidate loader/builder creation logic in lindera/src/dictionary.rs
  - Dictionary crates now only provide metadata, schema, and embedded data
  - Add conditional imports to fix unused import warnings
  - Fix all clippy warnings with cargo clippy --fix

This change improves separation of concerns by making dictionary crates
focus solely on data provision while centralizing loader/builder creation
in the main lindera crate.