### PR TITLE
fix(dictionary): relabel user-dictionary context IDs for remapped dictionaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "tempfile",
  "url",
 ]
 

--- a/lindera-dictionary/src/builder.rs
+++ b/lindera-dictionary/src/builder.rs
@@ -14,7 +14,7 @@ use csv::StringRecord;
 
 use self::character_definition::CharacterDefinitionBuilderOptions;
 use self::connection_cost_matrix::ConnectionCostMatrixBuilderOptions;
-use self::context_id_remap::{ContextIdRemap, compute_context_id_remap};
+use self::context_id_remap::compute_context_id_remap;
 use self::metadata::MetadataBuilder;
 use self::prefix_dictionary::PrefixDictionaryBuilderOptions;
 use self::unknown_dictionary::UnknownDictionaryBuilderOptions;
@@ -22,6 +22,7 @@ use self::user_dictionary::{UserDictionaryBuilderOptions, build_user_dictionary}
 use crate::LinderaResult;
 use crate::dictionary::UserDictionary;
 use crate::dictionary::character_definition::CharacterDefinition;
+use crate::dictionary::context_id_map::ContextIdMap;
 use crate::dictionary::metadata::Metadata;
 use crate::error::LinderaErrorKind;
 
@@ -79,7 +80,7 @@ impl DictionaryBuilder {
         // Compute the connection-cost context-ID remap ONCE, serially, before the
         // independent stages start, so the prefix / unknown / matrix stages all apply
         // the same permutations. `None` (flag off) keeps every stage byte-identical.
-        let remap: Option<Arc<ContextIdRemap>> = if self.metadata.connection_id_mapping {
+        let remap: Option<Arc<ContextIdMap>> = if self.metadata.connection_id_mapping {
             Some(Arc::new(compute_context_id_remap(
                 input_dir,
                 &self.metadata,
@@ -114,9 +115,9 @@ impl DictionaryBuilder {
         &self,
         input_dir: &Path,
         output_dir: &Path,
-        remap: Option<&Arc<ContextIdRemap>>,
+        remap: Option<&Arc<ContextIdMap>>,
     ) -> LinderaResult<()> {
-        self.build_metadata(output_dir)?;
+        self.build_metadata(output_dir, remap)?;
         let chardef = self.build_character_definition(input_dir, output_dir)?;
         self.build_unknown_dictionary(input_dir, output_dir, &chardef, remap.cloned())?;
         self.build_prefix_dictionary(input_dir, output_dir, remap.cloned())?;
@@ -148,10 +149,10 @@ impl DictionaryBuilder {
         &self,
         input_dir: &Path,
         output_dir: &Path,
-        remap: Option<&Arc<ContextIdRemap>>,
+        remap: Option<&Arc<ContextIdMap>>,
     ) -> LinderaResult<()> {
         std::thread::scope(|scope| {
-            let metadata = scope.spawn(move || self.build_metadata(output_dir));
+            let metadata = scope.spawn(move || self.build_metadata(output_dir, remap));
             let unknown = scope.spawn(move || {
                 let chardef = self.build_character_definition(input_dir, output_dir)?;
                 self.build_unknown_dictionary(input_dir, output_dir, &chardef, remap.cloned())
@@ -181,8 +182,30 @@ impl DictionaryBuilder {
         })
     }
 
-    pub fn build_metadata(&self, output_dir: &Path) -> LinderaResult<()> {
-        MetadataBuilder::new().build(&self.metadata, output_dir)
+    /// Write `metadata.json`, embedding the context-ID permutation when one was applied.
+    ///
+    /// Persisting the permutation is what lets a user dictionary compiled later be
+    /// relabeled into the same ID space (see
+    /// [`crate::dictionary::UserDictionary::remap_context_ids`]). With no remap the
+    /// metadata is written unchanged, so the artifact stays byte-identical.
+    ///
+    /// # Arguments
+    ///
+    /// * `output_dir` - Directory to write `metadata.json` into.
+    /// * `remap` - The permutation applied by this build, if any.
+    pub fn build_metadata(
+        &self,
+        output_dir: &Path,
+        remap: Option<&Arc<ContextIdMap>>,
+    ) -> LinderaResult<()> {
+        match remap {
+            Some(map) => {
+                let mut metadata = self.metadata.clone();
+                metadata.context_id_map = Some(ContextIdMap::clone(map));
+                MetadataBuilder::new().build(&metadata, output_dir)
+            }
+            None => MetadataBuilder::new().build(&self.metadata, output_dir),
+        }
     }
 
     pub fn build_character_definition(
@@ -202,7 +225,7 @@ impl DictionaryBuilder {
         input_dir: &Path,
         output_dir: &Path,
         chardef: &CharacterDefinition,
-        remap: Option<Arc<ContextIdRemap>>,
+        remap: Option<Arc<ContextIdMap>>,
     ) -> LinderaResult<()> {
         UnknownDictionaryBuilderOptions::default()
             .encoding(self.metadata.encoding.clone())
@@ -216,7 +239,7 @@ impl DictionaryBuilder {
         &self,
         input_dir: &Path,
         output_dir: &Path,
-        remap: Option<Arc<ContextIdRemap>>,
+        remap: Option<Arc<ContextIdMap>>,
     ) -> LinderaResult<()> {
         PrefixDictionaryBuilderOptions::default()
             .flexible_csv(self.metadata.flexible_csv)
@@ -234,7 +257,7 @@ impl DictionaryBuilder {
         &self,
         input_dir: &Path,
         output_dir: &Path,
-        remap: Option<Arc<ContextIdRemap>>,
+        remap: Option<Arc<ContextIdMap>>,
     ) -> LinderaResult<()> {
         ConnectionCostMatrixBuilderOptions::default()
             .encoding(self.metadata.encoding.clone())

--- a/lindera-dictionary/src/builder/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/builder/connection_cost_matrix.rs
@@ -10,7 +10,7 @@ use log::debug;
 use memchr::memchr;
 
 use crate::LinderaResult;
-use crate::builder::context_id_remap::ContextIdRemap;
+use crate::dictionary::context_id_map::ContextIdMap;
 use crate::error::LinderaErrorKind;
 use crate::util::{read_file, write_data};
 
@@ -42,7 +42,7 @@ pub struct ConnectionCostMatrixBuilder {
     /// frequently-used cells cluster near the front of each row. `None` keeps the
     /// output byte-identical to the un-remapped build.
     #[builder(default = "None")]
-    context_id_remap: Option<Arc<ContextIdRemap>>,
+    context_id_remap: Option<Arc<ContextIdMap>>,
 }
 
 impl ConnectionCostMatrixBuilder {
@@ -338,7 +338,7 @@ fn parse_data_line(
     line: &[u8],
     forward_size: u32,
     costs_len: usize,
-    remap: Option<&ContextIdRemap>,
+    remap: Option<&ContextIdMap>,
 ) -> LinderaResult<Option<(usize, i16)>> {
     let mut pos = 0;
     let Some(forward_id) = next_int(line, &mut pos) else {
@@ -391,7 +391,7 @@ fn fill_costs_sequential(
     data: &[u8],
     forward_size: u32,
     costs: &mut [i16],
-    remap: Option<&ContextIdRemap>,
+    remap: Option<&ContextIdMap>,
 ) -> LinderaResult<()> {
     let costs_len = costs.len();
     let mut pos = 0;
@@ -425,7 +425,7 @@ fn fill_costs_parallel(
     data: &[u8],
     forward_size: u32,
     costs: &mut [i16],
-    remap: Option<&ContextIdRemap>,
+    remap: Option<&ContextIdMap>,
 ) -> LinderaResult<()> {
     use rayon::prelude::*;
 
@@ -480,7 +480,7 @@ fn parse_chunk(
     chunk: &[u8],
     forward_size: u32,
     costs_len: usize,
-    remap: Option<&ContextIdRemap>,
+    remap: Option<&ContextIdMap>,
 ) -> LinderaResult<Vec<(usize, i16)>> {
     let mut out = Vec::with_capacity(chunk.len() / 8);
     let mut pos = 0;

--- a/lindera-dictionary/src/builder/context_id_remap.rs
+++ b/lindera-dictionary/src/builder/context_id_remap.rs
@@ -20,21 +20,9 @@ use glob::glob;
 
 use crate::LinderaResult;
 use crate::builder::connection_cost_matrix::read_matrix_header;
+use crate::dictionary::context_id_map::ContextIdMap;
 use crate::dictionary::metadata::Metadata;
 use crate::error::LinderaErrorKind;
-
-/// A pair of context-ID permutations, `perm[old_id] = new_id`.
-///
-/// `left` permutes left-context IDs (the matrix backward/row axis, length
-/// `backward_size`) and `right` permutes right-context IDs (the matrix
-/// forward/column axis, length `forward_size`).
-#[derive(Debug, Clone)]
-pub struct ContextIdRemap {
-    /// Permutation of left-context IDs (`WordEntry.left_id`, matrix backward axis).
-    pub left: Vec<u16>,
-    /// Permutation of right-context IDs (`WordEntry.right_id`, matrix forward axis).
-    pub right: Vec<u16>,
-}
 
 /// Compute the two frequency-ordered context-ID permutations for a dictionary.
 ///
@@ -60,14 +48,14 @@ pub struct ContextIdRemap {
 ///
 /// # Returns
 ///
-/// A [`ContextIdRemap`] whose axes match the `matrix.def` header sizes, or an error
+/// A [`ContextIdMap`] whose axes match the `matrix.def` header sizes, or an error
 /// if the header is unreadable, the schema lacks the context-ID columns, or an axis
 /// exceeds the `u16` ID range.
 pub fn compute_context_id_remap(
     input_dir: &Path,
     metadata: &Metadata,
     freq_file: Option<&Path>,
-) -> LinderaResult<ContextIdRemap> {
+) -> LinderaResult<ContextIdMap> {
     let (forward_size, backward_size) = read_matrix_header(input_dir, &metadata.encoding)?;
 
     // Context IDs are stored as u16; a larger axis cannot be represented.
@@ -86,7 +74,7 @@ pub fn compute_context_id_remap(
     if let Some(freq_path) = corpus_freq {
         let (hist_left, hist_right) =
             load_freq_file(freq_path, backward_size as usize, forward_size as usize)?;
-        return Ok(ContextIdRemap {
+        return Ok(ContextIdMap {
             left: build_perm(&hist_left),
             right: build_perm(&hist_right),
         });
@@ -173,7 +161,7 @@ pub fn compute_context_id_remap(
         }
     }
 
-    Ok(ContextIdRemap {
+    Ok(ContextIdMap {
         left: build_perm(&hist_left),
         right: build_perm(&hist_right),
     })

--- a/lindera-dictionary/src/builder/prefix_dictionary.rs
+++ b/lindera-dictionary/src/builder/prefix_dictionary.rs
@@ -18,7 +18,7 @@ use glob::glob;
 use log::debug;
 
 use crate::LinderaResult;
-use crate::builder::context_id_remap::ContextIdRemap;
+use crate::dictionary::context_id_map::ContextIdMap;
 use crate::dictionary::schema::Schema;
 use crate::error::LinderaErrorKind;
 use crate::util::write_data;
@@ -43,7 +43,7 @@ pub struct PrefixDictionaryBuilder {
     /// `left_id`/`right_id` is relabeled via `remap.left`/`remap.right` before the
     /// `WordEntry` is created, matching the remap applied to the connection matrix.
     #[builder(default = "None")]
-    context_id_remap: Option<Arc<ContextIdRemap>>,
+    context_id_remap: Option<Arc<ContextIdMap>>,
 }
 
 impl PrefixDictionaryBuilder {

--- a/lindera-dictionary/src/builder/unknown_dictionary.rs
+++ b/lindera-dictionary/src/builder/unknown_dictionary.rs
@@ -8,8 +8,8 @@ use derive_builder::Builder;
 use log::debug;
 
 use crate::LinderaResult;
-use crate::builder::context_id_remap::ContextIdRemap;
 use crate::dictionary::character_definition::CharacterDefinition;
+use crate::dictionary::context_id_map::ContextIdMap;
 use crate::dictionary::unknown_dictionary::parse_unk;
 use crate::error::LinderaErrorKind;
 use crate::util::{read_file_with_encoding, write_data};
@@ -23,7 +23,7 @@ pub struct UnknownDictionaryBuilder {
     /// Optional connection-cost context-ID remap, applied to each unknown-word
     /// entry's `left_id`/`right_id` so they match the remapped connection matrix.
     #[builder(default = "None")]
-    context_id_remap: Option<Arc<ContextIdRemap>>,
+    context_id_remap: Option<Arc<ContextIdMap>>,
 }
 
 impl UnknownDictionaryBuilder {

--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -1,5 +1,6 @@
 pub mod character_definition;
 pub mod connection_cost_matrix;
+pub mod context_id_map;
 pub mod metadata;
 pub mod prefix_dictionary;
 pub mod schema;
@@ -17,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::LinderaResult;
 use crate::dictionary::character_definition::CharacterDefinition;
 use crate::dictionary::connection_cost_matrix::ConnectionCostMatrix;
+use crate::dictionary::context_id_map::ContextIdMap;
 use crate::dictionary::metadata::Metadata;
 use crate::dictionary::prefix_dictionary::PrefixDictionary;
 use crate::dictionary::unknown_dictionary::UnknownDictionary;
@@ -26,6 +28,8 @@ use crate::loader::connection_cost_matrix::ConnectionCostMatrixLoader;
 use crate::loader::metadata::MetadataLoader;
 use crate::loader::prefix_dictionary::PrefixDictionaryLoader;
 use crate::loader::unknown_dictionary::UnknownDictionaryLoader;
+use crate::util::Data;
+use crate::viterbi::WordEntry;
 
 pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec!["UNK"]);
 
@@ -157,6 +161,37 @@ pub struct UserDictionary {
 }
 
 impl UserDictionary {
+    /// Relabel this dictionary's context IDs with a system dictionary's permutation.
+    ///
+    /// User dictionaries are always compiled in the *original* context-ID space, which
+    /// keeps a built `.bin` portable across remapped and un-remapped system
+    /// dictionaries. When one is attached to a system dictionary built with
+    /// `connection_id_mapping`, its `left_id`/`right_id` must be moved into the same
+    /// space, or every connection cost it participates in would address the wrong
+    /// matrix cell — silently, since the IDs stay in range.
+    ///
+    /// Entries live in `vals_data` as a flat [`WordEntry::SERIALIZED_LEN`]-byte stride
+    /// with `left_id` at offset 6 and `right_id` at offset 8 (little endian), so this
+    /// rewrites those two `u16`s in place. IDs outside the permutation are left
+    /// untouched, matching the builder's behaviour for malformed IDs.
+    ///
+    /// # Arguments
+    ///
+    /// * `map` - The permutation persisted in the system dictionary's metadata.
+    pub fn remap_context_ids(&mut self, map: &ContextIdMap) {
+        const LEFT_ID_OFFSET: usize = 6;
+        const RIGHT_ID_OFFSET: usize = 8;
+
+        let mut vals = self.dict.vals_data.to_vec();
+        for entry in vals.chunks_exact_mut(WordEntry::SERIALIZED_LEN) {
+            let left = LittleEndian::read_u16(&entry[LEFT_ID_OFFSET..][..2]);
+            let right = LittleEndian::read_u16(&entry[RIGHT_ID_OFFSET..][..2]);
+            LittleEndian::write_u16(&mut entry[LEFT_ID_OFFSET..][..2], map.map_left(left));
+            LittleEndian::write_u16(&mut entry[RIGHT_ID_OFFSET..][..2], map.map_right(right));
+        }
+        self.dict.vals_data = Data::Vec(vals);
+    }
+
     pub fn load(user_dict_data: &[u8]) -> LinderaResult<UserDictionary> {
         let mut aligned = rkyv::util::AlignedVec::<16>::new();
         aligned.extend_from_slice(user_dict_data);

--- a/lindera-dictionary/src/dictionary/context_id_map.rs
+++ b/lindera-dictionary/src/dictionary/context_id_map.rs
@@ -1,0 +1,77 @@
+//! Connection-cost context-ID permutation shipped with a dictionary.
+//!
+//! When `connection_id_mapping` is enabled, the build relabels left/right context IDs by
+//! access frequency so that hot connection-matrix cells cluster in cache. The permutation
+//! is applied to the connection matrix, the system dictionary and the unknown dictionary
+//! at build time, and is persisted here so that anything compiled later against the same
+//! dictionary — most importantly a detailed user dictionary — can be relabeled into the
+//! same ID space.
+
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use serde::{Deserialize, Serialize};
+
+/// A pair of context-ID permutations, `perm[old_id] = new_id`.
+///
+/// `left` permutes left-context IDs (a word's `left_id`, the connection matrix's backward
+/// / row axis, length `backward_size`) and `right` permutes right-context IDs (a word's
+/// `right_id`, the forward / column axis, length `forward_size`). Both are bijections
+/// over `0..len`, with ID 0 pinned to 0 because it is reserved for BOS/EOS.
+#[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
+pub struct ContextIdMap {
+    /// Permutation of left-context IDs (`WordEntry.left_id`, matrix backward axis).
+    pub left: Vec<u16>,
+    /// Permutation of right-context IDs (`WordEntry.right_id`, matrix forward axis).
+    pub right: Vec<u16>,
+}
+
+impl ContextIdMap {
+    /// Map a left-context ID into the remapped space.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Left-context ID in the original space.
+    ///
+    /// # Returns
+    ///
+    /// The remapped ID, or `id` unchanged when it is outside the permutation (a
+    /// malformed ID; the matrix build rejects those separately).
+    #[inline]
+    pub fn map_left(&self, id: u16) -> u16 {
+        self.left.get(id as usize).copied().unwrap_or(id)
+    }
+
+    /// Map a right-context ID into the remapped space.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Right-context ID in the original space.
+    ///
+    /// # Returns
+    ///
+    /// The remapped ID, or `id` unchanged when it is outside the permutation.
+    #[inline]
+    pub fn map_right(&self, id: u16) -> u16 {
+        self.right.get(id as usize).copied().unwrap_or(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mapping uses the right axis for each ID kind and passes through out-of-range IDs.
+    #[test]
+    fn test_map_left_and_right() {
+        let map = ContextIdMap {
+            left: vec![0, 2, 1],
+            right: vec![0, 5, 6, 7],
+        };
+        assert_eq!(map.map_left(0), 0); // BOS/EOS pinned
+        assert_eq!(map.map_left(1), 2);
+        assert_eq!(map.map_left(2), 1);
+        assert_eq!(map.map_right(3), 7);
+        // Out of range on each axis is returned untouched.
+        assert_eq!(map.map_left(9), 9);
+        assert_eq!(map.map_right(9), 9);
+    }
+}

--- a/lindera-dictionary/src/dictionary/metadata.rs
+++ b/lindera-dictionary/src/dictionary/metadata.rs
@@ -1,6 +1,7 @@
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 
+use crate::dictionary::context_id_map::ContextIdMap;
 use crate::dictionary::schema::Schema;
 
 const DEFAULT_WORD_COST: i16 = -10000;
@@ -40,6 +41,15 @@ pub struct Metadata {
     /// so existing files stay byte-identical, and the build output is unchanged.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub connection_id_mapping: bool,
+    /// The context-ID permutation that was applied when this dictionary was built.
+    ///
+    /// Written into the *built* `metadata.json` when `connection_id_mapping` is on, so
+    /// that anything compiled later against this dictionary — most importantly a
+    /// detailed user dictionary — can be relabeled into the same ID space. Absent (and
+    /// omitted from the file) for an un-remapped dictionary, which keeps those builds
+    /// byte-identical. Source `metadata.json` files carry only the boolean flag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id_map: Option<ContextIdMap>,
     pub dictionary_schema: Schema,      // Schema for the dictionary
     pub user_dictionary_schema: Schema, // Schema for user dictionary
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -96,6 +106,7 @@ impl Metadata {
             skip_invalid_cost_or_id,
             normalize_details,
             connection_id_mapping: false,
+            context_id_map: None,
             user_dictionary_schema: userdic_schema,
             model_info: None,
         }

--- a/lindera-dictionary/src/dictionary/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/unknown_dictionary.rs
@@ -252,7 +252,7 @@ fn make_category_references(
 
 fn make_costs_array(
     entries: &[UnknownDictionaryEntry],
-    remap: Option<&crate::builder::context_id_remap::ContextIdRemap>,
+    remap: Option<&crate::dictionary::context_id_map::ContextIdMap>,
 ) -> Vec<WordEntry> {
     entries
         .iter()
@@ -286,7 +286,7 @@ fn make_costs_array(
 pub fn parse_unk(
     categories: &[String],
     file_content: &str,
-    remap: Option<&crate::builder::context_id_remap::ContextIdRemap>,
+    remap: Option<&crate::dictionary::context_id_map::ContextIdMap>,
 ) -> LinderaResult<UnknownDictionary> {
     let mut unknown_dict_entries = Vec::new();
     let mut words_idx_data = Vec::new();

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -76,6 +76,7 @@ criterion = { version = "0.8.2", default-features = false, features = [
 insta = "1.48.0"
 once_cell = { workspace = true }
 serde_json = { workspace = true }
+tempfile = "3.27.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -67,6 +67,20 @@ impl Segmenter {
         // Get SPACE category ID for MeCab compatibility (ignore whitespace by default)
         let space_category_id = dictionary.character_definition.category_id_by_name("SPACE");
 
+        // A user dictionary is always compiled in the original context-ID space. If the
+        // system dictionary was built with `connection_id_mapping`, relabel the user
+        // entries into the same space; otherwise their connection costs would address
+        // the wrong matrix cells. This is the single point where both dictionaries are
+        // available, and `user_dictionary` is taken by value so it cannot be remapped
+        // twice.
+        let user_dictionary = match (user_dictionary, dictionary.metadata.context_id_map.as_ref()) {
+            (Some(mut user_dictionary), Some(map)) => {
+                user_dictionary.remap_context_ids(map);
+                Some(user_dictionary)
+            }
+            (user_dictionary, _) => user_dictionary,
+        };
+
         Self {
             mode,
             dictionary,
@@ -174,8 +188,8 @@ impl Segmenter {
             .and_then(Value::as_bool)
             .unwrap_or(false); // Default: false (ignore whitespace)
 
-        // Get the SPACE category ID if whitespace should be ignored
-        let space_category_id = if !keep_whitespace {
+        // Ignoring whitespace requires a SPACE category to detect it by.
+        if !keep_whitespace {
             dictionary
                 .character_definition
                 .category_id_by_name("SPACE")
@@ -184,23 +198,13 @@ impl Segmenter {
                         "SPACE category is not defined in the dictionary (char.def)"
                     ))
                 })?;
-            Some(
-                dictionary
-                    .character_definition
-                    .category_id_by_name("SPACE")
-                    .unwrap(),
-            )
-        } else {
-            None
-        };
+        }
 
-        Ok(Self {
-            mode,
-            dictionary,
-            user_dictionary,
-            keep_whitespace,
-            space_category_id,
-        })
+        // Go through `new` so the user-dictionary context-ID remap has a single
+        // application point. `space_category_id` is only read when `keep_whitespace` is
+        // false, so letting `new` always resolve it is equivalent to the previous
+        // conditional.
+        Ok(Self::new(mode, dictionary, user_dictionary).keep_whitespace(keep_whitespace))
     }
 
     /// Segments the input text into tokens based on the dictionary and user-defined rules.

--- a/lindera/tests/user_dictionary_context_id_remap.rs
+++ b/lindera/tests/user_dictionary_context_id_remap.rs
@@ -1,0 +1,218 @@
+//! A user dictionary must produce the same segmentation against a system dictionary
+//! built with `connection_id_mapping` as against one built without it.
+//!
+//! User dictionaries are always compiled in the original context-ID space. When the
+//! system dictionary is built with the remap enabled, those IDs have to be relabeled or
+//! every connection cost the user entry participates in addresses the wrong matrix cell
+//! — silently, because the IDs stay in range.
+//!
+//! The fixture below is tuned so that failing to relabel actually changes the output:
+//! the frequency histogram forces the permutation `1 <-> 3` on both axes, and the
+//! connection matrix puts a cheap cost where the remapped user entry looks and a
+//! prohibitive one where an un-remapped entry would look.
+
+use std::borrow::Cow;
+use std::fs;
+use std::path::Path;
+
+use lindera::dictionary::{load_dictionary, load_user_dictionary};
+use lindera::mode::Mode;
+use lindera::segmenter::Segmenter;
+use lindera_dictionary::builder::DictionaryBuilder;
+use lindera_dictionary::dictionary::metadata::Metadata;
+
+/// DEFAULT plus KANJI, with the CJK range mapped to KANJI. `invoke = 0` keeps unknown
+/// words out of the way whenever a lexicon entry matches.
+const CHAR_DEF: &str = "\
+DEFAULT 0 1 0
+KANJI 0 0 2
+0x4E00..0x9FFF KANJI
+";
+
+/// Unknown words are given a prohibitive cost so they never win over the entries below.
+const UNK_DEF: &str = "\
+DEFAULT,0,0,10000,補助記号,一般,*,*,*,*,*,*,*
+KANJI,0,0,10000,名詞,一般,*,*,*,*,*,*,*
+";
+
+/// Both system entries use context ID 2; the user entry (below) uses 3.
+const LEX_CSV: &str = "\
+東京,2,2,0,名詞,固有名詞,地域,一般,*,*,東京,トウキョウ,トウキョウ
+都,2,2,0,名詞,接尾,地域,*,*,*,都,ト,ト
+";
+
+/// A *detailed* user dictionary row: 13 fields, so `row[1]`/`row[2]` are parsed as
+/// explicit context IDs (a 3-field row would use the metadata defaults instead).
+const USER_CSV: &str = "\
+東京都,3,3,0,名詞,固有名詞,地域,一般,*,*,東京都,トウキョウト,トウキョウト
+";
+
+/// 4x4 matrix. Everything costs 100 except:
+/// - `(0, 3) = 0`: BOS -> the user entry's left ID, making the single-token path cheap.
+/// - `(0, 1) = 30000`: the trap. ID 1 is used by no entry, but the permutation maps
+///   1 -> 3, so an un-remapped user entry (still left ID 3) lands exactly here.
+const MATRIX_DEF: &str = "\
+4 4
+0 0 100
+0 1 30000
+0 2 100
+0 3 0
+1 0 100
+1 1 100
+1 2 100
+1 3 100
+2 0 100
+2 1 100
+2 2 100
+2 3 100
+3 0 100
+3 1 100
+3 2 100
+3 3 100
+";
+
+/// Frequency histogram driving the permutation: ranking IDs by count descending gives
+/// 3 -> 1, 2 -> 2, 1 -> 3 on both axes (ID 0 is always pinned to 0).
+const CONTEXT_ID_FREQ: &str = "\
+4 4
+0 1 5 100
+0 1 5 100
+";
+
+/// Write the shared dictionary source files into `dir`.
+fn write_source(dir: &Path) {
+    fs::write(dir.join("char.def"), CHAR_DEF).unwrap();
+    fs::write(dir.join("unk.def"), UNK_DEF).unwrap();
+    fs::write(dir.join("lex.csv"), LEX_CSV).unwrap();
+    fs::write(dir.join("matrix.def"), MATRIX_DEF).unwrap();
+}
+
+/// Build the fixture dictionary into a fresh directory, with the context-ID remap either
+/// enabled (and fed the histogram above) or disabled.
+///
+/// Returns the temporary directory holding the built artifacts.
+fn build_dictionary(source: &Path, remap: bool) -> tempfile::TempDir {
+    let output = tempfile::tempdir().unwrap();
+
+    let metadata = Metadata {
+        connection_id_mapping: remap,
+        ..Default::default()
+    };
+
+    let mut builder = DictionaryBuilder::new(metadata);
+    if remap {
+        let freq = source.join("context_id_freq.txt");
+        fs::write(&freq, CONTEXT_ID_FREQ).unwrap();
+        builder = builder.with_context_id_freq(freq);
+    }
+
+    builder.build_dictionary(source, output.path()).unwrap();
+    output
+}
+
+/// Segment `text` with the built dictionary at `dict_dir` plus the user dictionary CSV,
+/// returning the token surfaces.
+fn segment_with_user_dictionary(dict_dir: &Path, user_csv: &Path, text: &str) -> Vec<String> {
+    let dictionary = load_dictionary(dict_dir.to_str().unwrap()).unwrap();
+    let user_dictionary =
+        load_user_dictionary(user_csv.to_str().unwrap(), &dictionary.metadata).unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, Some(user_dictionary));
+
+    segmenter
+        .segment(Cow::Borrowed(text))
+        .unwrap()
+        .into_iter()
+        .map(|token| token.surface.to_string())
+        .collect()
+}
+
+/// The same detailed user dictionary must segment identically whether or not the system
+/// dictionary was built with `connection_id_mapping`.
+#[test]
+fn detailed_user_dictionary_is_unaffected_by_context_id_remap() {
+    let source = tempfile::tempdir().unwrap();
+    write_source(source.path());
+
+    // The user CSV must live outside the source directory: the system build globs
+    // `*.csv` there, so a user dictionary placed alongside it would be compiled into the
+    // system lexicon and the user-dictionary path would never be exercised.
+    let user_dir = tempfile::tempdir().unwrap();
+    let user_csv = user_dir.path().join("user.csv");
+    fs::write(&user_csv, USER_CSV).unwrap();
+
+    let plain = build_dictionary(source.path(), false);
+    let remapped = build_dictionary(source.path(), true);
+
+    let text = "東京都";
+    let from_plain = segment_with_user_dictionary(plain.path(), &user_csv, text);
+    let from_remapped = segment_with_user_dictionary(remapped.path(), &user_csv, text);
+
+    // Sanity: the fixture is only meaningful if the user entry wins on the plain build.
+    assert_eq!(
+        from_plain,
+        vec!["東京都".to_string()],
+        "fixture is mis-tuned: the user entry should win without remapping"
+    );
+    // The actual regression: without relabeling, the un-remapped left ID 3 would hit the
+    // 30000 trap and the system entries would win instead.
+    assert_eq!(
+        from_remapped, from_plain,
+        "remapped dictionary segmented differently; user-dictionary context IDs were not relabeled"
+    );
+}
+
+/// The same must hold for a pre-built `.bin` user dictionary, which is compiled without
+/// any knowledge of the system dictionary it will later be attached to.
+#[test]
+fn prebuilt_user_dictionary_bin_is_unaffected_by_context_id_remap() {
+    let source = tempfile::tempdir().unwrap();
+    write_source(source.path());
+
+    let user_dir = tempfile::tempdir().unwrap();
+    let user_csv = user_dir.path().join("user.csv");
+    fs::write(&user_csv, USER_CSV).unwrap();
+
+    // Compile the user dictionary the way `lindera build -u` does: metadata only, no
+    // system dictionary in sight, so its context IDs stay in the original space.
+    let user_bin = user_dir.path().join("user.bin");
+    DictionaryBuilder::new(Metadata::default())
+        .build_user_dictionary(&user_csv, &user_bin)
+        .unwrap();
+
+    let plain = build_dictionary(source.path(), false);
+    let remapped = build_dictionary(source.path(), true);
+
+    let text = "東京都";
+    let from_plain = segment_with_user_dictionary(plain.path(), &user_bin, text);
+    let from_remapped = segment_with_user_dictionary(remapped.path(), &user_bin, text);
+
+    assert_eq!(from_plain, vec!["東京都".to_string()]);
+    assert_eq!(
+        from_remapped, from_plain,
+        "pre-built user dictionary was not relabeled for the remapped system dictionary"
+    );
+}
+
+/// The permutation must be persisted in the built metadata, since that is what the
+/// segmenter uses to relabel user dictionaries.
+#[test]
+fn built_metadata_carries_the_context_id_map() {
+    let source = tempfile::tempdir().unwrap();
+    write_source(source.path());
+
+    let remapped = build_dictionary(source.path(), true);
+    let dictionary = load_dictionary(remapped.path().to_str().unwrap()).unwrap();
+    let map = dictionary
+        .metadata
+        .context_id_map
+        .expect("a remapped build must persist its context-ID map");
+
+    // Ranked by the histogram: 3 -> 1, 2 -> 2, 1 -> 3, with 0 pinned.
+    assert_eq!(map.left, vec![0, 3, 2, 1]);
+    assert_eq!(map.right, vec![0, 3, 2, 1]);
+
+    // A dictionary built without the remap must not carry one.
+    let plain = build_dictionary(source.path(), false);
+    let plain_dictionary = load_dictionary(plain.path().to_str().unwrap()).unwrap();
+    assert!(plain_dictionary.metadata.context_id_map.is_none());
+}


### PR DESCRIPTION
Closes #792. Refs #789.

## The bug

#789 added build-time connection-cost context-ID remapping (`connection_id_mapping`,
enabled for UniDic). The permutation was computed, applied to the connection matrix,
system dictionary and unknown dictionary — and then **discarded**. Nothing persisted it.

A **detailed user dictionary** (a CSV row whose length differs from
`user_dictionary_schema.field_count()`, so `row[1]`/`row[2]` are parsed as explicit
context IDs) is compiled in the *original* ID space. Attached to a remapped system
dictionary, those IDs address different matrix cells, so every connection cost the entry
participates in is wrong. Nothing errors — the IDs stay in range — so segmentation
quality silently degrades.

Scope of the live bug: UniDic only (the sole dictionary with the flag on) and only
detailed user dictionaries. Simple user dictionaries are safe: every shipped
`metadata.json` sets `default_left_context_id`/`default_right_context_id` to `0`, and the
remap pins ID 0 to 0.

## The fix

**Persist the permutation, and relabel user dictionaries at the one place both
dictionaries are in hand.**

- `ContextIdMap` moves from a builder-private detail to `dictionary::context_id_map`,
  with serde/rkyv derives, and is written into the **built** `metadata.json` when a remap
  was applied. `#[serde(skip_serializing_if = "Option::is_none")]` keeps un-remapped
  builds byte-identical; source `metadata.json` files still carry only the boolean flag.
- `UserDictionary::remap_context_ids` rewrites the `left_id`/`right_id` pair in each
  10-byte `vals_data` entry.
- `Segmenter::new` applies it. `Segmenter::from_config` previously built the struct
  literal directly; it now routes through `new`, so there is a single application point.
  (`space_category_id` is only read when `keep_whitespace` is false, so having `new`
  resolve it unconditionally is equivalent to the previous conditional.) Taking
  `user_dictionary` by value means it cannot be remapped twice.

User dictionaries therefore stay in the original ID space, so a built `.bin` remains
**portable** across remapped and un-remapped system dictionaries, and both load paths
(`.csv` compiled on the fly, pre-built `.bin`) plus every binding are covered, since they
all reach segmentation through `Segmenter::new`.

## Why the trainer needs no change

Verified rather than assumed: `TrainerConfig::from_readers` consumes only MeCab *source*
files and discards the lexicon's context-ID columns; its internal `Dictionary` is a stub
with empty `vals_data` and a zero 6×6 matrix; and its export emits a self-consistent set
in its own fresh label space, which `lindera build` then remaps exactly once. A remapped
dictionary can never reach the trainer, and no double-remap is possible.

## Verification

- **Regression tests (3, new)** in `lindera/tests/user_dictionary_context_id_remap.rs`.
  The fixture is tuned so the bug actually changes output: the frequency histogram forces
  the permutation `1 <-> 3`, and the matrix puts a cheap cost where a remapped entry looks
  and a 30000 trap where an un-remapped one would. **Confirmed these fail without the
  fix** (`["東京", "都"]` instead of `["東京都"]`) and pass with it. Covers the `.csv`
  path, the pre-built `.bin` path, and that the map is persisted (and absent when the
  flag is off).
- **No effect on existing dictionaries**: an un-remapped IPADIC build produces all 8
  artifacts sha256-identical to before this change.
- Full test suite, `cargo fmt --check`, and clippy are clean across
  `lindera-dictionary`, `lindera`, `lindera-cli`, and `lindera-trainer`.
- **Performance** (UniDic, interleaved min-of-N): tokenize is unchanged — the hot path is
  untouched, so #789's −12.4% stands. Dictionary load is ~1.6% slower (30.16 → 30.64 ms)
  from parsing the larger `metadata.json`; the embedded binary grows ~160 KB.

## Notes for review

- The permutation is stored in `metadata.json` rather than as a new artifact file
  deliberately: every load path (embedded `include_bytes!`, `file://`, wasm) already
  reads it, so no loader, macro, or wasm API change is needed. `macros.rs` includes a
  fixed set of 8 files at compile time across six dictionary crates, and the wasm entry
  point takes those 8 blobs positionally, so an optional 9th artifact would break the JS
  API and `opfs.js`'s `DICTIONARY_FILES`.
- For UniDic the map is ~60 KB of JSON numbers. Kept as plain `Vec<u16>` for
  debuggability; a compact encoding is easy to add later if load-time measurement ever
  justifies it.
