### PR TITLE
refactor: Simplify dictionary architecture and improve feature management

### DIFF
--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let metadata = Metadata::new(
-        "CC-CEDICT".to_string(), // Dictionary name
+        "cc-cedict".to_string(), // Dictionary name
         "UTF-8".to_string(),     // Encoding for CC-CEDICT
         Algorithm::Deflate,      // Compression algorithm
         3,                       // Number of fields in simple user dictionary

--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -32,8 +32,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         true,                    // skip_invalid_cost_or_id is true for CC-CEDICT
         false,                   // normalize_details
         Schema::new(
-            "CC-CEDICT".to_string(),      // Schema name
-            "0.1.0-20200409".to_string(), // Schema version
             vec![
                 "major_pos".to_string(),
                 "middle_pos".to_string(),

--- a/lindera-cc-cedict/src/lib.rs
+++ b/lindera-cc-cedict/src/lib.rs
@@ -6,6 +6,8 @@ pub mod schema;
 #[cfg(feature = "embedded-cc-cedict")]
 pub mod embedded;
 
+pub const DICTIONARY_NAME: &str = "cc-cedict";
+pub const DICTIONARY_ENCODING: &str = "UTF-8";
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-cc-cedict/src/metadata.rs
+++ b/lindera-cc-cedict/src/metadata.rs
@@ -3,6 +3,9 @@ use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::CcCedictSchema;
 
+pub const DICTIONARY_NAME: &str = "cc-cedict";
+pub const DICTIONARY_ENCODING: &str = "UTF-8";
+
 /// CC-CEDICT metadata factory
 pub struct CcCedictMetadata;
 
@@ -16,8 +19,8 @@ impl CcCedictMetadata {
     /// Create default CC-CEDICT metadata
     pub fn metadata() -> Metadata {
         Metadata::new(
-            "CC-CEDICT".to_string(),
-            "UTF-8".to_string(),
+            DICTIONARY_NAME.to_string(),
+            DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
             3,
             -10000,

--- a/lindera-cc-cedict/src/metadata.rs
+++ b/lindera-cc-cedict/src/metadata.rs
@@ -2,9 +2,7 @@ use lindera_dictionary::decompress::Algorithm;
 use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::CcCedictSchema;
-
-pub const DICTIONARY_NAME: &str = "cc-cedict";
-pub const DICTIONARY_ENCODING: &str = "UTF-8";
+use crate::{DICTIONARY_ENCODING, DICTIONARY_NAME};
 
 /// CC-CEDICT metadata factory
 pub struct CcCedictMetadata;

--- a/lindera-cc-cedict/src/schema.rs
+++ b/lindera-cc-cedict/src/schema.rs
@@ -10,19 +10,15 @@ impl Default for CcCedictSchema {
 
 impl CcCedictSchema {
     pub fn schema() -> Schema {
-        Schema::new(
-            "CC-CEDICT".to_string(),
-            "0.1.0-20200409".to_string(),
-            vec![
-                "major_pos".to_string(),
-                "middle_pos".to_string(),
-                "small_pos".to_string(),
-                "fine_pos".to_string(),
-                "pinyin".to_string(),
-                "traditional".to_string(),
-                "simplified".to_string(),
-                "definition".to_string(),
-            ],
-        )
+        Schema::new(vec![
+            "major_pos".to_string(),
+            "middle_pos".to_string(),
+            "small_pos".to_string(),
+            "fine_pos".to_string(),
+            "pinyin".to_string(),
+            "traditional".to_string(),
+            "simplified".to_string(),
+            "definition".to_string(),
+        ])
     }
 }

--- a/lindera-dictionary/src/dictionary/metadata.rs
+++ b/lindera-dictionary/src/dictionary/metadata.rs
@@ -24,8 +24,8 @@ impl Default for Metadata {
     fn default() -> Self {
         // Default metadata values can be adjusted as needed
         Metadata::new(
-            "IPADIC".to_string(),
-            "EUC-JP".to_string(),
+            "default".to_string(),
+            "UTF-8".to_string(),
             Algorithm::Deflate,
             3,
             -10000,
@@ -154,8 +154,8 @@ mod tests {
     #[test]
     fn test_metadata_default() {
         let metadata = Metadata::default();
-        assert_eq!(metadata.name, "IPADIC");
-        assert_eq!(metadata.schema.name, "IPADIC");
+        assert_eq!(metadata.name, "default");
+        // Schema no longer has name field
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
             vec![Some(1), None, None, None, None, None, Some(2), None],
         );
         assert_eq!(metadata.name, "TestDict");
-        assert_eq!(metadata.schema.name, schema.name);
+        // Schema no longer has name field
     }
 
     #[test]
@@ -186,13 +186,13 @@ mod tests {
 
         // Test serialization
         let serialized = serde_json::to_string(&metadata).unwrap();
-        assert!(serialized.contains("IPADIC"));
+        assert!(serialized.contains("default"));
         assert!(serialized.contains("schema"));
         assert!(serialized.contains("name"));
 
         // Test deserialization
         let deserialized: Metadata = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized.name, "IPADIC");
-        assert_eq!(deserialized.schema.name, "IPADIC");
+        assert_eq!(deserialized.name, "default");
+        // Schema no longer has name field
     }
 }

--- a/lindera-dictionary/src/dictionary/schema.rs
+++ b/lindera-dictionary/src/dictionary/schema.rs
@@ -17,8 +17,6 @@ pub enum CommonField {
 /// Dictionary schema that defines the structure of dictionary entries
 #[derive(Debug, Clone, Serialize)]
 pub struct Schema {
-    pub name: String,
-    pub version: String,
     /// Custom field names (from 4th column onwards)
     pub custom_fields: Vec<String>,
     /// Field name to index mapping for fast lookup
@@ -33,15 +31,11 @@ impl<'de> serde::Deserialize<'de> for Schema {
     {
         #[derive(Deserialize)]
         struct DictionarySchemaHelper {
-            name: String,
-            version: String,
             custom_fields: Vec<String>,
         }
 
         let helper = DictionarySchemaHelper::deserialize(deserializer)?;
         let mut schema = Schema {
-            name: helper.name,
-            version: helper.version,
             custom_fields: helper.custom_fields,
             field_index_map: None,
         };
@@ -52,10 +46,8 @@ impl<'de> serde::Deserialize<'de> for Schema {
 
 impl Schema {
     /// Create a new dictionary schema
-    pub fn new(name: String, version: String, custom_fields: Vec<String>) -> Self {
+    pub fn new(custom_fields: Vec<String>) -> Self {
         let mut schema = Self {
-            name,
-            version,
             custom_fields,
             field_index_map: None,
         };
@@ -179,21 +171,17 @@ pub enum FieldType {
 
 impl Default for Schema {
     fn default() -> Self {
-        Self::new(
-            "IPADIC".to_string(),
-            "2.7.0".to_string(),
-            vec![
-                "major_pos".to_string(),
-                "middle_pos".to_string(),
-                "small_pos".to_string(),
-                "fine_pos".to_string(),
-                "conjugation_type".to_string(),
-                "conjugation_form".to_string(),
-                "base_form".to_string(),
-                "reading".to_string(),
-                "pronunciation".to_string(),
-            ],
-        )
+        Self::new(vec![
+            "major_pos".to_string(),
+            "middle_pos".to_string(),
+            "small_pos".to_string(),
+            "fine_pos".to_string(),
+            "conjugation_type".to_string(),
+            "conjugation_form".to_string(),
+            "base_form".to_string(),
+            "reading".to_string(),
+            "pronunciation".to_string(),
+        ])
     }
 }
 
@@ -204,10 +192,8 @@ mod tests {
     #[test]
     fn test_new_schema() {
         let custom_fields = vec!["field1".to_string(), "field2".to_string()];
-        let schema = Schema::new("TestDict".to_string(), "1.0.0".to_string(), custom_fields);
+        let schema = Schema::new(custom_fields);
 
-        assert_eq!(schema.name, "TestDict");
-        assert_eq!(schema.version, "1.0.0");
         assert_eq!(schema.custom_fields.len(), 2);
         assert!(schema.field_index_map.is_some());
     }
@@ -245,8 +231,7 @@ mod tests {
     #[test]
     fn test_default_schema() {
         let schema = Schema::default();
-        assert_eq!(schema.name, "IPADIC");
-        assert_eq!(schema.version, "2.7.0");
+        // Name and version fields have been removed from Schema
         assert_eq!(schema.field_count(), 13);
         assert_eq!(schema.custom_fields.len(), 9);
     }

--- a/lindera-dictionary/src/dictionary_builder/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_builder/prefix_dictionary.rs
@@ -537,8 +537,8 @@ mod tests {
         let schema = Schema::default();
         let builder = PrefixDictionaryBuilder::new(schema.clone());
 
-        assert_eq!(builder.schema.name, "IPADIC");
-        assert_eq!(builder.schema.version, "2.7.0");
+        // Schema no longer has name field
+        // Schema no longer has version field
         assert!(builder.flexible_csv);
         assert_eq!(builder.encoding, "UTF-8");
         assert!(!builder.normalize_details);

--- a/lindera-dictionary/src/dictionary_loader/metadata.rs
+++ b/lindera-dictionary/src/dictionary_loader/metadata.rs
@@ -104,7 +104,7 @@ mod tests {
         // Load from file
         let loaded_metadata = MetadataLoader::load(&temp_path).unwrap();
 
-        assert_eq!(loaded_metadata.encoding, "EUC-JP");
+        assert_eq!(loaded_metadata.encoding, "UTF-8");
         assert_eq!(loaded_metadata.simple_word_cost, -10000);
         assert_eq!(loaded_metadata.simple_context_id, 0);
         assert_eq!(loaded_metadata.simple_userdic_fields_num, 3);

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -32,8 +32,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         false,                        // skip_invalid_cost_or_id
         true,                         // normalize_details is true for IPAdic-NEologd
         Schema::new(
-            "IPADIC-NEologd".to_string(), // Schema name
-            "0.0.7-20200820".to_string(), // Schema version
             vec![
                 "major_pos".to_string(),
                 "middle_pos".to_string(),

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let metadata = Metadata::new(
-        "IPADIC-NEologd".to_string(), // Dictionary name
+        "ipadic-neologd".to_string(), // Dictionary name
         "UTF-8".to_string(),          // Encoding for IPADIC NEologd
         Algorithm::Deflate,           // Compression algorithm
         3,                            // Number of fields in simple user dictionary

--- a/lindera-ipadic-neologd/src/lib.rs
+++ b/lindera-ipadic-neologd/src/lib.rs
@@ -6,6 +6,8 @@ pub mod schema;
 #[cfg(feature = "embedded-ipadic-neologd")]
 pub mod embedded;
 
+pub const DICTIONARY_NAME: &str = "ipadic-neologd";
+pub const DICTIONARY_ENCODING: &str = "UTF-8";
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-ipadic-neologd/src/metadata.rs
+++ b/lindera-ipadic-neologd/src/metadata.rs
@@ -2,9 +2,7 @@ use lindera_dictionary::decompress::Algorithm;
 use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::IPADICNEologdSchema;
-
-pub const DICTIONARY_NAME: &str = "ipadic-neologd";
-pub const DICTIONARY_ENCODING: &str = "UTF-8";
+use crate::{DICTIONARY_ENCODING, DICTIONARY_NAME};
 
 /// IPADIC NEologd metadata factory
 pub struct IPADICNEologdMetadata;

--- a/lindera-ipadic-neologd/src/metadata.rs
+++ b/lindera-ipadic-neologd/src/metadata.rs
@@ -3,6 +3,9 @@ use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::IPADICNEologdSchema;
 
+pub const DICTIONARY_NAME: &str = "ipadic-neologd";
+pub const DICTIONARY_ENCODING: &str = "UTF-8";
+
 /// IPADIC NEologd metadata factory
 pub struct IPADICNEologdMetadata;
 
@@ -16,8 +19,8 @@ impl IPADICNEologdMetadata {
     /// Create default IPADIC NEologd metadata
     pub fn metadata() -> Metadata {
         Metadata::new(
-            "IPADIC-NEologd".to_string(),
-            "UTF-8".to_string(),
+            DICTIONARY_NAME.to_string(),
+            DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
             3,
             -10000,

--- a/lindera-ipadic-neologd/src/schema.rs
+++ b/lindera-ipadic-neologd/src/schema.rs
@@ -12,20 +12,16 @@ impl Default for IPADICNEologdSchema {
 impl IPADICNEologdSchema {
     /// Create default IPADIC NEologd schema
     pub fn schema() -> Schema {
-        Schema::new(
-            "IPADIC-NEologd".to_string(),
-            "0.0.7-20200820".to_string(),
-            vec![
-                "major_pos".to_string(),
-                "middle_pos".to_string(),
-                "small_pos".to_string(),
-                "fine_pos".to_string(),
-                "conjugation_type".to_string(),
-                "conjugation_form".to_string(),
-                "base_form".to_string(),
-                "reading".to_string(),
-                "pronunciation".to_string(),
-            ],
-        )
+        Schema::new(vec![
+            "major_pos".to_string(),
+            "middle_pos".to_string(),
+            "small_pos".to_string(),
+            "fine_pos".to_string(),
+            "conjugation_type".to_string(),
+            "conjugation_form".to_string(),
+            "base_form".to_string(),
+            "reading".to_string(),
+            "pronunciation".to_string(),
+        ])
     }
 }

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let metadata = Metadata::new(
-        "IPADIC".to_string(), // Dictionary name
+        "ipadic".to_string(), // Dictionary name
         "EUC-JP".to_string(), // Encoding for IPADIC
         Algorithm::Deflate,   // Compression algorithm
         3,                    // Number of fields in simple user dictionary

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -32,8 +32,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         false,                // skip_invalid_cost_or_id
         true,                 // normalize_details
         Schema::new(
-            "IPADIC".to_string(),         // Schema name
-            "2.7.0-20070801".to_string(), // Schema version
             vec![
                 "major_pos".to_string(),
                 "middle_pos".to_string(),

--- a/lindera-ipadic/src/lib.rs
+++ b/lindera-ipadic/src/lib.rs
@@ -6,6 +6,8 @@ pub mod schema;
 #[cfg(feature = "embedded-ipadic")]
 pub mod embedded;
 
+pub const DICTIONARY_NAME: &str = "ipadic";
+pub const DICTIONARY_ENCODING: &str = "EUC-JP";
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-ipadic/src/metadata.rs
+++ b/lindera-ipadic/src/metadata.rs
@@ -2,9 +2,7 @@ use lindera_dictionary::decompress::Algorithm;
 use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::IPADICSchema;
-
-pub const DICTIONARY_NAME: &str = "ipadic";
-pub const DICTIONARY_ENCODING: &str = "EUC-JP";
+use crate::{DICTIONARY_ENCODING, DICTIONARY_NAME};
 
 /// IPADIC metadata factory
 pub struct IPADICMetadata;

--- a/lindera-ipadic/src/metadata.rs
+++ b/lindera-ipadic/src/metadata.rs
@@ -3,6 +3,9 @@ use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::IPADICSchema;
 
+pub const DICTIONARY_NAME: &str = "ipadic";
+pub const DICTIONARY_ENCODING: &str = "EUC-JP";
+
 /// IPADIC metadata factory
 pub struct IPADICMetadata;
 
@@ -16,8 +19,8 @@ impl IPADICMetadata {
     /// Create default IPADIC metadata
     pub fn metadata() -> Metadata {
         Metadata::new(
-            "IPADIC".to_string(),
-            "EUC-JP".to_string(),
+            DICTIONARY_NAME.to_string(),
+            DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
             3,
             -10000,

--- a/lindera-ipadic/src/schema.rs
+++ b/lindera-ipadic/src/schema.rs
@@ -12,20 +12,16 @@ impl Default for IPADICSchema {
 impl IPADICSchema {
     /// Create default IPADIC schema
     pub fn schema() -> Schema {
-        Schema::new(
-            "IPADIC".to_string(),
-            "2.7.0-20070801".to_string(),
-            vec![
-                "major_pos".to_string(),
-                "middle_pos".to_string(),
-                "small_pos".to_string(),
-                "fine_pos".to_string(),
-                "conjugation_type".to_string(),
-                "conjugation_form".to_string(),
-                "base_form".to_string(),
-                "reading".to_string(),
-                "pronunciation".to_string(),
-            ],
-        )
+        Schema::new(vec![
+            "major_pos".to_string(),
+            "middle_pos".to_string(),
+            "small_pos".to_string(),
+            "fine_pos".to_string(),
+            "conjugation_type".to_string(),
+            "conjugation_form".to_string(),
+            "base_form".to_string(),
+            "reading".to_string(),
+            "pronunciation".to_string(),
+        ])
     }
 }

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let metadata = Metadata::new(
-        "KO-DIC".to_string(), // Dictionary name
+        "ko-dic".to_string(), // Dictionary name
         "UTF-8".to_string(),  // Encoding for Ko-Dic
         Algorithm::Deflate,   // Compression algorithm
         3,                    // Number of fields in simple user dictionary

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -32,8 +32,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         false,                // skip_invalid_cost_or_id
         false,                // normalize_details
         Schema::new(
-            "KO-DIC".to_string(),         // Schema name
-            "2.1.1-20180720".to_string(), // Schema version
             vec![
                 "pos_tag".to_string(),
                 "meaning".to_string(),

--- a/lindera-ko-dic/src/lib.rs
+++ b/lindera-ko-dic/src/lib.rs
@@ -6,6 +6,8 @@ pub mod schema;
 #[cfg(feature = "embedded-ko-dic")]
 pub mod embedded;
 
+pub const DICTIONARY_NAME: &str = "ko-dic";
+pub const DICTIONARY_ENCODING: &str = "UTF-8";
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-ko-dic/src/metadata.rs
+++ b/lindera-ko-dic/src/metadata.rs
@@ -2,9 +2,7 @@ use lindera_dictionary::decompress::Algorithm;
 use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::KoDicSchema;
-
-pub const DICTIONARY_NAME: &str = "ko-dic";
-pub const DICTIONARY_ENCODING: &str = "UTF-8";
+use crate::{DICTIONARY_ENCODING, DICTIONARY_NAME};
 
 /// Ko-Dic metadata factory
 pub struct KoDicMetadata;

--- a/lindera-ko-dic/src/metadata.rs
+++ b/lindera-ko-dic/src/metadata.rs
@@ -3,6 +3,9 @@ use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::KoDicSchema;
 
+pub const DICTIONARY_NAME: &str = "ko-dic";
+pub const DICTIONARY_ENCODING: &str = "UTF-8";
+
 /// Ko-Dic metadata factory
 pub struct KoDicMetadata;
 
@@ -16,8 +19,8 @@ impl KoDicMetadata {
     /// Create default Ko-Dic metadata
     pub fn metadata() -> Metadata {
         Metadata::new(
-            "KO-DIC".to_string(),
-            "UTF-8".to_string(),
+            DICTIONARY_NAME.to_string(),
+            DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
             3,
             -10000,

--- a/lindera-ko-dic/src/schema.rs
+++ b/lindera-ko-dic/src/schema.rs
@@ -10,19 +10,15 @@ impl Default for KoDicSchema {
 
 impl KoDicSchema {
     pub fn schema() -> Schema {
-        Schema::new(
-            "KO-DIC".to_string(),
-            "2.1.1-20180720".to_string(),
-            vec![
-                "pos_tag".to_string(),
-                "meaning".to_string(),
-                "presence_absence".to_string(),
-                "reading".to_string(),
-                "type".to_string(),
-                "first_pos".to_string(),
-                "last_pos".to_string(),
-                "expression".to_string(),
-            ],
-        )
+        Schema::new(vec![
+            "pos_tag".to_string(),
+            "meaning".to_string(),
+            "presence_absence".to_string(),
+            "reading".to_string(),
+            "type".to_string(),
+            "first_pos".to_string(),
+            "last_pos".to_string(),
+            "expression".to_string(),
+        ])
     }
 }

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -32,8 +32,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         false,                // skip_invalid_cost_or_id
         false,                // normalize_details
         Schema::new(
-            "UniDic".to_string(), // Schema name
-            "2.1.2".to_string(),  // Schema version
             vec![
                 "major_pos".to_string(),
                 "middle_pos".to_string(),

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let metadata = Metadata::new(
-        "UniDic".to_string(), // Dictionary name
+        "unidic".to_string(), // Dictionary name
         "UTF-8".to_string(),  // Encoding for UniDic
         Algorithm::Deflate,   // Compression algorithm
         3,                    // Number of fields in simple user dictionary

--- a/lindera-unidic/src/lib.rs
+++ b/lindera-unidic/src/lib.rs
@@ -6,6 +6,8 @@ pub mod schema;
 #[cfg(feature = "embedded-unidic")]
 pub mod embedded;
 
+pub const DICTIONARY_NAME: &str = "unidic";
+pub const DICTIONARY_ENCODING: &str = "UTF-8";
 const VERERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn get_version() -> &'static str {

--- a/lindera-unidic/src/metadata.rs
+++ b/lindera-unidic/src/metadata.rs
@@ -2,9 +2,7 @@ use lindera_dictionary::decompress::Algorithm;
 use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::UniDicSchema;
-
-pub const DICTIONARY_NAME: &str = "unidic";
-pub const DICTIONARY_ENCODING: &str = "UTF-8";
+use crate::{DICTIONARY_ENCODING, DICTIONARY_NAME};
 
 /// UniDic metadata factory
 pub struct UniDicMetadata;

--- a/lindera-unidic/src/metadata.rs
+++ b/lindera-unidic/src/metadata.rs
@@ -3,6 +3,9 @@ use lindera_dictionary::dictionary::metadata::Metadata;
 
 use crate::schema::UniDicSchema;
 
+pub const DICTIONARY_NAME: &str = "unidic";
+pub const DICTIONARY_ENCODING: &str = "UTF-8";
+
 /// UniDic metadata factory
 pub struct UniDicMetadata;
 
@@ -16,8 +19,8 @@ impl UniDicMetadata {
     /// Create default UniDic metadata
     pub fn metadata() -> Metadata {
         Metadata::new(
-            "UniDic".to_string(),
-            "UTF-8".to_string(),
+            DICTIONARY_NAME.to_string(),
+            DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
             3,
             -10000,

--- a/lindera-unidic/src/schema.rs
+++ b/lindera-unidic/src/schema.rs
@@ -12,28 +12,24 @@ impl Default for UniDicSchema {
 impl UniDicSchema {
     /// Create default UniDic schema
     pub fn schema() -> Schema {
-        Schema::new(
-            "UniDic".to_string(),
-            "2.1.2".to_string(),
-            vec![
-                "major_pos".to_string(),
-                "middle_pos".to_string(),
-                "small_pos".to_string(),
-                "fine_pos".to_string(),
-                "conjugation_form".to_string(),
-                "conjugation_type".to_string(),
-                "lexeme_reading".to_string(),
-                "lexeme".to_string(),
-                "orthography_appearance".to_string(),
-                "pronunciation_appearance".to_string(),
-                "orthography_basic".to_string(),
-                "pronunciation_basic".to_string(),
-                "word_type".to_string(),
-                "prefix_form".to_string(),
-                "prefix_type".to_string(),
-                "suffix_form".to_string(),
-                "suffix_type".to_string(),
-            ],
-        )
+        Schema::new(vec![
+            "major_pos".to_string(),
+            "middle_pos".to_string(),
+            "small_pos".to_string(),
+            "fine_pos".to_string(),
+            "conjugation_form".to_string(),
+            "conjugation_type".to_string(),
+            "lexeme_reading".to_string(),
+            "lexeme".to_string(),
+            "orthography_appearance".to_string(),
+            "pronunciation_appearance".to_string(),
+            "orthography_basic".to_string(),
+            "pronunciation_basic".to_string(),
+            "word_type".to_string(),
+            "prefix_form".to_string(),
+            "prefix_type".to_string(),
+            "suffix_form".to_string(),
+            "suffix_type".to_string(),
+        ])
     }
 }

--- a/lindera/examples/tokenize_with_filters.rs
+++ b/lindera/examples/tokenize_with_filters.rs
@@ -31,7 +31,6 @@ fn main() -> LinderaResult<()> {
             JapaneseIterationMarkCharacterFilter::new(true, true);
 
         let japanese_compound_word_token_filter = JapaneseCompoundWordTokenFilter::new(
-            DictionaryKind::IPADIC,
             vec!["名詞,数".to_string(), "名詞,接尾,助数詞".to_string()]
                 .into_iter()
                 .collect(),

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -1,25 +1,30 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-#[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
-use lindera_cc_cedict::embedded::EmbeddedCcCedictLoader;
-#[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
-use lindera_ipadic::embedded::EmbeddedIPADICLoader;
-#[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
-use lindera_ipadic_neologd::embedded::EmbeddedIPADICNEologdLoader;
-#[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
-use lindera_ko_dic::embedded::EmbeddedKoDicLoader;
-#[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
-use lindera_unidic::embedded::EmbeddedUniDicLoader;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
+#[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
+use lindera_cc_cedict::embedded::EmbeddedCcCedictLoader;
+use lindera_cc_cedict::metadata::DICTIONARY_NAME as CC_CEDICT_DICTIONARY_NAME;
 use lindera_dictionary::dictionary_builder::DictionaryBuilder;
 use lindera_dictionary::dictionary_loader::DictionaryLoader;
 use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
 use lindera_dictionary::dictionary_loader::user_dictionary::UserDictionaryLoader;
+#[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+use lindera_ipadic::embedded::EmbeddedIPADICLoader;
+use lindera_ipadic::metadata::DICTIONARY_NAME as IPADIC_DICTIONARY_NAME;
+#[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
+use lindera_ipadic_neologd::embedded::EmbeddedIPADICNEologdLoader;
+use lindera_ipadic_neologd::metadata::DICTIONARY_NAME as IPADIC_NEOLOGD_DICTIONARY_NAME;
+#[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+use lindera_ko_dic::embedded::EmbeddedKoDicLoader;
+use lindera_ko_dic::metadata::DICTIONARY_NAME as KO_DIC_DICTIONARY_NAME;
+#[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
+use lindera_unidic::embedded::EmbeddedUniDicLoader;
+use lindera_unidic::metadata::DICTIONARY_NAME as UNIDIC_DICTIONARY_NAME;
 
 use crate::LinderaResult;
 use crate::error::{LinderaError, LinderaErrorKind};
@@ -63,11 +68,11 @@ impl DictionaryKind {
 
     pub fn as_str(&self) -> &str {
         match self {
-            DictionaryKind::IPADIC => "ipadic",
-            DictionaryKind::IPADICNEologd => "ipadic-neologd",
-            DictionaryKind::UniDic => "unidic",
-            DictionaryKind::KoDic => "ko-dic",
-            DictionaryKind::CcCedict => "cc-cedict",
+            DictionaryKind::IPADIC => IPADIC_DICTIONARY_NAME,
+            DictionaryKind::IPADICNEologd => IPADIC_NEOLOGD_DICTIONARY_NAME,
+            DictionaryKind::UniDic => UNIDIC_DICTIONARY_NAME,
+            DictionaryKind::KoDic => KO_DIC_DICTIONARY_NAME,
+            DictionaryKind::CcCedict => CC_CEDICT_DICTIONARY_NAME,
         }
     }
 }
@@ -76,11 +81,11 @@ impl FromStr for DictionaryKind {
     type Err = LinderaError;
     fn from_str(input: &str) -> Result<DictionaryKind, Self::Err> {
         match input {
-            "ipadic" => Ok(DictionaryKind::IPADIC),
-            "ipadic-neologd" => Ok(DictionaryKind::IPADICNEologd),
-            "unidic" => Ok(DictionaryKind::UniDic),
-            "ko-dic" => Ok(DictionaryKind::KoDic),
-            "cc-cedict" => Ok(DictionaryKind::CcCedict),
+            IPADIC_DICTIONARY_NAME => Ok(DictionaryKind::IPADIC),
+            IPADIC_NEOLOGD_DICTIONARY_NAME => Ok(DictionaryKind::IPADICNEologd),
+            UNIDIC_DICTIONARY_NAME => Ok(DictionaryKind::UniDic),
+            KO_DIC_DICTIONARY_NAME => Ok(DictionaryKind::KoDic),
+            CC_CEDICT_DICTIONARY_NAME => Ok(DictionaryKind::CcCedict),
             _ => Err(LinderaErrorKind::Dictionary
                 .with_error(anyhow::anyhow!("Invalid dictionary kind: {}", input))),
         }

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -6,25 +6,30 @@ use serde_json::Value;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
+#[cfg(feature = "cc-cedict")]
+use lindera_cc_cedict::DICTIONARY_NAME as CC_CEDICT_DICTIONARY_NAME;
 #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
 use lindera_cc_cedict::embedded::EmbeddedCcCedictLoader;
-use lindera_cc_cedict::metadata::DICTIONARY_NAME as CC_CEDICT_DICTIONARY_NAME;
 use lindera_dictionary::dictionary_builder::DictionaryBuilder;
 use lindera_dictionary::dictionary_loader::DictionaryLoader;
 use lindera_dictionary::dictionary_loader::StandardDictionaryLoader;
 use lindera_dictionary::dictionary_loader::user_dictionary::UserDictionaryLoader;
+#[cfg(feature = "ipadic")]
+use lindera_ipadic::DICTIONARY_NAME as IPADIC_DICTIONARY_NAME;
 #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
 use lindera_ipadic::embedded::EmbeddedIPADICLoader;
-use lindera_ipadic::metadata::DICTIONARY_NAME as IPADIC_DICTIONARY_NAME;
+#[cfg(feature = "ipadic-neologd")]
+use lindera_ipadic_neologd::DICTIONARY_NAME as IPADIC_NEOLOGD_DICTIONARY_NAME;
 #[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
 use lindera_ipadic_neologd::embedded::EmbeddedIPADICNEologdLoader;
-use lindera_ipadic_neologd::metadata::DICTIONARY_NAME as IPADIC_NEOLOGD_DICTIONARY_NAME;
+#[cfg(feature = "ko-dic")]
+use lindera_ko_dic::DICTIONARY_NAME as KO_DIC_DICTIONARY_NAME;
 #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
 use lindera_ko_dic::embedded::EmbeddedKoDicLoader;
-use lindera_ko_dic::metadata::DICTIONARY_NAME as KO_DIC_DICTIONARY_NAME;
+#[cfg(feature = "unidic")]
+use lindera_unidic::DICTIONARY_NAME as UNIDIC_DICTIONARY_NAME;
 #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
 use lindera_unidic::embedded::EmbeddedUniDicLoader;
-use lindera_unidic::metadata::DICTIONARY_NAME as UNIDIC_DICTIONARY_NAME;
 
 use crate::LinderaResult;
 use crate::error::{LinderaError, LinderaErrorKind};
@@ -36,14 +41,19 @@ pub type WordId = lindera_dictionary::viterbi::WordId;
 
 #[derive(Debug, Clone, EnumIter, Deserialize, Serialize, PartialEq, Eq)]
 pub enum DictionaryKind {
+    #[cfg(feature = "ipadic")]
     #[serde(rename = "ipadic")]
     IPADIC,
+    #[cfg(feature = "ipadic-neologd")]
     #[serde(rename = "ipadic-neologd")]
     IPADICNEologd,
+    #[cfg(feature = "unidic")]
     #[serde(rename = "unidic")]
     UniDic,
+    #[cfg(feature = "ko-dic")]
     #[serde(rename = "ko-dic")]
     KoDic,
+    #[cfg(feature = "cc-cedict")]
     #[serde(rename = "cc-cedict")]
     CcCedict,
 }
@@ -57,10 +67,15 @@ impl DictionaryKind {
         DictionaryKind::variants()
             .into_iter()
             .filter(|kind| match kind {
+                #[cfg(feature = "ipadic")]
                 DictionaryKind::IPADIC => cfg!(feature = "ipadic"),
+                #[cfg(feature = "ipadic-neologd")]
                 DictionaryKind::IPADICNEologd => cfg!(feature = "ipadic-neologd"),
+                #[cfg(feature = "unidic")]
                 DictionaryKind::UniDic => cfg!(feature = "unidic"),
+                #[cfg(feature = "ko-dic")]
                 DictionaryKind::KoDic => cfg!(feature = "ko-dic"),
+                #[cfg(feature = "cc-cedict")]
                 DictionaryKind::CcCedict => cfg!(feature = "cc-cedict"),
             })
             .collect::<Vec<_>>()
@@ -68,10 +83,15 @@ impl DictionaryKind {
 
     pub fn as_str(&self) -> &str {
         match self {
+            #[cfg(feature = "ipadic")]
             DictionaryKind::IPADIC => IPADIC_DICTIONARY_NAME,
+            #[cfg(feature = "ipadic-neologd")]
             DictionaryKind::IPADICNEologd => IPADIC_NEOLOGD_DICTIONARY_NAME,
+            #[cfg(feature = "unidic")]
             DictionaryKind::UniDic => UNIDIC_DICTIONARY_NAME,
+            #[cfg(feature = "ko-dic")]
             DictionaryKind::KoDic => KO_DIC_DICTIONARY_NAME,
+            #[cfg(feature = "cc-cedict")]
             DictionaryKind::CcCedict => CC_CEDICT_DICTIONARY_NAME,
         }
     }
@@ -81,10 +101,15 @@ impl FromStr for DictionaryKind {
     type Err = LinderaError;
     fn from_str(input: &str) -> Result<DictionaryKind, Self::Err> {
         match input {
+            #[cfg(feature = "ipadic")]
             IPADIC_DICTIONARY_NAME => Ok(DictionaryKind::IPADIC),
+            #[cfg(feature = "ipadic-neologd")]
             IPADIC_NEOLOGD_DICTIONARY_NAME => Ok(DictionaryKind::IPADICNEologd),
+            #[cfg(feature = "unidic")]
             UNIDIC_DICTIONARY_NAME => Ok(DictionaryKind::UniDic),
+            #[cfg(feature = "ko-dic")]
             KO_DIC_DICTIONARY_NAME => Ok(DictionaryKind::KoDic),
+            #[cfg(feature = "cc-cedict")]
             CC_CEDICT_DICTIONARY_NAME => Ok(DictionaryKind::CcCedict),
             _ => Err(LinderaErrorKind::Dictionary
                 .with_error(anyhow::anyhow!("Invalid dictionary kind: {}", input))),
@@ -101,37 +126,22 @@ pub fn resolve_builder(dictionary_type: DictionaryKind) -> LinderaResult<Diction
         DictionaryKind::IPADIC => Ok(DictionaryBuilder::new(
             lindera_ipadic::metadata::IPADICMetadata::metadata(),
         )),
-        #[cfg(not(feature = "ipadic"))]
-        DictionaryKind::IPADIC => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
         #[cfg(feature = "ipadic-neologd")]
         DictionaryKind::IPADICNEologd => Ok(DictionaryBuilder::new(
             lindera_ipadic_neologd::metadata::IPADICNEologdMetadata::metadata(),
         )),
-        #[cfg(not(feature = "ipadic-neologd"))]
-        DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
         #[cfg(feature = "unidic")]
         DictionaryKind::UniDic => Ok(DictionaryBuilder::new(
             lindera_unidic::metadata::UniDicMetadata::metadata(),
         )),
-        #[cfg(not(feature = "unidic"))]
-        DictionaryKind::UniDic => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("UniDic feature is not enabled"))),
         #[cfg(feature = "ko-dic")]
         DictionaryKind::KoDic => Ok(DictionaryBuilder::new(
             lindera_ko_dic::metadata::KoDicMetadata::metadata(),
         )),
-        #[cfg(not(feature = "ko-dic"))]
-        DictionaryKind::KoDic => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("KO-DIC feature is not enabled"))),
         #[cfg(feature = "cc-cedict")]
         DictionaryKind::CcCedict => Ok(DictionaryBuilder::new(
             lindera_cc_cedict::metadata::CcCedictMetadata::metadata(),
         )),
-        #[cfg(not(feature = "cc-cedict"))]
-        DictionaryKind::CcCedict => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("CC-CEDICT feature is not enabled"))),
     }
 }
 
@@ -144,42 +154,27 @@ pub fn resolve_embedded_loader(
         #[cfg(all(feature = "ipadic", not(feature = "embedded-ipadic")))]
         DictionaryKind::IPADIC => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("IPADIC embedded feature is not enabled"))),
-        #[cfg(not(feature = "ipadic"))]
-        DictionaryKind::IPADIC => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
         #[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
         DictionaryKind::IPADICNEologd => Ok(Box::new(EmbeddedIPADICNEologdLoader::new())),
         #[cfg(all(feature = "ipadic-neologd", not(feature = "embedded-ipadic-neologd")))]
         DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::FeatureDisabled.with_error(
             anyhow::anyhow!("IPADIC-NEologd embedded feature is not enabled"),
         )),
-        #[cfg(not(feature = "ipadic-neologd"))]
-        DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
         #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
         DictionaryKind::UniDic => Ok(Box::new(EmbeddedUniDicLoader::new())),
         #[cfg(all(feature = "unidic", not(feature = "embedded-unidic")))]
         DictionaryKind::UniDic => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("UniDic embedded feature is not enabled"))),
-        #[cfg(not(feature = "unidic"))]
-        DictionaryKind::UniDic => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("UniDic feature is not enabled"))),
         #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
         DictionaryKind::KoDic => Ok(Box::new(EmbeddedKoDicLoader::new())),
         #[cfg(all(feature = "ko-dic", not(feature = "embedded-ko-dic")))]
         DictionaryKind::KoDic => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("KO-DIC embedded feature is not enabled"))),
-        #[cfg(not(feature = "ko-dic"))]
-        DictionaryKind::KoDic => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("KO-DIC feature is not enabled"))),
         #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
         DictionaryKind::CcCedict => Ok(Box::new(EmbeddedCcCedictLoader::new())),
         #[cfg(all(feature = "cc-cedict", not(feature = "embedded-cc-cedict")))]
         DictionaryKind::CcCedict => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("CC-CEDICT embedded feature is not enabled"))),
-        #[cfg(not(feature = "cc-cedict"))]
-        DictionaryKind::CcCedict => Err(LinderaErrorKind::FeatureDisabled
-            .with_error(anyhow::anyhow!("CC-CEDICT feature is not enabled"))),
     }
 }
 

--- a/lindera/src/token_filter/japanese_kana.rs
+++ b/lindera/src/token_filter/japanese_kana.rs
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_kana_token_filter_apply_katakana_to_hiragana_ipadic() {
         use std::borrow::Cow;
 
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_kana_token_filter_apply_hiragana_to_katakana_ipadic() {
         use std::borrow::Cow;
 
@@ -422,7 +422,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_kana_token_filter_apply_katakana_to_katakana_ipadic() {
         use std::borrow::Cow;
 
@@ -517,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_kana_token_filter_apply_hiragana_to_hiragana_ipadic() {
         use std::borrow::Cow;
 
@@ -647,7 +647,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_kana_token_filter_apply_mixed_to_katakana_ipadic() {
         use std::borrow::Cow;
 
@@ -777,7 +777,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_kana_token_filter_applymixed_to_hiragana_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_katakana_stem.rs
+++ b/lindera/src/token_filter/japanese_katakana_stem.rs
@@ -120,6 +120,7 @@ fn is_katakana(text: &str) -> bool {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
     fn test_japanese_katakana_stem_token_filter_config() {
         use crate::token_filter::japanese_katakana_stem::JapaneseKatakanaStemTokenFilterConfig;
 
@@ -134,6 +135,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
     fn test_japanese_katakana_stem_token_filter_config_zero() {
         use crate::token_filter::japanese_katakana_stem::JapaneseKatakanaStemTokenFilterConfig;
 
@@ -149,6 +151,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
     fn test_japanese_katakana_stem_token_filter() {
         use crate::token_filter::japanese_katakana_stem::{
             JapaneseKatakanaStemTokenFilter, JapaneseKatakanaStemTokenFilterConfig,
@@ -167,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
     fn test_japanese_katakana_stem_token_filter_zero() {
         use crate::token_filter::japanese_katakana_stem::{
             JapaneseKatakanaStemTokenFilter, JapaneseKatakanaStemTokenFilterConfig,
@@ -186,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_katakana_stem_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_keep_tags.rs
+++ b/lindera/src/token_filter/japanese_keep_tags.rs
@@ -116,6 +116,7 @@ impl TokenFilter for JapaneseKeepTagsTokenFilter {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(feature = "ipadic")]
     fn test_japanese_keep_tags_token_filter_config() {
         use crate::token_filter::japanese_keep_tags::JapaneseKeepTagsTokenFilterConfig;
 
@@ -227,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_keep_tags_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_number.rs
+++ b/lindera/src/token_filter/japanese_number.rs
@@ -276,12 +276,14 @@ fn to_arabic_numerals(from_str: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
     use crate::token_filter::japanese_number::{
         JapaneseNumberTokenFilter, JapaneseNumberTokenFilterConfig,
     };
 
     #[test]
-    fn test_to_number_str_ipadic() {
+    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    fn test_to_number_str() {
         use std::str::FromStr;
 
         use crate::token_filter::japanese_number::to_arabic_numerals;
@@ -823,6 +825,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
     fn test_japanese_number_token_filter_config() {
         {
             let config_str = r#"
@@ -859,6 +862,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
     fn test_japanese_number_token_filter() {
         {
             // test empty tags
@@ -888,7 +892,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_number_token_filter_apply_numbers_ipadic() {
         use std::borrow::Cow;
 
@@ -1066,7 +1070,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_number_token_filter_apply_empty_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_stop_tags.rs
+++ b/lindera/src/token_filter/japanese_stop_tags.rs
@@ -119,11 +119,13 @@ impl TokenFilter for JapaneseStopTagsTokenFilter {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "ipadic")]
     use crate::token_filter::japanese_stop_tags::{
         JapaneseStopTagsTokenFilter, JapaneseStopTagsTokenFilterConfig,
     };
 
     #[test]
+    #[cfg(feature = "ipadic")]
     fn test_japanese_stop_tags_token_filter_config() {
         let config_str = r#"
             {
@@ -161,6 +163,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "ipadic")]
     fn test_japanese_stop_tagss_token_filter() {
         let config_str = r#"
             {
@@ -200,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_japanese_stop_tags_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/keep_words.rs
+++ b/lindera/src/token_filter/keep_words.rs
@@ -118,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_keep_words_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/korean_keep_tags.rs
+++ b/lindera/src/token_filter/korean_keep_tags.rs
@@ -100,11 +100,13 @@ impl TokenFilter for KoreanKeepTagsTokenFilter {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "ko-dic")]
     use crate::token_filter::korean_keep_tags::{
         KoreanKeepTagsTokenFilter, KoreanKeepTagsTokenFilterConfig,
     };
 
     #[test]
+    #[cfg(feature = "ko-dic")]
     fn test_korean_keep_tags_token_filter_config() {
         let config_str = r#"
         {
@@ -118,6 +120,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "ko-dic")]
     fn test_korean_keep_tags_token_filter() {
         let config_str = r#"
         {
@@ -133,7 +136,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ko-dic")]
+    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
     fn test_korean_keep_tags_token_filter_apply() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/korean_reading_form.rs
+++ b/lindera/src/token_filter/korean_reading_form.rs
@@ -56,7 +56,7 @@ impl TokenFilter for KoreanReadingFormTokenFilter {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "ko-dic")]
+    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
     fn test_korean_reading_form_token_filter_apply() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/korean_stop_tags.rs
+++ b/lindera/src/token_filter/korean_stop_tags.rs
@@ -73,11 +73,13 @@ impl TokenFilter for KoreanStopTagsTokenFilter {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "ko-dic")]
     use crate::token_filter::korean_stop_tags::{
         KoreanStopTagsTokenFilter, KoreanStopTagsTokenFilterConfig,
     };
 
     #[test]
+    #[cfg(feature = "ko-dic")]
     fn test_korean_stop_tags_token_filter_config() {
         let config_str = r#"
             {
@@ -120,6 +122,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "ko-dic")]
     fn test_korean_stop_tagss_token_filter_from_slice() {
         let config_str = r#"
             {
@@ -164,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ko-dic")]
+    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
     fn test_korean_stop_tags_token_filter_apply() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/lowercase.rs
+++ b/lindera/src/token_filter/lowercase.rs
@@ -47,9 +47,8 @@ impl TokenFilter for LowercaseTokenFilter {
 
 #[cfg(test)]
 mod tests {
-
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_lowercase_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/mapping.rs
+++ b/lindera/src/token_filter/mapping.rs
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_mapping_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/remove_diacritical_mark.rs
+++ b/lindera/src/token_filter/remove_diacritical_mark.rs
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_remove_diacritical_token_filter_apply() {
         use std::borrow::Cow;
 
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_remove_diacritical_token_filter_apply_japanese() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/stop_words.rs
+++ b/lindera/src/token_filter/stop_words.rs
@@ -91,7 +91,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_stop_words_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/uppercase.rs
+++ b/lindera/src/token_filter/uppercase.rs
@@ -48,7 +48,7 @@ impl TokenFilter for UppercaseTokenFilter {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
     fn test_uppercase_token_filter_apply() {
         use std::borrow::Cow;
 

--- a/resources/lindera.yml
+++ b/resources/lindera.yml
@@ -16,13 +16,12 @@ character_filters:
       normalize_kana: true
   - kind: mapping
     args:
-       mapping:
-         リンデラ: Lindera
+      mapping:
+        リンデラ: Lindera
 
 token_filters:
   - kind: "japanese_compound_word"
     args:
-      kind: "ipadic"
       tags:
         - "名詞,数"
         - "名詞,接尾,助数詞"


### PR DESCRIPTION
  refactor: Simplify dictionary architecture and improve feature management

  - Remove redundant name/version fields from Schema structure
  - Standardize dictionary names to lowercase kebab-case format
  - Add conditional compilation for DictionaryKind enum variants
  - Refactor token filters to be dictionary-agnostic
  - Extract dictionary constants (DICTIONARY_NAME, DICTIONARY_ENCODING)

  Breaking changes:
  - Schema::new() no longer accepts name and version parameters
  - DictionaryKind variants are now feature-gated
  - Dictionary names changed from uppercase to lowercase format