### PR TITLE
perf: optimize tokenizer performance with memory pre-allocation and iterator patterns

### DIFF
--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -77,6 +77,8 @@ impl DictionaryKind {
                 DictionaryKind::KoDic => cfg!(feature = "ko-dic"),
                 #[cfg(feature = "cc-cedict")]
                 DictionaryKind::CcCedict => cfg!(feature = "cc-cedict"),
+                #[allow(unreachable_patterns)]
+                _ => false,
             })
             .collect::<Vec<_>>()
     }
@@ -93,6 +95,8 @@ impl DictionaryKind {
             DictionaryKind::KoDic => KO_DIC_DICTIONARY_NAME,
             #[cfg(feature = "cc-cedict")]
             DictionaryKind::CcCedict => CC_CEDICT_DICTIONARY_NAME,
+            #[allow(unreachable_patterns)]
+            _ => "",
         }
     }
 }

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -327,14 +327,15 @@ impl Tokenizer {
     pub fn tokenize<'a>(&'a self, text: &'a str) -> LinderaResult<Vec<Token<'a>>> {
         let mut normalized_text: Cow<'a, str> = Cow::Borrowed(text);
 
-        let mut offset_mappings: Vec<OffsetMapping> = Vec::with_capacity(self.character_filters.len());
+        let mut offset_mappings: Vec<OffsetMapping> =
+            Vec::with_capacity(self.character_filters.len());
 
         // Apply character filters to the text if it is not empty.
         // Optimize: Only convert to mutable when we have filters to apply
         if !self.character_filters.is_empty() {
             // Convert to owned string once for all filters
             let text_mut = normalized_text.to_mut();
-            
+
             for character_filter in &self.character_filters {
                 let mapping = character_filter.apply(text_mut)?;
 


### PR DESCRIPTION
perf: optimize tokenizer performance with memory pre-allocation and iterator patterns

  - Pre-allocate capacity for offset_mappings vector based on filter count
  - Refactor Clone implementation to use iterator pattern for better efficiency
  - Optimize Cow<str>::to_mut() calls to avoid unnecessary string conversions
  - Fix non-exhaustive pattern matching in dictionary.rs for conditional compilation

These optimizations improve performance especially when processing text with multiple
character filters by reducing memory allocations and unnecessary conversions.