### PR TITLE
perf: speed up dictionary building (sort keys, streaming matrix parser)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,7 @@ version = "4.0.1"
 dependencies = [
  "anyhow",
  "byteorder",
+ "criterion",
  "csv",
  "daachorse",
  "derive_builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,9 +1854,11 @@ dependencies = [
  "glob",
  "log",
  "md5",
+ "memchr",
  "memmap2",
  "once_cell",
  "rand 0.10.2",
+ "rayon",
  "reqwest",
  "rkyv",
  "serde",
@@ -2708,6 +2729,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -51,5 +51,12 @@ thiserror = "2.0.18"
 tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
+criterion = { version = "0.8.2", default-features = false, features = [
+    "html_reports",
+] }
 rand = { version = "0.10.2", default-features = false }
 tempfile = "3.27.0"
+
+[[bench]]
+name = "bench_build"
+harness = false

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -35,6 +35,7 @@ flate2 = { version = "1.1.9", optional = true }
 glob = "0.3.3"
 log = { workspace = true }
 md5 = { version = "0.8.1", optional = true }
+memchr = "2.8.0"
 memmap2 = { version = "0.9.11", optional = true }
 once_cell = { workspace = true }
 rand = { version = "0.10.2", default-features = false, optional = true }
@@ -49,6 +50,11 @@ strum_macros = { workspace = true }
 tar = { version = "0.4.46", optional = true }
 thiserror = "2.0.18"
 tokio = { workspace = true, optional = true }
+
+# rayon does not support wasm32-unknown-unknown (no OS threads); the connection
+# cost matrix parser falls back to a sequential path there.
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+rayon = "1.11.0"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false, features = [

--- a/lindera-dictionary/benches/bench_build.rs
+++ b/lindera-dictionary/benches/bench_build.rs
@@ -1,0 +1,150 @@
+//! Criterion benchmarks for the dictionary build pipeline.
+//!
+//! These benchmarks measure [`DictionaryBuilder`] against a real dictionary
+//! source directory. Dictionary sources are large and not bundled in the
+//! repository, so the source location is supplied via environment variables:
+//!
+//! - `LINDERA_BENCH_DICTIONARY_SOURCE_DIR` (required): directory containing
+//!   the lexicon CSV files, `matrix.def`, `char.def`, and `unk.def`
+//!   (e.g. a mecab-ipadic checkout converted to UTF-8).
+//! - `LINDERA_BENCH_DICTIONARY_METADATA` (optional): path to a
+//!   `metadata.json` matching the source. Defaults to the IPADIC metadata
+//!   bundled in this workspace (`lindera-ipadic/metadata.json`).
+//!
+//! When `LINDERA_BENCH_DICTIONARY_SOURCE_DIR` is not set, all benchmarks are
+//! skipped so that `cargo bench` remains runnable without dictionary data
+//! (e.g. in CI).
+//!
+//! Typical before/after comparison:
+//!
+//! ```sh
+//! # On the baseline branch:
+//! LINDERA_BENCH_DICTIONARY_SOURCE_DIR=/path/to/mecab-ipadic \
+//!   cargo bench -p lindera-dictionary --bench bench_build -- --save-baseline before
+//!
+//! # After applying optimizations:
+//! LINDERA_BENCH_DICTIONARY_SOURCE_DIR=/path/to/mecab-ipadic \
+//!   cargo bench -p lindera-dictionary --bench bench_build -- --baseline before
+//! ```
+
+use std::fs::File;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use lindera_dictionary::builder::DictionaryBuilder;
+use lindera_dictionary::dictionary::metadata::Metadata;
+
+/// Returns the dictionary source directory from the environment, or `None`
+/// (with a notice on stderr) when the benchmarks should be skipped.
+fn source_dir() -> Option<PathBuf> {
+    match std::env::var_os("LINDERA_BENCH_DICTIONARY_SOURCE_DIR") {
+        Some(dir) => Some(PathBuf::from(dir)),
+        None => {
+            eprintln!(
+                "LINDERA_BENCH_DICTIONARY_SOURCE_DIR is not set; skipping dictionary build benchmarks."
+            );
+            None
+        }
+    }
+}
+
+/// Loads the dictionary metadata from `LINDERA_BENCH_DICTIONARY_METADATA`,
+/// falling back to the IPADIC metadata bundled in this workspace.
+fn load_metadata() -> Metadata {
+    let metadata_path = std::env::var_os("LINDERA_BENCH_DICTIONARY_METADATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("lindera-ipadic")
+                .join("metadata.json")
+        });
+
+    let metadata_file = File::open(&metadata_path)
+        .unwrap_or_else(|err| panic!("failed to open metadata {metadata_path:?}: {err}"));
+    serde_json::from_reader(metadata_file)
+        .unwrap_or_else(|err| panic!("failed to parse metadata {metadata_path:?}: {err}"))
+}
+
+/// Measures the full `DictionaryBuilder::build_dictionary` pipeline
+/// (metadata, character definition, unknown dictionary, prefix dictionary,
+/// and connection cost matrix), including output file writes.
+fn bench_build_dictionary(c: &mut Criterion) {
+    let Some(input_dir) = source_dir() else {
+        return;
+    };
+    let builder = DictionaryBuilder::new(load_metadata());
+    let output_dir = tempfile::tempdir().unwrap();
+
+    let mut group = c.benchmark_group("build");
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(3))
+        .measurement_time(Duration::from_secs(60));
+    group.bench_function("bench-build-dictionary", |b| {
+        b.iter(|| {
+            builder
+                .build_dictionary(&input_dir, output_dir.path())
+                .unwrap();
+        })
+    });
+    group.finish();
+}
+
+/// Measures the prefix dictionary stage alone (lexicon CSV parse, sort,
+/// word entry grouping, double array construction, and serialization).
+fn bench_build_prefix_dictionary(c: &mut Criterion) {
+    let Some(input_dir) = source_dir() else {
+        return;
+    };
+    let builder = DictionaryBuilder::new(load_metadata());
+    let output_dir = tempfile::tempdir().unwrap();
+
+    let mut group = c.benchmark_group("build-stages");
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(3))
+        .measurement_time(Duration::from_secs(60));
+    group.bench_function("bench-build-prefix-dictionary", |b| {
+        b.iter(|| {
+            builder
+                .build_prefix_dictionary(&input_dir, output_dir.path())
+                .unwrap();
+        })
+    });
+    group.finish();
+}
+
+/// Measures the connection cost matrix stage alone (`matrix.def` parse and
+/// `matrix.mtx` serialization).
+fn bench_build_connection_cost_matrix(c: &mut Criterion) {
+    let Some(input_dir) = source_dir() else {
+        return;
+    };
+    let builder = DictionaryBuilder::new(load_metadata());
+    let output_dir = tempfile::tempdir().unwrap();
+
+    let mut group = c.benchmark_group("build-stages");
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(3))
+        .measurement_time(Duration::from_secs(30));
+    group.bench_function("bench-build-connection-cost-matrix", |b| {
+        b.iter(|| {
+            builder
+                .build_connection_cost_matrix(&input_dir, output_dir.path())
+                .unwrap();
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_build_dictionary,
+    bench_build_prefix_dictionary,
+    bench_build_connection_cost_matrix
+);
+criterion_main!(benches);

--- a/lindera-dictionary/src/builder/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/builder/connection_cost_matrix.rs
@@ -2,55 +2,105 @@ use std::borrow::Cow;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::Path;
-use std::str::FromStr;
 
-use byteorder::{LittleEndian, WriteBytesExt};
 use derive_builder::Builder;
+use encoding_rs::{Encoding, UTF_16BE, UTF_16LE};
 use log::debug;
+use memchr::memchr;
 
 use crate::LinderaResult;
 use crate::error::LinderaErrorKind;
-use crate::util::{read_file_with_encoding, write_data};
+use crate::util::{read_file, write_data};
 
+/// UTF-8 byte order mark. `encoding_rs::Encoding::decode` strips a leading
+/// UTF-8 BOM, so the raw-byte fast path must strip it too to stay
+/// byte-identical with the previous decode-based implementation.
+const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
+
+/// Minimum `matrix.def` data size (in bytes, excluding the header line) at
+/// which the parser switches to the parallel path. Small connection matrices
+/// (e.g. CC-CEDICT's 1x1, Jieba's 7x6) are parsed sequentially to avoid
+/// thread-pool overhead.
+#[cfg(not(target_family = "wasm"))]
+const PARALLEL_THRESHOLD: usize = 1 << 20; // 1 MiB
+
+/// Builder for the connection cost matrix (`matrix.mtx`).
 #[derive(Builder, Debug)]
 #[builder(name = ConnectionCostMatrixBuilderOptions)]
 #[builder(build_fn(name = "builder"))]
 pub struct ConnectionCostMatrixBuilder {
+    /// Character encoding of the source `matrix.def` file.
+    ///
+    /// If set to UTF-8, files with a UTF-16 BOM are still decoded correctly.
     #[builder(default = "\"UTF-8\".into()", setter(into))]
     encoding: Cow<'static, str>,
 }
 
 impl ConnectionCostMatrixBuilder {
+    /// Build `matrix.mtx` from the `matrix.def` file in `input_dir`.
+    ///
+    /// The parser reads the raw bytes and, for ASCII-compatible encodings,
+    /// parses the space-separated integers directly without decoding the whole
+    /// file into a `String`. Files whose encoding is UTF-16 (by configured
+    /// label or by BOM) fall back to the decode path. On non-wasm targets a
+    /// large matrix is parsed in parallel with rayon.
+    ///
+    /// # Arguments
+    ///
+    /// * `input_dir` - Directory containing the source `matrix.def`.
+    /// * `output_dir` - Directory to write `matrix.mtx` into.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` on success, or a [`LinderaResult`] error if the file cannot be
+    /// read, the header is missing, or a data line is malformed.
     pub fn build(&self, input_dir: &Path, output_dir: &Path) -> LinderaResult<()> {
         let matrix_data_path = input_dir.join("matrix.def");
         debug!("reading {matrix_data_path:?}");
-        let matrix_data = read_file_with_encoding(&matrix_data_path, &self.encoding)?;
+        let buffer = read_file(&matrix_data_path)?;
 
-        let mut lines = Vec::new();
-        for line in matrix_data.lines() {
-            let fields: Vec<i32> = line
-                .split_whitespace()
-                .map(i32::from_str)
-                .collect::<Result<_, _>>()
-                .map_err(|err| LinderaErrorKind::Parse.with_error(anyhow::anyhow!(err)))?;
-            lines.push(fields);
-        }
-        let mut lines_it = lines.into_iter();
-        let header = lines_it.next().ok_or_else(|| {
-            LinderaErrorKind::Content.with_error(anyhow::anyhow!("unknown error"))
-        })?;
-        let forward_size = header[0] as u32;
-        let backward_size = header[1] as u32;
-        let len = 3 + (forward_size * backward_size) as usize;
+        // Decode only when the bytes are not ASCII-compatible (UTF-16). The
+        // decoded String is kept alive here so the parser can borrow its bytes.
+        let decoded = self.decode_if_needed(&buffer)?;
+        let bytes: &[u8] = match &decoded {
+            Some(decoded) => decoded.as_bytes(),
+            None => strip_utf8_bom(&buffer),
+        };
+
+        // Parse the header line ("<forward_size> <backward_size>").
+        let header_end = memchr(b'\n', bytes).unwrap_or(bytes.len());
+        let mut header_pos = 0;
+        let forward_size = next_int(&bytes[..header_end], &mut header_pos).ok_or_else(|| {
+            LinderaErrorKind::Content
+                .with_error(anyhow::anyhow!("matrix.def is missing the size header"))
+        })? as u32;
+        let backward_size = next_int(&bytes[..header_end], &mut header_pos).ok_or_else(|| {
+            LinderaErrorKind::Content.with_error(anyhow::anyhow!(
+                "matrix.def header is missing backward size"
+            ))
+        })? as u32;
+
+        let len = 3 + (forward_size as usize) * (backward_size as usize);
         let mut costs = vec![i16::MAX; len];
         costs[0] = -1; // Version flag for transposed layout
         costs[1] = forward_size as i16;
         costs[2] = backward_size as i16;
-        for fields in lines_it {
-            let forward_id = fields[0] as u32;
-            let backward_id = fields[1] as u32;
-            let cost = fields[2] as u16;
-            costs[3 + (forward_id + backward_id * forward_size) as usize] = cost as i16;
+
+        // Parse the data region (everything after the header line) and scatter
+        // the costs into `costs`. Applied in file order so a duplicated
+        // (forward_id, backward_id) pair keeps last-occurrence-wins semantics.
+        let data = if header_end < bytes.len() {
+            &bytes[header_end + 1..]
+        } else {
+            &[]
+        };
+        self.fill_costs(data, forward_size, &mut costs)?;
+
+        // Serialize as little-endian i16 values (identical bytes to the
+        // previous per-value byteorder writes).
+        let mut matrix_mtx_buffer = Vec::with_capacity(costs.len() * 2);
+        for cost in &costs {
+            matrix_mtx_buffer.extend_from_slice(&cost.to_le_bytes());
         }
 
         let wtr_matrix_mtx_path = output_dir.join(Path::new("matrix.mtx"));
@@ -58,19 +108,436 @@ impl ConnectionCostMatrixBuilder {
             File::create(wtr_matrix_mtx_path)
                 .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?,
         );
-        let mut matrix_mtx_buffer = Vec::new();
-        for cost in costs {
-            matrix_mtx_buffer
-                .write_i16::<LittleEndian>(cost)
-                .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
-        }
-
         write_data(&matrix_mtx_buffer, &mut wtr_matrix_mtx)?;
-
         wtr_matrix_mtx
             .flush()
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
 
         Ok(())
+    }
+
+    /// Decode the buffer into a `String` only when the raw bytes cannot be
+    /// parsed directly, i.e. when the configured encoding is UTF-16 or a
+    /// UTF-16 BOM is present. `matrix.def` content is always ASCII, so every
+    /// other (ASCII-compatible) encoding is parsed from the raw bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - The raw bytes read from `matrix.def`.
+    ///
+    /// # Returns
+    ///
+    /// `Some(decoded)` when a charset decode is required, otherwise `None`.
+    fn decode_if_needed(&self, buffer: &[u8]) -> LinderaResult<Option<String>> {
+        let encoding =
+            Encoding::for_label_no_replacement(self.encoding.as_bytes()).ok_or_else(|| {
+                LinderaErrorKind::Decode
+                    .with_error(anyhow::anyhow!("Invalid encoding: {}", self.encoding))
+            })?;
+
+        let is_utf16 = encoding == UTF_16LE || encoding == UTF_16BE || has_utf16_bom(buffer);
+        if is_utf16 {
+            // `decode` performs BOM sniffing and honors a UTF-16 BOM over the
+            // configured label, matching the previous read_file_with_encoding.
+            Ok(Some(encoding.decode(buffer).0.into_owned()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Parse the data region and scatter costs into `costs`.
+    ///
+    /// On non-wasm targets a sufficiently large region is parsed in parallel.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - Bytes of the data region (after the header line).
+    /// * `forward_size` - Number of forward context IDs (matrix stride).
+    /// * `costs` - Destination cost array to scatter into.
+    #[cfg(not(target_family = "wasm"))]
+    fn fill_costs(&self, data: &[u8], forward_size: u32, costs: &mut [i16]) -> LinderaResult<()> {
+        if data.len() >= PARALLEL_THRESHOLD {
+            fill_costs_parallel(data, forward_size, costs)
+        } else {
+            fill_costs_sequential(data, forward_size, costs)
+        }
+    }
+
+    /// Parse the data region and scatter costs into `costs` (wasm: always
+    /// sequential, since rayon is unavailable on `wasm32-unknown-unknown`).
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - Bytes of the data region (after the header line).
+    /// * `forward_size` - Number of forward context IDs (matrix stride).
+    /// * `costs` - Destination cost array to scatter into.
+    #[cfg(target_family = "wasm")]
+    fn fill_costs(&self, data: &[u8], forward_size: u32, costs: &mut [i16]) -> LinderaResult<()> {
+        fill_costs_sequential(data, forward_size, costs)
+    }
+}
+
+/// Return the buffer with a leading UTF-8 BOM removed, if present.
+///
+/// # Arguments
+///
+/// * `buffer` - The raw bytes read from `matrix.def`.
+///
+/// # Returns
+///
+/// The buffer without a leading UTF-8 BOM.
+fn strip_utf8_bom(buffer: &[u8]) -> &[u8] {
+    buffer.strip_prefix(UTF8_BOM).unwrap_or(buffer)
+}
+
+/// Return `true` if the buffer starts with a UTF-16 (LE or BE) byte order
+/// mark. A UTF-32 LE BOM (`FF FE 00 00`) also starts with the UTF-16 LE BOM
+/// and is likewise routed to the decode path.
+///
+/// # Arguments
+///
+/// * `buffer` - The raw bytes read from `matrix.def`.
+///
+/// # Returns
+///
+/// `true` when a UTF-16 BOM is present.
+fn has_utf16_bom(buffer: &[u8]) -> bool {
+    buffer.starts_with(&[0xFF, 0xFE]) || buffer.starts_with(&[0xFE, 0xFF])
+}
+
+/// Parse the next whitespace-delimited signed integer from `bytes`, advancing
+/// `pos` past it. Leading spaces, tabs, and carriage returns are skipped.
+///
+/// # Arguments
+///
+/// * `bytes` - The line (or header) bytes to parse.
+/// * `pos` - Cursor into `bytes`, advanced past the parsed integer.
+///
+/// # Returns
+///
+/// `Some(value)` if an integer was parsed, or `None` if no digits remain
+/// (e.g. an empty or whitespace-only line).
+fn next_int(bytes: &[u8], pos: &mut usize) -> Option<i32> {
+    while *pos < bytes.len() && matches!(bytes[*pos], b' ' | b'\t' | b'\r') {
+        *pos += 1;
+    }
+    if *pos >= bytes.len() {
+        return None;
+    }
+    let negative = bytes[*pos] == b'-';
+    if negative {
+        *pos += 1;
+    }
+    let start = *pos;
+    let mut value: i32 = 0;
+    while *pos < bytes.len() && bytes[*pos].is_ascii_digit() {
+        // matrix.def integers are small (context IDs < ~6000, costs within
+        // i16 range), so wrapping arithmetic never triggers in practice; it
+        // only avoids a debug-mode panic on pathological input.
+        value = value
+            .wrapping_mul(10)
+            .wrapping_add((bytes[*pos] - b'0') as i32);
+        *pos += 1;
+    }
+    if *pos == start {
+        // A lone '-' with no digits: not a valid integer.
+        return None;
+    }
+    Some(if negative { -value } else { value })
+}
+
+/// Parse a single `matrix.def` data line into a `(index, cost)` pair.
+///
+/// Casts match the previous implementation exactly (`forward_id`/`backward_id`
+/// via `i32 as u32`, `cost` via `i32 as u16 as i16`) so the resulting bytes
+/// are identical.
+///
+/// # Arguments
+///
+/// * `line` - The line bytes (without the trailing newline).
+/// * `forward_size` - Number of forward context IDs (matrix stride).
+/// * `costs_len` - Length of the destination cost array, for bounds checking.
+///
+/// # Returns
+///
+/// `Ok(Some((index, cost)))` for a data line, `Ok(None)` for an empty or
+/// whitespace-only line, or an error for a malformed or out-of-range line.
+fn parse_data_line(
+    line: &[u8],
+    forward_size: u32,
+    costs_len: usize,
+) -> LinderaResult<Option<(usize, i16)>> {
+    let mut pos = 0;
+    let Some(forward_id) = next_int(line, &mut pos) else {
+        // Empty or whitespace-only line: skip it.
+        return Ok(None);
+    };
+    let backward_id = next_int(line, &mut pos).ok_or_else(|| {
+        LinderaErrorKind::Content
+            .with_error(anyhow::anyhow!("matrix.def line is missing backward id"))
+    })?;
+    let cost = next_int(line, &mut pos).ok_or_else(|| {
+        LinderaErrorKind::Content.with_error(anyhow::anyhow!("matrix.def line is missing cost"))
+    })?;
+
+    let forward_id = forward_id as u32 as usize;
+    let backward_id = backward_id as u32 as usize;
+    let index = 3 + forward_id + backward_id * forward_size as usize;
+    if index >= costs_len {
+        return Err(LinderaErrorKind::Content.with_error(anyhow::anyhow!(
+            "matrix.def entry ({forward_id}, {backward_id}) is out of range"
+        )));
+    }
+    let cost = (cost as u16) as i16;
+    Ok(Some((index, cost)))
+}
+
+/// Parse the data region sequentially, scattering costs into `costs`.
+///
+/// # Arguments
+///
+/// * `data` - Bytes of the data region (after the header line).
+/// * `forward_size` - Number of forward context IDs (matrix stride).
+/// * `costs` - Destination cost array to scatter into.
+fn fill_costs_sequential(data: &[u8], forward_size: u32, costs: &mut [i16]) -> LinderaResult<()> {
+    let costs_len = costs.len();
+    let mut pos = 0;
+    while pos < data.len() {
+        let line_end = memchr(b'\n', &data[pos..])
+            .map(|offset| pos + offset)
+            .unwrap_or(data.len());
+        if let Some((index, cost)) = parse_data_line(&data[pos..line_end], forward_size, costs_len)?
+        {
+            costs[index] = cost;
+        }
+        pos = line_end + 1;
+    }
+    Ok(())
+}
+
+/// Parse the data region in parallel, then scatter costs into `costs` in file
+/// order (preserving last-occurrence-wins for duplicate entries).
+///
+/// The input is split into newline-aligned chunks, each parsed on a rayon
+/// worker into a `(index, cost)` list; the lists are then applied in order.
+///
+/// # Arguments
+///
+/// * `data` - Bytes of the data region (after the header line).
+/// * `forward_size` - Number of forward context IDs (matrix stride).
+/// * `costs` - Destination cost array to scatter into.
+#[cfg(not(target_family = "wasm"))]
+fn fill_costs_parallel(data: &[u8], forward_size: u32, costs: &mut [i16]) -> LinderaResult<()> {
+    use rayon::prelude::*;
+
+    let costs_len = costs.len();
+    let n_chunks = (rayon::current_num_threads() * 4).max(1);
+
+    // Compute chunk boundaries snapped to line starts so no line is split.
+    let mut bounds = Vec::with_capacity(n_chunks + 1);
+    bounds.push(0usize);
+    for i in 1..n_chunks {
+        let target = data.len() * i / n_chunks;
+        let last = *bounds.last().unwrap_or(&0);
+        if target <= last {
+            continue;
+        }
+        if let Some(offset) = memchr(b'\n', &data[target..]) {
+            let boundary = target + offset + 1;
+            if boundary > last && boundary < data.len() {
+                bounds.push(boundary);
+            }
+        }
+    }
+    bounds.push(data.len());
+
+    let chunks: Vec<&[u8]> = bounds.windows(2).map(|w| &data[w[0]..w[1]]).collect();
+    let partials: Vec<Vec<(usize, i16)>> = chunks
+        .par_iter()
+        .map(|chunk| parse_chunk(chunk, forward_size, costs_len))
+        .collect::<LinderaResult<Vec<_>>>()?;
+
+    for partial in &partials {
+        for &(index, cost) in partial {
+            costs[index] = cost;
+        }
+    }
+    Ok(())
+}
+
+/// Parse all data lines in a single chunk into a `(index, cost)` list.
+///
+/// # Arguments
+///
+/// * `chunk` - A newline-aligned slice of the data region.
+/// * `forward_size` - Number of forward context IDs (matrix stride).
+/// * `costs_len` - Length of the destination cost array, for bounds checking.
+///
+/// # Returns
+///
+/// The parsed `(index, cost)` pairs in chunk order.
+#[cfg(not(target_family = "wasm"))]
+fn parse_chunk(
+    chunk: &[u8],
+    forward_size: u32,
+    costs_len: usize,
+) -> LinderaResult<Vec<(usize, i16)>> {
+    let mut out = Vec::with_capacity(chunk.len() / 8);
+    let mut pos = 0;
+    while pos < chunk.len() {
+        let line_end = memchr(b'\n', &chunk[pos..])
+            .map(|offset| pos + offset)
+            .unwrap_or(chunk.len());
+        if let Some(entry) = parse_data_line(&chunk[pos..line_end], forward_size, costs_len)? {
+            out.push(entry);
+        }
+        pos = line_end + 1;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reference parser replicating the previous split_whitespace + from_str
+    /// implementation, used to assert byte-identical output.
+    fn reference_costs(matrix: &str) -> Vec<i16> {
+        let mut lines = Vec::new();
+        for line in matrix.lines() {
+            let fields: Vec<i32> = line
+                .split_whitespace()
+                .map(|f| f.parse::<i32>().unwrap())
+                .collect();
+            lines.push(fields);
+        }
+        let mut lines_it = lines.into_iter();
+        let header = lines_it.next().unwrap();
+        let forward_size = header[0] as u32;
+        let backward_size = header[1] as u32;
+        let len = 3 + (forward_size * backward_size) as usize;
+        let mut costs = vec![i16::MAX; len];
+        costs[0] = -1;
+        costs[1] = forward_size as i16;
+        costs[2] = backward_size as i16;
+        for fields in lines_it {
+            if fields.is_empty() {
+                continue;
+            }
+            let forward_id = fields[0] as u32;
+            let backward_id = fields[1] as u32;
+            let cost = fields[2] as u16;
+            costs[3 + (forward_id + backward_id * forward_size) as usize] = cost as i16;
+        }
+        costs
+    }
+
+    /// Parse a matrix string through the new code path under test.
+    fn new_costs(matrix: &str) -> Vec<i16> {
+        let bytes = matrix.as_bytes();
+        let header_end = memchr(b'\n', bytes).unwrap_or(bytes.len());
+        let mut header_pos = 0;
+        let forward_size = next_int(&bytes[..header_end], &mut header_pos).unwrap() as u32;
+        let backward_size = next_int(&bytes[..header_end], &mut header_pos).unwrap() as u32;
+        let len = 3 + (forward_size as usize) * (backward_size as usize);
+        let mut costs = vec![i16::MAX; len];
+        costs[0] = -1;
+        costs[1] = forward_size as i16;
+        costs[2] = backward_size as i16;
+        let data = if header_end < bytes.len() {
+            &bytes[header_end + 1..]
+        } else {
+            &[]
+        };
+        fill_costs_sequential(data, forward_size, &mut costs).unwrap();
+        costs
+    }
+
+    #[test]
+    fn test_matches_reference_simple() {
+        // 2x2 matrix, all cells present, extra whitespace, trailing newline.
+        let matrix = "2 2\n0 0 10\n0 1 20\n1 0 30\n1 1 40\n";
+        assert_eq!(new_costs(matrix), reference_costs(matrix));
+    }
+
+    #[test]
+    fn test_matches_reference_sparse_and_negative() {
+        // Missing cells default to i16::MAX; negative cost round-trips via the
+        // u16 cast; multiple spaces between fields.
+        let matrix = "3 2\n0  0  -1\n2 1 32767\n1 0 -32768\n";
+        let new = new_costs(matrix);
+        let reference = reference_costs(matrix);
+        assert_eq!(new, reference);
+        // Spot-check the negative cost round-trip.
+        assert_eq!(new[3], -1);
+    }
+
+    #[test]
+    fn test_no_trailing_newline() {
+        let matrix = "1 1\n0 0 7";
+        assert_eq!(new_costs(matrix), reference_costs(matrix));
+    }
+
+    #[test]
+    fn test_duplicate_last_occurrence_wins() {
+        // The reference (sequential) code keeps the last write for a duplicate
+        // (forward, backward) pair; the new sequential path must match.
+        let matrix = "1 1\n0 0 5\n0 0 9\n";
+        let costs = new_costs(matrix);
+        assert_eq!(costs[3], 9);
+        assert_eq!(costs, reference_costs(matrix));
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn test_parallel_matches_sequential() {
+        // Build a matrix large enough that a real build would take the
+        // parallel path, and assert both paths produce identical arrays.
+        let forward = 200u32;
+        let backward = 200u32;
+        let mut matrix = format!("{forward} {backward}\n");
+        for b in 0..backward {
+            for f in 0..forward {
+                let cost = ((f + b) % 100) as i32 - 50;
+                matrix.push_str(&format!("{f} {b} {cost}\n"));
+            }
+        }
+        let bytes = matrix.as_bytes();
+        let header_end = memchr(b'\n', bytes).unwrap();
+        let data = &bytes[header_end + 1..];
+        let len = 3 + (forward as usize) * (backward as usize);
+
+        let mut seq = vec![i16::MAX; len];
+        seq[0] = -1;
+        seq[1] = forward as i16;
+        seq[2] = backward as i16;
+        fill_costs_sequential(data, forward, &mut seq).unwrap();
+
+        let mut par = vec![i16::MAX; len];
+        par[0] = -1;
+        par[1] = forward as i16;
+        par[2] = backward as i16;
+        fill_costs_parallel(data, forward, &mut par).unwrap();
+
+        assert_eq!(seq, par);
+        assert_eq!(seq, reference_costs(&matrix));
+    }
+
+    #[test]
+    fn test_missing_field_errors() {
+        // A data line with only two fields is malformed (was a panic before).
+        let matrix = "2 2\n0 0\n";
+        let bytes = matrix.as_bytes();
+        let header_end = memchr(b'\n', bytes).unwrap();
+        let data = &bytes[header_end + 1..];
+        let mut costs = vec![i16::MAX; 3 + 4];
+        assert!(fill_costs_sequential(data, 2, &mut costs).is_err());
+    }
+
+    #[test]
+    fn test_strip_utf8_bom() {
+        let with_bom = [0xEF, 0xBB, 0xBF, b'1', b' ', b'1'];
+        assert_eq!(strip_utf8_bom(&with_bom), b"1 1");
+        assert_eq!(strip_utf8_bom(b"1 1"), b"1 1");
     }
 }

--- a/lindera-dictionary/src/builder/prefix_dictionary.rs
+++ b/lindera-dictionary/src/builder/prefix_dictionary.rs
@@ -74,8 +74,10 @@ impl PrefixDictionaryBuilder {
         // Sort dictionary entries by the first column (word)
         // Change sorting method based on normalization settings
         if self.normalize_details {
-            // Sort after normalizing characters (―→—, ～→〜)
-            rows.sort_by_key(|row| normalize(&row[0]));
+            // Sort after normalizing characters (―→—, ～→〜).
+            // The cached variant computes the allocating normalize key once
+            // per row instead of once per comparison.
+            rows.sort_by_cached_key(|row| normalize(&row[0]));
         } else {
             // Sort using original strings directly
             rows.sort_by(|a, b| a[0].cmp(&b[0]))
@@ -631,6 +633,30 @@ mod tests {
 
         let right_id = builder.parse_right_id(&record).unwrap();
         assert_eq!(right_id, Some(456));
+    }
+
+    #[test]
+    fn test_sort_by_cached_key_matches_sort_by_key() {
+        // Rows whose surfaces normalize to the same key (～ -> 〜) exercise
+        // stability: equal-key rows must keep their input order, so the
+        // cached-key sort must produce exactly the same order as the
+        // per-comparison sort_by_key it replaced.
+        let mut rows_cached: Vec<StringRecord> = vec![
+            StringRecord::from(vec!["テスト～", "1", "1", "10"]),
+            StringRecord::from(vec!["テスト〜", "2", "2", "20"]),
+            StringRecord::from(vec!["あ", "3", "3", "30"]),
+            StringRecord::from(vec!["テスト～", "4", "4", "40"]),
+            StringRecord::from(vec!["―", "5", "5", "50"]),
+            StringRecord::from(vec!["—", "6", "6", "60"]),
+        ];
+        let mut rows_naive = rows_cached.clone();
+
+        rows_cached.sort_by_cached_key(|row| normalize(&row[0]));
+        rows_naive.sort_by_key(|row| normalize(&row[0]));
+
+        let order_cached: Vec<String> = rows_cached.iter().map(|r| r[1].to_string()).collect();
+        let order_naive: Vec<String> = rows_naive.iter().map(|r| r[1].to_string()).collect();
+        assert_eq!(order_cached, order_naive);
     }
 
     #[test]

--- a/lindera-dictionary/src/builder/user_dictionary.rs
+++ b/lindera-dictionary/src/builder/user_dictionary.rs
@@ -69,7 +69,9 @@ impl UserDictionaryBuilder {
             })?;
             rows.push(record);
         }
-        rows.sort_by_key(|row| row[0].to_string());
+        // The cached variant computes the allocating surface key once per row
+        // instead of once per comparison.
+        rows.sort_by_cached_key(|row| row[0].to_string());
 
         let mut word_entry_map: BTreeMap<String, Vec<WordEntry>> = BTreeMap::new();
 


### PR DESCRIPTION
## Summary

Speeds up dictionary building without changing the built output bytes. Three
commits, each independently useful:

1. **`test:`** add a criterion benchmark for the build pipeline
   (`lindera-dictionary/benches/bench_build.rs`). It measures the full build
   plus the two heavy stages against a real dictionary source directory,
   supplied via `LINDERA_BENCH_DICTIONARY_SOURCE_DIR` (skipped when unset, so
   `cargo bench` stays runnable without dictionary data).
2. **`perf:` (P1)** compute lexicon sort keys once with `sort_by_cached_key`.
   `sort_by_key` re-evaluates the key on every comparison, so the
   `normalize_details` path allocated three `String`s per comparison
   (`O(n log n)` allocating key evaluations). `sort_by_cached_key` computes each
   key once and is stable, so equal-key order — and therefore `word_id`
   assignment and all output bytes — is unchanged. The same fix is applied to
   the user dictionary sort.
3. **`perf:` (P2 + P3)** rewrite the connection cost matrix builder as a
   streaming byte-level parser: read raw bytes and parse the space-separated
   integers directly (no per-line `Vec<i32>`, no whole-file `into_owned` decode
   copy), with `memchr` line scanning. On non-wasm targets a large matrix is
   parsed in parallel with rayon over newline-aligned chunks, applying results
   in file order so duplicate entries keep last-occurrence-wins semantics.

## Measurements

Real mecab-ipadic data, release build, i7-1185G7, criterion baseline comparison
(`before` = `main`):

| Metric | before | after | change |
| --- | --- | --- | --- |
| full build | 2.73 s | 1.22 s | **-54%** |
| prefix dictionary stage | 2.21 s | 1.24 s | -43% (P1) |
| connection cost matrix stage | 183 ms | 20.6 ms | **-89% / ~8.9x** (P2+P3) |

The absolute matrix-stage win grows substantially on dictionaries with large
matrices — UniDic's matrix.def is 5981x5981 (~35.8M lines / 491 MiB), ko-dic
~10.3M lines — where that stage dominates the build.

## Correctness

- **Byte-identical output verified end-to-end**: a full IPADIC build on this
  branch produces byte-identical `matrix.mtx`, `dict.da`, `dict.vals`,
  `dict.words`, `dict.wordsidx`, `char_def.bin`, `unk.bin`, and `metadata.json`
  versus `main` (sha256 diff of all eight files).
- Unit tests assert the new matrix parser matches a faithful reference parser,
  that the parallel and sequential paths agree, and cover duplicate entries
  (last-occurrence-wins), negative costs, missing trailing newline, malformed
  lines, and UTF-8 BOM stripping.
- UTF-16 input (by configured encoding label or BOM) still falls back to the
  decode path; a UTF-8 BOM is stripped to match `encoding_rs` behavior.
- Malformed data lines now return an error instead of panicking (a behavior
  change for invalid input only; output for well-formed input is unchanged).
- `wasm32-unknown-unknown` builds (rayon is a non-wasm dependency; wasm uses the
  sequential path).
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, and
  `cargo test -p lindera-dictionary --all-features` pass.

## Notes

- New dependencies: `memchr` (promoted from transitive to direct;
  Unlicense OR MIT), `rayon` (non-wasm only; MIT OR Apache-2.0).
- A follow-up (P4: run the independent build stages concurrently) is tracked in
  the issue.

Refs #771
