### PR TITLE
fix(analysis): avoid panic in japanese_stop_tags on empty token details

### DIFF
--- a/lindera-analysis/src/token_filter/japanese_stop_tags.rs
+++ b/lindera-analysis/src/token_filter/japanese_stop_tags.rs
@@ -69,9 +69,11 @@ impl TokenFilter for JapaneseStopTagsTokenFilter {
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         apply_tag_filter(tokens, &self.tags, TagPolicy::Remove, |token| {
             let details = token.details();
-            // If the length of the details is greater than or equal to 4,
-            // the tag length is 4, otherwise 1 is assigned to tags_len.
-            let tags_len = if details.len() >= 4 { 4 } else { 1 };
+            // Use up to the first 4 part-of-speech levels as the tag. When fewer
+            // details are available (e.g. a token whose details were left empty),
+            // use only what is present. `min` also keeps the slice in bounds for
+            // empty details, which would otherwise panic.
+            let tags_len = details.len().min(4);
             // Make a string of the part-of-speech tags.
             details[0..tags_len].join(",")
         });
@@ -368,5 +370,43 @@ mod tests {
         assert_eq!(&tokens[1].surface, "もも");
         assert_eq!(&tokens[2].surface, "もも");
         assert_eq!(&tokens[3].surface, "うち");
+    }
+
+    // Regression test for https://github.com/lindera/lindera/issues/438:
+    // a token with empty details must not cause an out-of-range panic when the
+    // filter builds its part-of-speech tag key.
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_japanese_stop_tags_empty_details_no_panic() {
+        use std::borrow::Cow;
+        use std::collections::HashSet;
+
+        use crate::token_filter::TokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let filter = JapaneseStopTagsTokenFilter::new(HashSet::new());
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("テスト"),
+            byte_start: 0,
+            byte_end: 9,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 0),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            // Details were explicitly left empty; this is what triggered the panic.
+            details: Some(vec![]),
+        }];
+
+        // Must not panic. The empty tag matches no stop tag, so the token is kept.
+        filter.apply(&mut tokens).unwrap();
+
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(&tokens[0].surface, "テスト");
     }
 }


### PR DESCRIPTION
## Summary

`japanese_stop_tags` built its part-of-speech tag key with `details[0..tags_len]`, where `tags_len` fell back to `1` when a token had fewer than 4 details. A token with **empty** details therefore sliced `[0..1]` on an empty vector and panicked with `range end index 1 out of range for slice of length 0`.

This changes `tags_len` to `details.len().min(4)`, which:

- keeps the slice in bounds for empty details (`[0..0]`), removing the panic;
- matches the safe pattern already used by `japanese_compound_word`;
- matches the method's own documented behavior ("if it has fewer details, only the available details are used").

## Context (Refs #438)

The original report described empty compound-word details — produced when building without a built-in dictionary feature — flowing into `japanese_stop_tags` and triggering this panic. That **root cause was already resolved** by the `DictionaryKind` → `Metadata`/`DictionarySchema` migration (#543, #545): `japanese_compound_word` now populates details from the dictionary schema regardless of feature flags, and `Token::ensure_details()` pads details to the schema's custom-field count. This PR removes the remaining latent panic in `japanese_stop_tags` and locks it in with a regression test.

## Test

Added `test_japanese_stop_tags_empty_details_no_panic`, which filters a token with empty details and asserts no panic. Verified it panics against the previous code (`range end index 1 out of range for slice of length 0`) and passes with this change. `cargo fmt` / `cargo clippy -D warnings` / the crate's tests all pass.

Refs #438