### PR TITLE
fix(prefix-dict): expand system dict variant-count from 5 to 8 bits

### DIFF
--- a/lindera-dictionary/src/builder/prefix_dictionary.rs
+++ b/lindera-dictionary/src/builder/prefix_dictionary.rs
@@ -426,7 +426,7 @@ impl PrefixDictionaryBuilder {
 
         for (key, word_entries) in word_entry_map {
             let len = word_entries.len() as u32;
-            let val = (id << 5) | len; // 27bit for word ID, 5bit for different parts of speech on the same surface.
+            let val = (id << 8) | len; // 24bit for word ID, 8bit for variant count (up to 255 per surface).
             keyset.push((key.as_bytes(), val));
             id += len;
         }

--- a/lindera-dictionary/src/builder/user_dictionary.rs
+++ b/lindera-dictionary/src/builder/user_dictionary.rs
@@ -202,6 +202,12 @@ impl UserDictionaryBuilder {
         let mut keyset: Vec<(&[u8], u32)> = vec![];
         for (key, word_entries) in &word_entry_map {
             let len = word_entries.len() as u32;
+            // User dictionaries keep the legacy 5-bit variant-count encoding
+            // (max 31 variants per surface) for binary backward compatibility
+            // with existing pre-built `.bin` user dictionary files. User dicts
+            // are user-defined and realistically never hit the 5-bit limit on
+            // a single surface (that only happened for the Korean system
+            // dictionary entry "이" which has 32 POS variants).
             let val = (id << 5) | len;
             keyset.push((key.as_bytes(), val));
             id += len;

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -110,6 +110,21 @@ pub struct PrefixDictionary {
 }
 
 impl PrefixDictionary {
+    /// Decode the `(offset, count)` pair stored in the double-array value.
+    ///
+    /// System dictionaries use 8-bit count (supports up to 255 variants per
+    /// surface), while user dictionaries retain the legacy 5-bit count
+    /// encoding (max 31) for binary backward compatibility with pre-built
+    /// `.bin` user dictionary files.
+    #[inline]
+    pub(crate) fn decode_val(&self, val: u32) -> (u32, u32) {
+        if self.is_system {
+            (val >> 8u32, val & ((1u32 << 8) - 1u32))
+        } else {
+            (val >> 5u32, val & ((1u32 << 5) - 1u32))
+        }
+    }
+
     /// Load a `PrefixDictionary` from raw binary data.
     ///
     /// # Arguments
@@ -149,9 +164,7 @@ impl PrefixDictionary {
             .find_overlapping_iter(s)
             .filter(|m| m.start() == 0)
             .flat_map(move |m| {
-                let id = m.value();
-                let len = id & ((1u32 << 5) - 1u32);
-                let offset = id >> 5u32;
+                let (offset, len) = self.decode_val(m.value());
                 let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
                 let data: &[u8] = &self.vals_data[offset_bytes..];
                 (0..len as usize).map(move |i| {
@@ -181,11 +194,9 @@ impl PrefixDictionary {
             .find_overlapping_iter(surface)
             .filter(|m| m.start() == 0 && m.end() == surface.len())
             .flat_map(move |m| {
-                let offset_len = m.value();
-                let offset = offset_len >> 5u32;
+                let (offset, len) = self.decode_val(m.value());
                 let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
                 let data = &self.vals_data[offset_bytes..];
-                let len = offset_len & ((1u32 << 5) - 1u32);
                 (0..len as usize).map(move |i| {
                     WordEntry::deserialize(&data[WordEntry::SERIALIZED_LEN * i..], self.is_system)
                 })
@@ -207,9 +218,7 @@ impl PrefixDictionary {
             .find_overlapping_iter(&suffix_str)
             .filter(|m| m.start() == 0)
             .flat_map(|m| {
-                let offset_len = m.value();
-                let len = offset_len & ((1u32 << 5) - 1u32);
-                let offset = offset_len >> 5u32;
+                let (offset, len) = self.decode_val(m.value());
                 let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
                 // 範囲チェックを追加
@@ -262,6 +271,16 @@ impl PrefixDictionary {
 }
 
 impl ArchivedPrefixDictionary {
+    /// Decode the `(offset, count)` pair. See [`PrefixDictionary::decode_val`].
+    #[inline]
+    fn decode_val(&self, val: u32) -> (u32, u32) {
+        if self.is_system {
+            (val >> 8u32, val & ((1u32 << 8) - 1u32))
+        } else {
+            (val >> 5u32, val & ((1u32 << 5) - 1u32))
+        }
+    }
+
     /// Find all prefix matches for the given string using the archived dictionary.
     ///
     /// # Arguments
@@ -288,8 +307,7 @@ impl ArchivedPrefixDictionary {
             .collect();
 
         Ok(matches.into_iter().flat_map(move |(end, offset_len)| {
-            let len = offset_len & ((1u32 << 5) - 1u32);
-            let offset = offset_len >> 5u32;
+            let (offset, len) = self.decode_val(offset_len);
             let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
             let vals = self.vals_data.as_slice();
@@ -337,8 +355,7 @@ impl ArchivedPrefixDictionary {
         Ok(matches
             .into_iter()
             .flat_map(|offset_len| {
-                let len = offset_len & ((1u32 << 5) - 1u32);
-                let offset = offset_len >> 5u32;
+                let (offset, len) = self.decode_val(offset_len);
                 let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
                 let vals = self.vals_data.as_slice();
                 if offset_bytes >= vals.len() {

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -383,12 +383,10 @@ impl Lattice {
         let mut matches_head = vec![usize::MAX; len + 1];
         let mut matches_store: Vec<(usize, WordEntry, usize)> = Vec::with_capacity(len * 10);
 
-        // System dictionary scan
+        // System dictionary scan (8-bit variant-count encoding)
         for m in dict.da.find_overlapping_iter(text) {
             let start = m.start();
-            let id = m.value();
-            let count = id & ((1u32 << 5) - 1u32);
-            let offset = id >> 5u32;
+            let (offset, count) = dict.decode_val(m.value());
             let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
             // Bounds check for safety, though daachorse should guarantee valid ids if built correctly
@@ -408,13 +406,11 @@ impl Lattice {
             }
         }
 
-        // User dictionary scan
+        // User dictionary scan (5-bit variant-count encoding for bwd compat)
         if let Some(ud) = user_dict {
             for m in ud.da.find_overlapping_iter(text) {
                 let start = m.start();
-                let id = m.value();
-                let count = id & ((1u32 << 5) - 1u32);
-                let offset = id >> 5u32;
+                let (offset, count) = ud.decode_val(m.value());
                 let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
                 if offset_bytes < ud.vals_data.len() {
@@ -932,12 +928,10 @@ impl Lattice {
         let mut matches_head = vec![usize::MAX; len + 1];
         let mut matches_store: Vec<(usize, WordEntry, usize)> = Vec::with_capacity(len * 10);
 
-        // System dictionary scan
+        // System dictionary scan (8-bit variant-count encoding)
         for m in dict.da.find_overlapping_iter(text) {
             let start = m.start();
-            let id = m.value();
-            let count = id & ((1u32 << 5) - 1u32);
-            let offset = id >> 5u32;
+            let (offset, count) = dict.decode_val(m.value());
             let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
             if offset_bytes < dict.vals_data.len() {
@@ -956,13 +950,11 @@ impl Lattice {
             }
         }
 
-        // User dictionary scan
+        // User dictionary scan (5-bit variant-count encoding for bwd compat)
         if let Some(ud) = user_dict {
             for m in ud.da.find_overlapping_iter(text) {
                 let start = m.start();
-                let id = m.value();
-                let count = id & ((1u32 << 5) - 1u32);
-                let offset = id >> 5u32;
+                let (offset, count) = ud.decode_val(m.value());
                 let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
                 if offset_bytes < ud.vals_data.len() {


### PR DESCRIPTION
## Summary

The prefix dictionary's double-array value packs `(offset, variant_count)` into a `u32`. The count field occupied the low **5 bits**, capping variants per surface at 31. The Korean `ko-dic` entry `이` has exactly **32** POS variants — `32 & 0x1F == 0`, so the count wrapped to zero and **every `이` entry vanished from the dictionary at build time**.

Consequences in real Korean input:
- `이것이 아니다`, `사실이다`, `가방이` etc. lost the subject/copula particle `이` entirely.
- Viterbi then fell back to bizarre paths (e.g. `학/NNG + 생이/NNG`), cascading errors across the whole sentence.

## Fix

- **System dictionaries**: widen the count field to **8 bits** (24-bit offset, 8-bit count — max 255). Writes in `builder/prefix_dictionary.rs` now pack `(id << 8) | len`.
- **User dictionaries**: keep the legacy 5-bit encoding. Existing pre-built `.bin` user-dict fixtures (e.g. `resources/user_dict/*.bin`) were produced with the old layout; switching them to 8 bits would break binary backward compatibility, and in practice no user-defined surface ever approaches 31 variants — that only happened for the Korean system dict `이`.
- **Readers** branch on `is_system` via a new helper:
  - `PrefixDictionary::decode_val(val) -> (offset, count)`
  - `ArchivedPrefixDictionary::decode_val(val) -> (offset, count)` (for rkyv-archived dicts)
  - Replaces 4 inline decode sites in `dictionary/prefix_dictionary.rs` and 4 scan-loop sites in `viterbi.rs` (`set_text` / `set_text_nbest`, system + user).

## Backward compatibility

- **User dict `.bin` files**: unchanged layout, still load correctly.
- **Non-Korean system dicts** (`lindera-ipadic`, `lindera-unidic`, `lindera-ipadic-neologd`, `lindera-cc-cedict`, `lindera-jieba`): rebuilt with the new encoding, but no surface in any of these dictionaries approaches even the old 31-variant ceiling, so behavior is identical.
- **Korean `ko-dic`**: the 32-variant `이` surface is now fully represented.

## Impact

Measured on `korean-ambiguity-data` (35,396 cases) against `mecab-ko` reference:

| Metric | main | with this PR |
|---|---|---|
| Overall accuracy | 38.8% | **45.7%** (+6.9pp) |
| `JKS` (subject particle `이`) recognition | 35.1% | **90.5%** (+55.4pp) |

This PR is the first of three independent changes that together bring lindera's Korean accuracy in line with mecab-ko. The remaining two (left-space-penalty, COPY-on-space) will be submitted as follow-up PRs.