### PR TITLE
Add keep_whitespace option for MeCab-compatible whitespace handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lindera-cli = { version = "1.3.2", path = "lindera-cli" }
 anyhow = "1.0.100"
 bincode = { version = "2.0.1", features = ["serde"] }
 byteorder = "1.5.0"
-clap = { version = "4.5.48", features = ["derive", "cargo"] }
+clap = { version = "4.5.49", features = ["derive", "cargo"] }
 criterion = { version = "0.7.0", default-features = false, features = [
     "html_reports",
 ] }
@@ -33,7 +33,7 @@ derive_builder = "0.20.2"
 encoding = "0.2.33"
 encoding_rs = "0.8.35"
 encoding_rs_io = "0.1.7"
-flate2 = "1.1.2"
+flate2 = "1.1.4"
 glob = "0.3.3"
 kanaria = "0.2.0"
 log = "0.4.28"
@@ -45,8 +45,8 @@ percent-encoding = "2.3.2"
 rand = { version = "0.9.2", default-features = false, features = [
     "small_rng",
 ] } # Specify `default-features` and `features` to support WebAssembly
-regex = "1.11.3"
-reqwest = { version = "0.12.23", features = [
+regex = "1.12.2"
+reqwest = { version = "0.12.24", features = [
     "rustls-tls",
 ], default-features = false } # use rustls-tls instead of native-tls which avoids the need to link openssl
 rucrf = "0.3.3"

--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -92,6 +92,11 @@ struct TokenizeArgs {
         help = "Token filter config (JSON)"
     )]
     token_filters: Option<Vec<String>>,
+    #[clap(
+        long = "keep-whitespace",
+        help = "Keep whitespace tokens in output (default: whitespace is ignored for MeCab compatibility)"
+    )]
+    keep_whitespace: bool,
     #[clap(help = "Input text file (default: stdin)")]
     input_file: Option<PathBuf>,
 }
@@ -333,6 +338,11 @@ fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
 
     // Mode
     builder.set_segmenter_mode(&args.mode);
+
+    // Keep whitespace (default is to ignore whitespace for MeCab compatibility)
+    if args.keep_whitespace {
+        builder.set_segmenter_keep_whitespace(true);
+    }
 
     // Tokenizer
     let mut tokenizer = builder

--- a/lindera-dictionary/src/dictionary/character_definition.rs
+++ b/lindera-dictionary/src/dictionary/character_definition.rs
@@ -69,6 +69,13 @@ impl CharacterDefinition {
         &self.category_names[category_id.0]
     }
 
+    pub fn category_id_by_name(&self, name: &str) -> Option<CategoryId> {
+        self.category_names
+            .iter()
+            .position(|n| n == name)
+            .map(CategoryId)
+    }
+
     pub fn lookup_categories(&self, c: char) -> &[CategoryId] {
         self.mapping.eval(c as u32)
     }

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 
 use lindera_dictionary::mode::Mode;
 
-use lindera_dictionary::dictionary::{Dictionary, UserDictionary};
 use lindera_dictionary::dictionary::character_definition::CategoryId;
+use lindera_dictionary::dictionary::{Dictionary, UserDictionary};
 use lindera_dictionary::viterbi::Lattice;
 use serde_json::Value;
 
