### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,9 +1739,7 @@ name = "lindera"
 version = "4.0.1"
 dependencies = [
  "anyhow",
- "byteorder",
  "criterion",
- "csv",
  "daachorse",
  "insta",
  "kanaria",
@@ -1752,7 +1750,6 @@ dependencies = [
  "lindera-jieba",
  "lindera-ko-dic",
  "lindera-unidic",
- "log",
  "once_cell",
  "percent-encoding",
  "regex",
@@ -1824,7 +1821,6 @@ dependencies = [
  "log",
  "md5",
  "memmap2",
- "num_cpus",
  "once_cell",
  "rand 0.10.2",
  "regex",

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -37,7 +37,6 @@ glob = "0.3.3"
 log = { workspace = true }
 md5 = { version = "0.8.1", optional = true }
 memmap2 = { version = "0.9.11", optional = true }
-num_cpus = { workspace = true }
 once_cell = { workspace = true }
 rand = { version = "0.10.2", default-features = false, optional = true }
 regex = { workspace = true }

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -51,8 +51,6 @@ default = ["mmap"]
 
 [dependencies]
 anyhow = { workspace = true }
-byteorder = { workspace = true }
-csv = { workspace = true }
 daachorse = { workspace = true }
 kanaria = "0.2.0"
 lindera-cc-cedict = { workspace = true, optional = true }
@@ -62,8 +60,6 @@ lindera-ipadic-neologd = { workspace = true, optional = true }
 lindera-jieba = { workspace = true, optional = true }
 lindera-ko-dic = { workspace = true, optional = true }
 lindera-unidic = { workspace = true, optional = true }
-log = { workspace = true }
-once_cell = { workspace = true }
 percent-encoding = "2.3.2"
 regex = { workspace = true }
 serde = { workspace = true }
@@ -81,6 +77,7 @@ criterion = { version = "0.8.2", default-features = false, features = [
     "html_reports",
 ] }
 insta = "1.48.0"
+once_cell = { workspace = true }
 serde_json = { workspace = true }
 
 [[bench]]


### PR DESCRIPTION
## Summary

Dependency hygiene (Phase A of #754): remove dependencies that a workspace-wide audit found to be declared but never used.

- `lindera`: remove `byteorder`, `csv`, and `log` from `[dependencies]` (zero use sites in the crate's src/benches/examples/tests)
- `lindera`: move `once_cell` to `[dev-dependencies]` (used only inside a `#[cfg(test)]` module in `character_filter/japanese_iteration_mark.rs`)
- `lindera-dictionary`: remove `num_cpus` (zero use sites; it remains a workspace dependency because lindera-cli and the bindings use it)
- `Cargo.lock` updated in the same commit

No behavior change: these crates stay in the dependency tree via other workspace members; only the dead direct declarations are removed.

## Verification

- `cargo check -p lindera -p lindera-dictionary` — pass
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p lindera -p lindera-dictionary --all-targets` — clean
- `cargo test -p lindera` (51 tests) and `cargo test -p lindera-dictionary` (33 tests) — all pass
- `cargo tree -e normal --depth 1` confirms the removed crates are no longer direct dependencies

Closes #755
Refs #754
