### PR TITLE
perf: run independent dictionary build stages concurrently

### DIFF
--- a/lindera-dictionary/src/builder.rs
+++ b/lindera-dictionary/src/builder.rs
@@ -32,10 +32,50 @@ impl DictionaryBuilder {
         Self { metadata }
     }
 
+    /// Build all dictionary artifacts from `input_dir` into `output_dir`.
+    ///
+    /// The independent stages run concurrently on non-wasm targets and
+    /// sequentially on wasm (which has no OS threads). The output files are
+    /// identical regardless of the path taken.
+    ///
+    /// # Arguments
+    ///
+    /// * `input_dir` - Directory containing the source dictionary files.
+    /// * `output_dir` - Directory to write the built artifacts into.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` on success, or the first stage error in stage order.
     pub fn build_dictionary(&self, input_dir: &Path, output_dir: &Path) -> LinderaResult<()> {
         fs::create_dir_all(output_dir)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
 
+        #[cfg(not(target_family = "wasm"))]
+        {
+            self.build_dictionary_parallel(input_dir, output_dir)
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            self.build_dictionary_sequential(input_dir, output_dir)
+        }
+    }
+
+    /// Build every stage sequentially.
+    ///
+    /// Used on wasm targets, and as the reference ordering: metadata,
+    /// character definition, unknown dictionary, prefix dictionary, then
+    /// connection cost matrix.
+    ///
+    /// # Arguments
+    ///
+    /// * `input_dir` - Directory containing the source dictionary files.
+    /// * `output_dir` - Directory to write the built artifacts into.
+    #[cfg(target_family = "wasm")]
+    fn build_dictionary_sequential(
+        &self,
+        input_dir: &Path,
+        output_dir: &Path,
+    ) -> LinderaResult<()> {
         self.build_metadata(output_dir)?;
         let chardef = self.build_character_definition(input_dir, output_dir)?;
         self.build_unknown_dictionary(input_dir, output_dir, &chardef)?;
@@ -43,6 +83,55 @@ impl DictionaryBuilder {
         self.build_connection_cost_matrix(input_dir, output_dir)?;
 
         Ok(())
+    }
+
+    /// Build the four independent stage chains concurrently.
+    ///
+    /// The only data dependency is `character definition -> unknown
+    /// dictionary`; the metadata, prefix dictionary, and connection cost matrix
+    /// stages are independent and write disjoint files, so each chain runs on
+    /// its own scoped thread. All threads are joined before results are
+    /// inspected, and the earliest failure in stage order is returned so the
+    /// result matches the sequential fail-fast order; a panicked stage is
+    /// re-raised rather than swallowed.
+    ///
+    /// Peak memory is higher than the sequential path, since the working sets
+    /// of the concurrent stages (most notably the prefix dictionary and
+    /// connection cost matrix) are held at the same time.
+    ///
+    /// # Arguments
+    ///
+    /// * `input_dir` - Directory containing the source dictionary files.
+    /// * `output_dir` - Directory to write the built artifacts into.
+    #[cfg(not(target_family = "wasm"))]
+    fn build_dictionary_parallel(&self, input_dir: &Path, output_dir: &Path) -> LinderaResult<()> {
+        std::thread::scope(|scope| {
+            let metadata = scope.spawn(move || self.build_metadata(output_dir));
+            let unknown = scope.spawn(move || {
+                let chardef = self.build_character_definition(input_dir, output_dir)?;
+                self.build_unknown_dictionary(input_dir, output_dir, &chardef)
+            });
+            let prefix = scope.spawn(move || self.build_prefix_dictionary(input_dir, output_dir));
+            let matrix =
+                scope.spawn(move || self.build_connection_cost_matrix(input_dir, output_dir));
+
+            // Join all stages, then report the earliest failure in stage order.
+            let results = [
+                metadata.join(),
+                unknown.join(),
+                prefix.join(),
+                matrix.join(),
+            ];
+            for result in results {
+                match result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(err)) => return Err(err),
+                    Err(panic) => std::panic::resume_unwind(panic),
+                }
+            }
+
+            Ok(())
+        })
     }
 
     pub fn build_metadata(&self, output_dir: &Path) -> LinderaResult<()> {

--- a/lindera-dictionary/tests/build_dictionary.rs
+++ b/lindera-dictionary/tests/build_dictionary.rs
@@ -1,0 +1,112 @@
+//! End-to-end tests for `DictionaryBuilder::build_dictionary`.
+//!
+//! On non-wasm targets `build_dictionary` runs its independent stages
+//! concurrently, so these tests exercise the parallel build path and assert it
+//! produces the expected files deterministically.
+
+use std::fs;
+use std::path::Path;
+
+use lindera_dictionary::builder::DictionaryBuilder;
+use lindera_dictionary::dictionary::metadata::Metadata;
+
+/// Minimal `char.def`: the mandatory DEFAULT category plus KANJI, with the CJK
+/// range mapped to KANJI so the sample surfaces are categorized.
+const CHAR_DEF: &str = "\
+DEFAULT 0 1 0
+KANJI 0 0 2
+0x4E00..0x9FFF KANJI
+";
+
+/// Minimal `unk.def`: one entry per category (category, left_id, right_id,
+/// cost, then detail fields).
+const UNK_DEF: &str = "\
+DEFAULT,0,0,0,補助記号,一般,*,*,*,*,*,*,*
+KANJI,0,0,0,名詞,一般,*,*,*,*,*,*,*
+";
+
+/// Minimal lexicon matching the default 13-field schema
+/// (surface, left_context_id, right_context_id, cost, then 9 detail fields).
+const LEX_CSV: &str = "\
+日本,0,0,100,名詞,固有名詞,地域,国,*,*,日本,ニッポン,ニッポン
+本,0,0,200,名詞,一般,*,*,*,*,本,ホン,ホン
+";
+
+/// Minimal 1x1 connection cost matrix.
+const MATRIX_DEF: &str = "1 1\n0 0 0\n";
+
+/// Write the minimal dictionary source files into `dir`.
+fn write_source(dir: &Path) {
+    fs::write(dir.join("char.def"), CHAR_DEF).unwrap();
+    fs::write(dir.join("unk.def"), UNK_DEF).unwrap();
+    fs::write(dir.join("lex.csv"), LEX_CSV).unwrap();
+    fs::write(dir.join("matrix.def"), MATRIX_DEF).unwrap();
+}
+
+/// The artifacts a completed build must produce.
+const EXPECTED_FILES: &[&str] = &[
+    "metadata.json",
+    "char_def.bin",
+    "unk.bin",
+    "dict.da",
+    "dict.vals",
+    "dict.words",
+    "dict.wordsidx",
+    "matrix.mtx",
+];
+
+#[test]
+fn build_dictionary_produces_all_artifacts() {
+    let input = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    write_source(input.path());
+
+    let builder = DictionaryBuilder::new(Metadata::default());
+    builder
+        .build_dictionary(input.path(), output.path())
+        .expect("build_dictionary should succeed");
+
+    for name in EXPECTED_FILES {
+        let path = output.path().join(name);
+        let meta =
+            fs::metadata(&path).unwrap_or_else(|err| panic!("missing artifact {name}: {err}"));
+        assert!(meta.len() > 0, "artifact {name} is empty");
+    }
+}
+
+#[test]
+fn build_dictionary_is_deterministic() {
+    // Building the same source twice must yield byte-identical artifacts. On
+    // non-wasm targets the stages run concurrently, so a data race would show
+    // up as a byte difference between the two runs.
+    let input = tempfile::tempdir().unwrap();
+    write_source(input.path());
+    let builder = DictionaryBuilder::new(Metadata::default());
+
+    let out_a = tempfile::tempdir().unwrap();
+    let out_b = tempfile::tempdir().unwrap();
+    builder
+        .build_dictionary(input.path(), out_a.path())
+        .unwrap();
+    builder
+        .build_dictionary(input.path(), out_b.path())
+        .unwrap();
+
+    for name in EXPECTED_FILES {
+        let a = fs::read(out_a.path().join(name)).unwrap();
+        let b = fs::read(out_b.path().join(name)).unwrap();
+        assert_eq!(a, b, "artifact {name} differs between builds");
+    }
+}
+
+#[test]
+fn build_dictionary_reports_missing_input() {
+    // An empty input directory (no matrix.def / char.def) must return an error
+    // rather than panicking, even though stages run concurrently.
+    let input = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+
+    let builder = DictionaryBuilder::new(Metadata::default());
+    let result = builder.build_dictionary(input.path(), output.path());
+    assert!(result.is_err(), "expected an error for missing input files");
+}


### PR DESCRIPTION
## Summary

Runs the independent dictionary build stages concurrently. `build_dictionary`
previously ran its five stages sequentially, but the only data dependency is
`character definition -> unknown dictionary`; the metadata, prefix dictionary,
and connection cost matrix stages are independent and write disjoint files.

This change runs the four independent chains under `std::thread::scope`, joins
them all, and returns the earliest failure in stage order (matching the
sequential fail-fast order); a panicked stage is re-raised rather than swallowed.
`wasm32` has no OS threads, so it keeps the sequential path (guarded by
`cfg(target_family = "wasm")`).

Follow-up to #772 (P4 in #771).

## Measurements

Real `unidic-mecab` data (matrix.def 5981x5981 = ~35.8M lines / 491 MiB), release
build, i7-1185G7. UniDic is the relevant target because its matrix stage stays
substantial even after the streaming parser from #772; on IPADIC/NEologd the
matrix stage is tiny (~21 ms) so the overlap is negligible.

Per-stage timing (stable): prefix ~1.9 s (dominant), connection cost matrix
~0.8 s, char def / unknown / metadata sub-millisecond.

Full build, min of 8 interleaved runs (min is robust to this laptop's thermal
throttling, which only adds time):

| Metric | sequential | concurrent (this PR) | change |
| --- | --- | --- | --- |
| full build (min) | 2.51 s | 2.29 s | **-8.9%** |
| full build (median) | 2.83 s | 2.53 s | -10.7% |
| peak RSS | 1.61 GB | 1.45 GB | not increased |

Peak RSS does **not** increase: the matrix stage's large allocations
(491 MiB read + parser buffers) are freed early, before the prefix stage reaches
its daachorse-construction peak, so the two peaks do not coincide.

The realized speedup is below the ~30% ceiling (hiding the ~0.8 s matrix stage
entirely behind the ~1.9 s prefix stage) because the matrix parser's rayon pool
and the prefix thread oversubscribe the cores while the two stages overlap.

## Correctness

- **Byte-identical output**: a full IPADIC build on this branch matches `main`
  for all eight artifacts (`matrix.mtx`, `dict.*`, `char_def.bin`, `unk.bin`,
  `metadata.json`) by sha256.
- New end-to-end integration tests (`tests/build_dictionary.rs`): assert the
  built artifacts exist and are non-empty, are byte-identical across two runs (a
  data race would surface as a diff), and that missing input returns an error
  instead of panicking.
- `wasm32-unknown-unknown` builds (sequential path).
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, and
  `cargo test -p lindera-dictionary --all-features` pass.

## Notes

- No new dependencies (`std::thread::scope`).
- Trade-off: on non-wasm, the independent stages hold their working sets
  concurrently. Measured peak RSS did not increase on UniDic (see above), but the
  worst case is the sum of the concurrent stages' peaks.

Refs #771