@@ -65,9 +65,7 @@ impl Segmenter {
         user_dictionary: Option<UserDictionary>,
     ) -> Self {
         // Get SPACE category ID for MeCab compatibility (ignore whitespace by default)
-        let space_category_id = dictionary
-            .character_definition
-            .category_id_by_name("SPACE");
+        let space_category_id = dictionary.character_definition.category_id_by_name("SPACE");
 
         Self {
             mode,
@@ -3025,9 +3023,7 @@ mod tests {
         let config = serde_json::from_str::<SegmenterConfig>(config_str).unwrap();
 
         let segmenter = Segmenter::from_config(&config).unwrap();
-        let tokens = segmenter
-            .segment(Cow::Borrowed("東京 都"))
-            .unwrap();
+        let tokens = segmenter.segment(Cow::Borrowed("東京 都")).unwrap();
 
         // Default behavior: should have 2 tokens, space is ignored (MeCab compatible)
         assert_eq!(tokens.len(), 2);
@@ -3050,9 +3046,7 @@ mod tests {
         let config = serde_json::from_str::<SegmenterConfig>(config_str).unwrap();
 
         let segmenter = Segmenter::from_config(&config).unwrap();
-        let tokens = segmenter
-            .segment(Cow::Borrowed("東京 都"))
-            .unwrap();
+        let tokens = segmenter.segment(Cow::Borrowed("東京 都")).unwrap();
 
         // With keep_whitespace=true: should have 3 tokens including space
         assert_eq!(tokens.len(), 3);
@@ -3075,9 +3069,7 @@ mod tests {
         let config = serde_json::from_str::<SegmenterConfig>(config_str).unwrap();
 
         let segmenter = Segmenter::from_config(&config).unwrap();
-        let tokens = segmenter
-            .segment(Cow::Borrowed("東京   都"))
-            .unwrap();
+        let tokens = segmenter.segment(Cow::Borrowed("東京   都")).unwrap();
 
         // Should have 2 tokens: "東京" and "都", multiple spaces are ignored
         assert_eq!(tokens.len(), 2);
@@ -3101,17 +3093,13 @@ mod tests {
         let segmenter = Segmenter::from_config(&config).unwrap();
 
         // Leading spaces - "   東京都" is segmented as "東京" and "都" (not "東京都")
-        let tokens = segmenter
-            .segment(Cow::Borrowed("   東京都"))
-            .unwrap();
+        let tokens = segmenter.segment(Cow::Borrowed("   東京都")).unwrap();
         assert_eq!(tokens.len(), 2);
         assert_eq!(tokens[0].surface, "東京");
         assert_eq!(tokens[1].surface, "都");
 
         // Trailing spaces - "東京都   " is also segmented as "東京" and "都"
-        let tokens = segmenter
-            .segment(Cow::Borrowed("東京都   "))
-            .unwrap();
+        let tokens = segmenter.segment(Cow::Borrowed("東京都   ")).unwrap();
         assert_eq!(tokens.len(), 2);
         assert_eq!(tokens[0].surface, "東京");
         assert_eq!(tokens[1].surface, "都");

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -134,6 +134,11 @@ impl TokenizerBuilder {
         self
     }
 
+    pub fn set_segmenter_keep_whitespace(&mut self, keep_whitespace: bool) -> &mut Self {
+        self.config["segmenter"]["keep_whitespace"] = json!(keep_whitespace);
+        self
+    }
+
     pub fn append_character_filter(&mut self, kind: &str, args: &Value) -> &mut Self {
         if let Some(array) = self.config["character_filters"].as_array_mut() {
             array.push(json!({ "kind": kind, "args": args }));


### PR DESCRIPTION
## Summary

Added MeCab-compatible whitespace handling. By default, whitespace tokens are now ignored (consistent with MeCab behavior), with an optional `--keep-whitespace` flag to preserve them in the output.

## Motivation

Previously, Lindera included whitespace as tokens in the output. However, MeCab's default behavior is to ignore whitespace. To improve MeCab compatibility, we've changed the default behavior to match MeCab.

## Changes

### Core Implementation

- **CharacterDefinition** ([lindera-dictionary/src/dictionary/character_definition.rs](lindera-dictionary/src/dictionary/character_definition.rs)):
  - Added `category_id_by_name()` method to look up category ID by name

- **Segmenter** ([lindera/src/segmenter.rs](lindera/src/segmenter.rs)):
  - Added `keep_whitespace` field (default: `false`)
  - Added `space_category_id` field to cache SPACE category ID
  - Modified `segment()` method to filter out whitespace tokens when `keep_whitespace` is false
  - Load `keep_whitespace` option from configuration

- **Tokenizer** ([lindera/src/tokenizer.rs](lindera/src/tokenizer.rs)):
  - Added `set_segmenter_keep_whitespace()` builder method

### CLI

- **lindera-cli** ([lindera-cli/src/main.rs](lindera-cli/src/main.rs)):
  - Added `--keep-whitespace` option to tokenize command

### Tests

Added 4 new test cases:
- `test_segment_default_ignores_space` - Default behavior ignores whitespace
- `test_segment_with_keep_whitespace` - With `keep_whitespace: true`, whitespace is preserved
- `test_segment_default_multiple_spaces` - Multiple consecutive spaces handling
- `test_segment_default_leading_trailing` - Leading and trailing spaces handling

## Behavior

### Before (v1.3.2)

```bash
$ echo "東京 都" | lindera tokenize --dict embedded://ipadic
東京	名詞,固有名詞,地域,一般,*,*,東京,トウキョウ,トーキョー
 	UNK
都	名詞,一般,*,*,*,*,都,ト,ト
```

### After (Default - MeCab compatible)

```
$ echo "東京 都" | lindera tokenize --dict embedded://ipadic
東京	名詞,固有名詞,地域,一般,*,*,東京,トウキョウ,トーキョー
都	名詞,一般,*,*,*,*,都,ト,ト
```

### After (With --keep-whitespace)

```
$ echo "東京 都" | lindera tokenize --dict embedded://ipadic --keep-whitespace
東京	名詞,固有名詞,地域,一般,*,*,東京,トウキョウ,トーキョー
 	UNK
都	名詞,一般,*,*,*,*,都,ト,ト
```

## Breaking Changes
⚠️ This is a breaking change The default behavior has changed. Previous versions included whitespace as tokens in the output, but this version ignores whitespace by default to match MeCab behavior. To preserve the old behavior:

- CLI: Use the --keep-whitespace flag
- API: Call builder.set_segmenter_keep_whitespace(true)
- Config: Set "keep_whitespace": true in configuration
