### PR TITLE
fix: free runner disk space for large embedded-dictionary CI jobs

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -115,6 +115,11 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v7
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+          df -h /
+
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -133,6 +138,11 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v7
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+          df -h /
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -236,6 +236,7 @@ jobs:
     with:
       crate: lindera-ipadic-neologd
       features: "--features embed-ipadic-neologd"
+      free-disk-space: true
 
   test-lindera-unidic:
     name: Test lindera-unidic
@@ -247,6 +248,7 @@ jobs:
     with:
       crate: lindera-unidic
       features: "--features embed-unidic"
+      free-disk-space: true
 
   test-lindera-ko-dic:
     name: Test lindera-ko-dic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
       crate: lindera-ipadic-neologd
       features: "--features embed-ipadic-neologd"
       cache: true
+      free-disk-space: true
 
   test-lindera-unidic:
     name: Test lindera-unidic
@@ -86,6 +87,7 @@ jobs:
       crate: lindera-unidic
       features: "--features embed-unidic"
       cache: true
+      free-disk-space: true
 
   test-lindera-ko-dic:
     name: Test lindera-ko-dic

--- a/.github/workflows/test-crate.yml
+++ b/.github/workflows/test-crate.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: string
         default: ""
+      free-disk-space:
+        description: "Remove unused preinstalled tooling to free runner disk space (Linux only). Use for crates with very large build artifacts."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   test:
@@ -43,6 +48,12 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v7
+
+      - name: Free disk space
+        if: ${{ inputs.free-disk-space && runner.os == 'Linux' }}
+        run: |
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+          df -h /
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust


### PR DESCRIPTION
## Summary

Fix the intermittent `No space left on device` failures of the `Test lindera-ipadic-neologd` job (#752). The NEologd embedded dictionary is the largest one and its intermediate artifacts can exhaust the hosted `ubuntu-latest` runner's free disk; because most other jobs `need` this one, a failure cascades into skipped jobs and manual reruns.

## Changes

- `test-crate.yml`: new opt-in `free-disk-space` boolean input; when set (Linux runners only), a step removes unused preinstalled tooling (`/usr/local/lib/android`, `/opt/hostedtoolcache/CodeQL`, `/usr/share/dotnet`, `/opt/ghc`, `/usr/local/.ghcup`) before the build and logs `df -h /`. Frees roughly 15–20 GB
- `regression.yml` / `release.yml`: enable the flag for `lindera-ipadic-neologd` and `lindera-unidic` (the other large embedded dictionary, same risk profile)
- `periodic.yml`: same cleanup step added inline to those two jobs

A plain `rm -rf` step is used instead of a third-party action to avoid a new supply-chain dependency. Reducing debuginfo (the issue's second candidate) is left as a follow-up lever if exhaustion ever recurs.

## Verification

- YAML validation passes for all four workflows
- The cleanup step is gated to Linux (`runner.os == 'Linux'`); the Windows matrix jobs (lindera-dictionary / lindera) are unaffected since the flag defaults to false
- Note: the regression run on this PR does not exercise the NEologd job itself (its `detect-changes` path filter does not include workflow files), so the effective verification is the first `main` run after merge — the step's `df -h` output will show the freed space

Closes #752
