### PR TITLE
Refactor dictionary architecture: simplify loaders and consolidate responsibilities

### DIFF
--- a/lindera-cc-cedict/src/embedded.rs
+++ b/lindera-cc-cedict/src/embedded.rs
@@ -12,6 +12,7 @@ use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix
 use lindera_dictionary::dictionary::metadata::Metadata;
 use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
 use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
+use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
 macro_rules! decompress_data {
     ($name: ident, $bytes: expr, $filename: literal) => {
@@ -128,5 +129,23 @@ pub fn load() -> LinderaResult<Dictionary> {
             unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
             metadata,
         })
+    }
+}
+
+pub struct EmbeddedLoader;
+
+impl EmbeddedLoader {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn load(&self) -> LinderaResult<Dictionary> {
+        load()
+    }
+}
+
+impl DictionaryLoader for EmbeddedLoader {
+    fn load(&self) -> LinderaResult<Dictionary> {
+        load()
     }
 }

--- a/lindera-cc-cedict/src/lib.rs
+++ b/lindera-cc-cedict/src/lib.rs
@@ -6,28 +6,6 @@ pub mod schema;
 #[cfg(feature = "embedded-cc-cedict")]
 pub mod embedded;
 
-#[cfg(feature = "embedded-cc-cedict")]
-use lindera_dictionary::LinderaResult;
-#[cfg(feature = "embedded-cc-cedict")]
-use lindera_dictionary::dictionary_loader::DictionaryLoader;
-
-#[cfg(feature = "embedded-cc-cedict")]
-pub struct EmbeddedLoader;
-
-#[cfg(feature = "embedded-cc-cedict")]
-impl EmbeddedLoader {
-    pub fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
-#[cfg(feature = "embedded-cc-cedict")]
-impl DictionaryLoader for EmbeddedLoader {
-    fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-dictionary/src/dictionary_loader.rs
+++ b/lindera-dictionary/src/dictionary_loader.rs
@@ -13,89 +13,36 @@ use crate::error::LinderaErrorKind;
 
 /// Common trait for all dictionary loaders (both external and embedded)
 pub trait DictionaryLoader {
-    /// Load dictionary from default location or embedded data
-    fn load(&self) -> LinderaResult<Dictionary>;
+    /// Load dictionary from configured location or embedded data
+    fn load(&self) -> LinderaResult<Dictionary> {
+        Err(LinderaErrorKind::Io.with_error(anyhow::anyhow!(
+            "This loader does not support load function"
+        )))
+    }
 
     /// Load dictionary from a specific path (optional for embedded loaders)
     fn load_from_path(&self, path: &Path) -> LinderaResult<Dictionary> {
-        // Default implementation for embedded loaders that don't support path loading
         let _ = path;
         Err(LinderaErrorKind::Io.with_error(anyhow::anyhow!(
-            "This loader does not support loading from a specific path"
+            "This loader does not support load_from_path function"
         )))
     }
 }
 
-pub struct StandardDictionaryLoader {
-    dictionary_name: String,
-    search_paths: Vec<String>,
-    env_var_name: String,
-}
+pub struct StandardDictionaryLoader;
 
 impl StandardDictionaryLoader {
-    pub fn new(dictionary_name: String, search_paths: Vec<String>, env_var_name: String) -> Self {
-        Self {
-            dictionary_name,
-            search_paths,
-            env_var_name,
-        }
+    pub fn new() -> Self {
+        Self
     }
 
     pub fn load_from_path<P: AsRef<Path>>(&self, dict_path: P) -> LinderaResult<Dictionary> {
         Dictionary::load_from_path(dict_path.as_ref())
     }
-
-    pub fn load(&self) -> LinderaResult<Dictionary> {
-        // Search for dictionary in common locations
-        for path in &self.search_paths {
-            let dict_path = Path::new(path);
-            if dict_path.exists() && dict_path.is_dir() {
-                return self.load_from_path(dict_path);
-            }
-        }
-
-        // If environment variable is set, use that
-        if let Ok(dict_path) = std::env::var(&self.env_var_name) {
-            let path = Path::new(&dict_path);
-            if path.exists() {
-                return self.load_from_path(path);
-            }
-        }
-
-        Err(LinderaErrorKind::Io.with_error(anyhow::anyhow!(
-            "{} dictionary not found. Please set {} environment variable or place dictionary files in one of these locations: {}",
-            self.dictionary_name, self.env_var_name, self.search_paths.join(", ")
-        )))
-    }
 }
 
 impl DictionaryLoader for StandardDictionaryLoader {
-    fn load(&self) -> LinderaResult<Dictionary> {
-        // Search for dictionary in common locations
-        for path in &self.search_paths {
-            let dict_path = Path::new(path);
-            if dict_path.exists() && dict_path.is_dir() {
-                return self.load_from_path(dict_path);
-            }
-        }
-
-        // If environment variable is set, use that
-        if let Ok(dict_path) = std::env::var(&self.env_var_name) {
-            let path = Path::new(&dict_path);
-            if path.exists() {
-                return self.load_from_path(path);
-            }
-        }
-
-        Err(LinderaErrorKind::Io.with_error(anyhow::anyhow!(
-            "{} dictionary not found. Please set {} environment variable or place dictionary files in one of these locations: {}",
-            self.dictionary_name, self.env_var_name, self.search_paths.join(", ")
-        )))
-    }
-
     fn load_from_path(&self, dict_path: &Path) -> LinderaResult<Dictionary> {
-        // StandardDictionaryLoader always uses the default (non-mmap) loading
-        // Users can control mmap usage through config or explicit API calls
         Dictionary::load_from_path(dict_path)
     }
 }

--- a/lindera-ipadic-neologd/src/embedded.rs
+++ b/lindera-ipadic-neologd/src/embedded.rs
@@ -12,6 +12,7 @@ use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix
 use lindera_dictionary::dictionary::metadata::Metadata;
 use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
 use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
+use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
 macro_rules! decompress_data {
     ($name: ident, $bytes: expr, $filename: literal) => {
@@ -132,5 +133,23 @@ pub fn load() -> LinderaResult<Dictionary> {
             unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
             metadata,
         })
+    }
+}
+
+pub struct EmbeddedLoader;
+
+impl EmbeddedLoader {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn load(&self) -> LinderaResult<Dictionary> {
+        load()
+    }
+}
+
+impl DictionaryLoader for EmbeddedLoader {
+    fn load(&self) -> LinderaResult<Dictionary> {
+        load()
     }
 }

--- a/lindera-ipadic-neologd/src/lib.rs
+++ b/lindera-ipadic-neologd/src/lib.rs
@@ -6,28 +6,6 @@ pub mod schema;
 #[cfg(feature = "embedded-ipadic-neologd")]
 pub mod embedded;
 
-#[cfg(feature = "embedded-ipadic-neologd")]
-use lindera_dictionary::LinderaResult;
-#[cfg(feature = "embedded-ipadic-neologd")]
-use lindera_dictionary::dictionary_loader::DictionaryLoader;
-
-#[cfg(feature = "embedded-ipadic-neologd")]
-pub struct EmbeddedLoader;
-
-#[cfg(feature = "embedded-ipadic-neologd")]
-impl EmbeddedLoader {
-    pub fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
-#[cfg(feature = "embedded-ipadic-neologd")]
-impl DictionaryLoader for EmbeddedLoader {
-    fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-ipadic/src/embedded.rs
+++ b/lindera-ipadic/src/embedded.rs
@@ -12,6 +12,7 @@ use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix
 use lindera_dictionary::dictionary::metadata::Metadata;
 use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
 use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
+use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
 macro_rules! decompress_data {
     ($name: ident, $bytes: expr, $filename: literal) => {
@@ -123,5 +124,23 @@ pub fn load() -> LinderaResult<Dictionary> {
             unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
             metadata,
         })
+    }
+}
+
+pub struct EmbeddedLoader;
+
+impl EmbeddedLoader {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn load(&self) -> LinderaResult<Dictionary> {
+        load()
+    }
+}
+
+impl DictionaryLoader for EmbeddedLoader {
+    fn load(&self) -> LinderaResult<Dictionary> {
+        load()
     }
 }

--- a/lindera-ipadic/src/lib.rs
+++ b/lindera-ipadic/src/lib.rs
@@ -6,28 +6,6 @@ pub mod schema;
 #[cfg(feature = "embedded-ipadic")]
 pub mod embedded;
 
-#[cfg(feature = "embedded-ipadic")]
-use lindera_dictionary::LinderaResult;
-#[cfg(feature = "embedded-ipadic")]
-use lindera_dictionary::dictionary_loader::DictionaryLoader;
-
-#[cfg(feature = "embedded-ipadic")]
-pub struct EmbeddedLoader;
-
-#[cfg(feature = "embedded-ipadic")]
-impl EmbeddedLoader {
-    pub fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
-#[cfg(feature = "embedded-ipadic")]
-impl DictionaryLoader for EmbeddedLoader {
-    fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-ko-dic/src/embedded.rs
+++ b/lindera-ko-dic/src/embedded.rs
@@ -12,6 +12,7 @@ use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix
 use lindera_dictionary::dictionary::metadata::Metadata;
 use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
 use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
+use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
 macro_rules! decompress_data {
     ($name: ident, $bytes: expr, $filename: literal) => {
@@ -123,5 +124,23 @@ pub fn load() -> LinderaResult<Dictionary> {
             unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
             metadata,
         })
+    }
+}
+
+pub struct EmbeddedLoader;
+
+impl EmbeddedLoader {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn load(&self) -> LinderaResult<Dictionary> {
+        load()
+    }
+}
+
+impl DictionaryLoader for EmbeddedLoader {
+    fn load(&self) -> LinderaResult<Dictionary> {
+        load()
     }
 }

--- a/lindera-ko-dic/src/lib.rs
+++ b/lindera-ko-dic/src/lib.rs
@@ -6,28 +6,6 @@ pub mod schema;
 #[cfg(feature = "embedded-ko-dic")]
 pub mod embedded;
 
-#[cfg(feature = "embedded-ko-dic")]
-use lindera_dictionary::LinderaResult;
-#[cfg(feature = "embedded-ko-dic")]
-use lindera_dictionary::dictionary_loader::DictionaryLoader;
-
-#[cfg(feature = "embedded-ko-dic")]
-pub struct EmbeddedLoader;
-
-#[cfg(feature = "embedded-ko-dic")]
-impl EmbeddedLoader {
-    pub fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
-#[cfg(feature = "embedded-ko-dic")]
-impl DictionaryLoader for EmbeddedLoader {
-    fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-unidic/src/embedded.rs
+++ b/lindera-unidic/src/embedded.rs
@@ -12,6 +12,7 @@ use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix
 use lindera_dictionary::dictionary::metadata::Metadata;
 use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
 use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
+use lindera_dictionary::dictionary_loader::DictionaryLoader;
 
 macro_rules! decompress_data {
     ($name: ident, $bytes: expr, $filename: literal) => {
@@ -123,5 +124,23 @@ pub fn load() -> LinderaResult<Dictionary> {
             unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
             metadata,
         })
+    }
+}
+
+pub struct EmbeddedLoader;
+
+impl EmbeddedLoader {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn load(&self) -> LinderaResult<Dictionary> {
+        load()
+    }
+}
+
+impl DictionaryLoader for EmbeddedLoader {
+    fn load(&self) -> LinderaResult<Dictionary> {
+        load()
     }
 }

--- a/lindera-unidic/src/lib.rs
+++ b/lindera-unidic/src/lib.rs
@@ -6,28 +6,6 @@ pub mod schema;
 #[cfg(feature = "embedded-unidic")]
 pub mod embedded;
 
-#[cfg(feature = "embedded-unidic")]
-use lindera_dictionary::LinderaResult;
-#[cfg(feature = "embedded-unidic")]
-use lindera_dictionary::dictionary_loader::DictionaryLoader;
-
-#[cfg(feature = "embedded-unidic")]
-pub struct EmbeddedLoader;
-
-#[cfg(feature = "embedded-unidic")]
-impl EmbeddedLoader {
-    pub fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
-#[cfg(feature = "embedded-unidic")]
-impl DictionaryLoader for EmbeddedLoader {
-    fn load(&self) -> LinderaResult<lindera_dictionary::dictionary::Dictionary> {
-        embedded::load()
-    }
-}
-
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -130,82 +130,41 @@ pub fn resolve_builder(dictionary_type: DictionaryKind) -> LinderaResult<Diction
 pub fn resolve_loader(dictionary_type: DictionaryKind) -> LinderaResult<Box<dyn DictionaryLoader>> {
     match dictionary_type {
         #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
-        DictionaryKind::IPADIC => Ok(Box::new(lindera_ipadic::EmbeddedLoader)),
+        DictionaryKind::IPADIC => Ok(Box::new(lindera_ipadic::embedded::EmbeddedLoader::new())),
         #[cfg(all(feature = "ipadic", not(feature = "embedded-ipadic")))]
-        DictionaryKind::IPADIC => Ok(Box::new(StandardDictionaryLoader::new(
-            "IPADIC".to_string(),
-            vec![
-                "./dict/ipadic".to_string(),
-                "./lindera-ipadic".to_string(),
-                "/usr/local/share/lindera/ipadic".to_string(),
-                "/usr/share/lindera/ipadic".to_string(),
-            ],
-            "LINDERA_IPADIC_PATH".to_string(),
-        ))),
+        DictionaryKind::IPADIC => Ok(Box::new(StandardDictionaryLoader::new())),
         #[cfg(not(feature = "ipadic"))]
         DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
         #[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
-        DictionaryKind::IPADICNEologd => Ok(Box::new(lindera_ipadic_neologd::EmbeddedLoader)),
+        DictionaryKind::IPADICNEologd => Ok(Box::new(
+            lindera_ipadic_neologd::embedded::EmbeddedLoader::new(),
+        )),
         #[cfg(all(feature = "ipadic-neologd", not(feature = "embedded-ipadic-neologd")))]
-        DictionaryKind::IPADICNEologd => Ok(Box::new(StandardDictionaryLoader::new(
-            "IPADIC-NEologd".to_string(),
-            vec![
-                "./dict/ipadic-neologd".to_string(),
-                "./lindera-ipadic-neologd".to_string(),
-                "/usr/local/share/lindera/ipadic-neologd".to_string(),
-                "/usr/share/lindera/ipadic-neologd".to_string(),
-            ],
-            "LINDERA_IPADIC_NEOLOGD_PATH".to_string(),
-        ))),
+        DictionaryKind::IPADICNEologd => Ok(Box::new(StandardDictionaryLoader::new())),
         #[cfg(not(feature = "ipadic-neologd"))]
         DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
         #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
-        DictionaryKind::UniDic => Ok(Box::new(lindera_unidic::EmbeddedLoader)),
+        DictionaryKind::UniDic => Ok(Box::new(lindera_unidic::embedded::EmbeddedLoader::new())),
         #[cfg(all(feature = "unidic", not(feature = "embedded-unidic")))]
-        DictionaryKind::UniDic => Ok(Box::new(StandardDictionaryLoader::new(
-            "UniDic".to_string(),
-            vec![
-                "./dict/unidic".to_string(),
-                "./lindera-unidic".to_string(),
-                "/usr/local/share/lindera/unidic".to_string(),
-                "/usr/share/lindera/unidic".to_string(),
-            ],
-            "LINDERA_UNIDIC_PATH".to_string(),
-        ))),
+        DictionaryKind::UniDic => Ok(Box::new(StandardDictionaryLoader::new())),
         #[cfg(not(feature = "unidic"))]
         DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("UniDic feature is not enabled"))),
         #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
-        DictionaryKind::KoDic => Ok(Box::new(lindera_ko_dic::EmbeddedLoader)),
+        DictionaryKind::KoDic => Ok(Box::new(lindera_ko_dic::embedded::EmbeddedLoader::new())),
         #[cfg(all(feature = "ko-dic", not(feature = "embedded-ko-dic")))]
-        DictionaryKind::KoDic => Ok(Box::new(StandardDictionaryLoader::new(
-            "Ko-Dic".to_string(),
-            vec![
-                "./dict/ko-dic".to_string(),
-                "./lindera-ko-dic".to_string(),
-                "/usr/local/share/lindera/ko-dic".to_string(),
-                "/usr/share/lindera/ko-dic".to_string(),
-            ],
-            "LINDERA_KO_DIC_PATH".to_string(),
-        ))),
+        DictionaryKind::KoDic => Ok(Box::new(StandardDictionaryLoader::new())),
         #[cfg(not(feature = "ko-dic"))]
         DictionaryKind::KoDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("KO-DIC feature is not enabled"))),
         #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
-        DictionaryKind::CcCedict => Ok(Box::new(lindera_cc_cedict::EmbeddedLoader)),
+        DictionaryKind::CcCedict => {
+            Ok(Box::new(lindera_cc_cedict::embedded::EmbeddedLoader::new()))
+        }
         #[cfg(all(feature = "cc-cedict", not(feature = "embedded-cc-cedict")))]
-        DictionaryKind::CcCedict => Ok(Box::new(StandardDictionaryLoader::new(
-            "CC-CEDICT".to_string(),
-            vec![
-                "./dict/cc-cedict".to_string(),
-                "./lindera-cc-cedict".to_string(),
-                "/usr/local/share/lindera/cc-cedict".to_string(),
-                "/usr/share/lindera/cc-cedict".to_string(),
-            ],
-            "LINDERA_CC_CEDICT_PATH".to_string(),
-        ))),
+        DictionaryKind::CcCedict => Ok(Box::new(StandardDictionaryLoader::new())),
         #[cfg(not(feature = "cc-cedict"))]
         DictionaryKind::CcCedict => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("CC-CEDICT feature is not enabled"))),


### PR DESCRIPTION
  Refactor dictionary architecture: simplify loaders and consolidate responsibilities

  - Remove create_loader() and create_builder() from dictionary crates
  - Simplify StandardDictionaryLoader to use single path without search logic
  - Move EmbeddedLoader from lib.rs to embedded.rs in each dictionary crate
  - Consolidate loader/builder creation in lindera/src/dictionary.rs
  - Add new() method to all EmbeddedLoader implementations for consistency
  - Remove re-exports following project guidelines (use explicit paths)
  - Fix clippy warnings and conditional imports

  Dictionary crates now focus solely on providing metadata and embedded data,
  while loader creation is centralized in the main lindera crate. External
  access to EmbeddedLoader now uses explicit module paths like
  lindera_ipadic::embedded::EmbeddedLoader.