### PR TITLE
chore(deps): bump dependency versions across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "half"
@@ -2065,9 +2065,9 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -2137,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.10.5"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6826e5ddc15589b2d68c8ad5321c18e85d40488e93e32962f362e572669bccf6"
+checksum = "de33522036981030a75c231829566bc63414e08101a6f5ff4ac6cef19c8e0941"
 dependencies = [
  "bitflags 2.11.1",
  "ctor",
@@ -2160,9 +2160,9 @@ checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.10"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fe526e81c105d3640516fcde83909dd1afe757c0d7a15af58830b5bc0fb9a1"
+checksum = "a49c513341a61a16a10af6efcce46b30d0822ba2d4fb197d24d33dfc199c78d5"
 dependencies = [
  "convert_case",
  "ctor",
@@ -2174,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.1.2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514281397bcddd9ea9a876c7a21a57bff2374237a000ca9a64ea0211ec1993e2"
+checksum = "4747005fa3e2c9989ac45a723a514c5db2411238b72981a3cda4c701a9dfea17"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.2.3"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e43cf2eb0bd1bf95a43c07c076ebd2da5d1e015a71c3d201faeffffcc0ecac"
+checksum = "85fbf1fa9f1babfe396d74bbbf52b3643770243e8f5b0b46715d4caf7f0dfc9a"
 dependencies = [
  "libloading 0.9.0",
 ]
@@ -3129,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3530,9 +3530,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [workspace.dependencies]
-anyhow = "1.0.103"
+anyhow = "1.0.104"
 byteorder = "1.5.0"
 csv = "1.4.0"
 daachorse = "3.0.3"
@@ -61,11 +61,11 @@ num_cpus = "1.17.0"
 once_cell = "1.21.4"
 regex = "1.13.1"
 rkyv = { version = "0.8.17", features = ["bytecheck"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 strum = { version = "0.28.0", features = ["derive"] }
 strum_macros = "0.28.0"
-tokio = { version = "1.53.0", features = [
+tokio = { version = "1.53.1", features = [
     "rt",
     "macros",
     "time",

--- a/lindera-analysis/Cargo.toml
+++ b/lindera-analysis/Cargo.toml
@@ -12,24 +12,16 @@ categories = { workspace = true }
 license = { workspace = true }
 
 [features]
-embed-ipadic = [
-    "lindera/embed-ipadic",
-] # Embed IPADIC dictionary in the binary
+embed-ipadic = ["lindera/embed-ipadic"] # Embed IPADIC dictionary in the binary
 embed-ipadic-neologd = [
     "lindera/embed-ipadic-neologd",
 ] # Embed IPADIC-NEologd dictionary in the binary
-embed-unidic = [
-    "lindera/embed-unidic",
-] # Embed UniDic dictionary in the binary
-embed-ko-dic = [
-    "lindera/embed-ko-dic",
-] # Embed ko-dic dictionary in the binary
+embed-unidic = ["lindera/embed-unidic"] # Embed UniDic dictionary in the binary
+embed-ko-dic = ["lindera/embed-ko-dic"] # Embed ko-dic dictionary in the binary
 embed-cc-cedict = [
     "lindera/embed-cc-cedict",
 ] # Embed CC-CEDICT dictionary in the binary
-embed-jieba = [
-    "lindera/embed-jieba",
-] # Embed Jieba dictionary in the binary
+embed-jieba = ["lindera/embed-jieba"] # Embed Jieba dictionary in the binary
 default = []
 
 [dependencies]
@@ -41,7 +33,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = "0.10.0"
-unicode-blocks = "0.1.9"
+unicode-blocks = "0.1.10"
 unicode-normalization = "0.1.25"
 unicode-segmentation = "1.13.3"
 

--- a/lindera-cli/Cargo.toml
+++ b/lindera-cli/Cargo.toml
@@ -39,7 +39,7 @@ default = ["mmap", "train"]
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "4.6.2", features = ["derive", "cargo"] }
+clap = { version = "4.6.4", features = ["derive", "cargo"] }
 lindera = { workspace = true }
 lindera-analysis = { workspace = true }
 num_cpus = { workspace = true }

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -36,10 +36,10 @@ derive_builder = "0.20.2"
 encoding_rs = "0.8.35"
 encoding_rs_io = "0.1.7"
 flate2 = { version = "1.1.9", optional = true }
-glob = "0.3.3"
+glob = "0.3.4"
 log = { workspace = true }
 md5 = { version = "0.8.1", optional = true }
-memchr = "2.8.0"
+memchr = "2.8.3"
 memmap2 = { version = "0.9.11", optional = true }
 once_cell = { workspace = true }
 rand = { version = "0.10.2", default-features = false, optional = true }
@@ -52,13 +52,13 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tar = { version = "0.4.46", optional = true }
-thiserror = "2.0.18"
+thiserror = "2.0.19"
 tokio = { workspace = true, optional = true }
 
 # rayon does not support wasm32-unknown-unknown (no OS threads); the connection
 # cost matrix parser falls back to a sequential path there.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-rayon = "1.11.0"
+rayon = "1.12.0"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false, features = [

--- a/lindera-nodejs/Cargo.toml
+++ b/lindera-nodejs/Cargo.toml
@@ -34,12 +34,12 @@ default = ["train"] # Training enabled by default
 [dependencies]
 lindera = { workspace = true }
 lindera-binding-core = { workspace = true }
-napi = { version = "3.10.5", features = ["napi8", "serde-json"] }
-napi-derive = "3.5.10"
+napi = { version = "3.11.0", features = ["napi8", "serde-json"] }
+napi-derive = "3.6.0"
 num_cpus = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.3.2"
-napi-derive-backend = "5.1.2"
+napi-derive-backend = "6.0.0"


### PR DESCRIPTION
## Summary

- Bump `anyhow`, `serde`, `serde_json`, `tokio` in workspace-level dependencies
- Bump `clap` in `lindera-cli`
- Bump `glob`, `memchr`, `thiserror`, `rayon` in `lindera-dictionary`
- Bump `unicode-blocks` in `lindera-analysis`
- Bump `napi`, `napi-derive`, `napi-derive-backend` in `lindera-nodejs`
- Regenerate `Cargo.lock` accordingly

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p lindera-dictionary -p lindera-analysis -p lindera-cli --features train`