### PR TITLE
fix(analysis): fix quadratic scan in mapping character/token filters

### DIFF
--- a/lindera-analysis/src/character_filter/mapping.rs
+++ b/lindera-analysis/src/character_filter/mapping.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use daachorse::DoubleArrayAhoCorasick;
 use daachorse::DoubleArrayAhoCorasickBuilder;
+use daachorse::MatchKind;
 use serde_json::Value;
 
 use crate::character_filter::{CharacterFilter, OffsetMapping, Transformation};
@@ -19,7 +20,25 @@ pub struct MappingCharacterFilter {
 }
 
 impl MappingCharacterFilter {
+    /// Create a new `MappingCharacterFilter` from a surface-to-replacement mapping.
+    ///
+    /// # Arguments
+    ///
+    /// * `mapping` - A map from surface text to its replacement text. Keys must be
+    ///   non-empty; an empty key would match at every byte position under the
+    ///   leftmost-longest search strategy used by `apply`, which is never a
+    ///   meaningful mapping and is therefore rejected.
+    ///
+    /// # Returns
+    ///
+    /// A `MappingCharacterFilter`, or an error if `mapping` contains an empty key or
+    /// the underlying Aho-Corasick automaton fails to build.
     pub fn new(mapping: HashMap<String, String>) -> LinderaResult<Self> {
+        if mapping.keys().any(|key| key.is_empty()) {
+            return Err(LinderaErrorKind::Args
+                .with_error(anyhow::anyhow!("mapping key must not be empty.")));
+        }
+
         let mut keyset: Vec<(&[u8], u32)> = Vec::new();
         let mut keys = mapping.keys().collect::<Vec<_>>();
         keys.sort();
@@ -28,6 +47,7 @@ impl MappingCharacterFilter {
         }
 
         let trie = DoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostLongest)
             .build_with_values(keyset)
             .map_err(|err| LinderaErrorKind::Build.with_error(anyhow::anyhow!(err)))?;
 
@@ -54,50 +74,62 @@ impl CharacterFilter for MappingCharacterFilter {
         MAPPING_CHARACTER_FILTER_NAME
     }
 
-    /// Apply the filter using the OffsetMapping API
+    /// Apply the filter using the `OffsetMapping` API.
+    ///
+    /// Performs a single leftmost-longest pass over `text` with the underlying
+    /// Aho-Corasick automaton: at each position the longest configured key wins,
+    /// matches never overlap, and scanning resumes immediately after each match
+    /// (mirroring `docs/src/concepts/filters.md`'s documented "longest-match
+    /// search" semantics for this filter).
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - The text to filter, replaced in place with the mapped text.
+    ///
+    /// # Returns
+    ///
+    /// An `OffsetMapping` recording one `Transformation` per replacement whose
+    /// byte length differs from the original (length-preserving replacements are
+    /// not recorded), in ascending filtered-offset order.
     fn apply(&self, text: &mut String) -> LinderaResult<OffsetMapping> {
         let mut filtered_text = String::with_capacity(text.len());
         let mut mapping = OffsetMapping::new();
-        let mut input_start = 0_usize;
-        let len = text.len();
 
-        while input_start < len {
-            let suffix = &text[input_start..];
-            match self
-                .trie
-                .find_overlapping_iter(suffix.as_bytes())
-                .filter(|m| m.start() == 0)
-                .last()
-                .map(|m| m.end())
-            {
-                Some(input_len) => {
-                    let input_text = &text[input_start..input_start + input_len];
-                    let replacement_text = &self.mapping[input_text];
-                    let replacement_len = replacement_text.len();
+        {
+            let source = text.as_str();
+            let mut cursor = 0_usize;
 
-                    // Record transformation if text changed
-                    if input_len != replacement_len {
-                        let transformation = Transformation::new(
-                            input_start,
-                            input_start + input_len,
-                            filtered_text.len(),
-                            filtered_text.len() + replacement_len,
-                        );
-                        mapping.add_transformation(transformation);
-                    }
+            for m in self.trie.leftmost_find_iter(source) {
+                // Keys are validated non-empty in `new`, and all keys are valid
+                // UTF-8, so matches are non-empty, non-overlapping, strictly
+                // ascending, and always land on char boundaries.
+                debug_assert!(m.start() >= cursor && m.end() > m.start());
 
-                    filtered_text.push_str(replacement_text);
-                    input_start += input_len;
+                // Copy the unmatched gap before this match verbatim.
+                filtered_text.push_str(&source[cursor..m.start()]);
+
+                let input_start = m.start();
+                let input_len = m.end() - m.start();
+                let replacement_text = &self.mapping[&source[m.start()..m.end()]];
+                let replacement_len = replacement_text.len();
+
+                // Record transformation if text changed
+                if input_len != replacement_len {
+                    let transformation = Transformation::new(
+                        input_start,
+                        input_start + input_len,
+                        filtered_text.len(),
+                        filtered_text.len() + replacement_len,
+                    );
+                    mapping.add_transformation(transformation);
                 }
-                None => {
-                    if let Some(c) = suffix.chars().next() {
-                        filtered_text.push(c);
-                        input_start += c.len_utf8();
-                    } else {
-                        break;
-                    }
-                }
+
+                filtered_text.push_str(replacement_text);
+                cursor = m.end();
             }
+
+            // Copy the trailing unmatched tail.
+            filtered_text.push_str(&source[cursor..]);
         }
 
         *text = filtered_text;
@@ -107,8 +139,10 @@ impl CharacterFilter for MappingCharacterFilter {
 
 #[cfg(test)]
 mod tests {
-    use crate::character_filter::CharacterFilter;
+    use std::collections::HashMap;
+
     use crate::character_filter::mapping::{MappingCharacterFilter, MappingCharacterFilterConfig};
+    use crate::character_filter::{CharacterFilter, Transformation};
 
     #[test]
     fn test_mapping_character_filter_config() {
@@ -339,5 +373,110 @@ mod tests {
             assert_eq!(9, correct_end);
             assert_eq!("㍑", &original_text[correct_start..correct_end]);
         }
+    }
+
+    #[test]
+    fn test_mapping_character_filter_apply_longest_match() {
+        let mut mapping = HashMap::new();
+        mapping.insert("ab".to_string(), "X".to_string());
+        mapping.insert("abc".to_string(), "YY".to_string());
+        mapping.insert("b".to_string(), "Z".to_string());
+        let filter = MappingCharacterFilter::new(mapping).unwrap();
+
+        let mut text = "abcabx".to_string();
+        let mapping = filter.apply(&mut text).unwrap();
+        assert_eq!("YYXx", text.as_str());
+
+        // "abc" (longest match at 0) wins over "ab"/"b"; "ab" (longest at 3) wins over "b".
+        assert_eq!(2, mapping.transformations.len());
+        assert_eq!(Transformation::new(0, 3, 0, 2), mapping.transformations[0]);
+        assert_eq!(Transformation::new(3, 5, 2, 3), mapping.transformations[1]);
+    }
+
+    #[test]
+    fn test_mapping_character_filter_apply_backtrack() {
+        // "abcd" fails to match "abx", but the shorter key "b" hiding inside the
+        // failed prefix must still be found via the automaton's fail links.
+        let mut mapping = HashMap::new();
+        mapping.insert("abcd".to_string(), "1".to_string());
+        mapping.insert("b".to_string(), "22".to_string());
+        let filter = MappingCharacterFilter::new(mapping).unwrap();
+
+        let mut text = "abx".to_string();
+        let mapping = filter.apply(&mut text).unwrap();
+        assert_eq!("a22x", text.as_str());
+        assert_eq!(1, mapping.transformations.len());
+        assert_eq!(Transformation::new(1, 2, 1, 3), mapping.transformations[0]);
+    }
+
+    #[test]
+    fn test_mapping_character_filter_apply_leftmost_wins() {
+        // The long leftmost match consumes "h", so the overlapping key "hz"
+        // starting inside it must not fire.
+        let mut mapping = HashMap::new();
+        mapping.insert("abcdefgh".to_string(), "1".to_string());
+        mapping.insert("hz".to_string(), "2".to_string());
+        let filter = MappingCharacterFilter::new(mapping).unwrap();
+
+        let mut text = "abcdefghz".to_string();
+        let mapping = filter.apply(&mut text).unwrap();
+        assert_eq!("1z", text.as_str());
+        assert_eq!(1, mapping.transformations.len());
+    }
+
+    #[test]
+    fn test_mapping_character_filter_apply_shared_prefix() {
+        // "ﾃﾞ" and "ﾗ" share the "EF BE" lead byte pair; this exercises fail-link
+        // recovery mid-multibyte-character and proves the gap copy never slices
+        // across a char boundary.
+        let mut mapping = HashMap::new();
+        mapping.insert("ﾃﾞ".to_string(), "デ".to_string());
+        mapping.insert("ﾗ".to_string(), "ラ".to_string());
+        let filter = MappingCharacterFilter::new(mapping).unwrap();
+
+        let mut text = "ﾃﾗ".to_string();
+        let mapping = filter.apply(&mut text).unwrap();
+        assert_eq!("ﾃラ", text.as_str());
+        // "ﾗ" -> "ラ" is a same-byte-length substitution (3 -> 3 bytes).
+        assert!(mapping.is_empty());
+    }
+
+    #[test]
+    fn test_mapping_character_filter_empty_key_rejected() {
+        let mut mapping = HashMap::new();
+        mapping.insert(String::new(), "x".to_string());
+        assert!(MappingCharacterFilter::new(mapping).is_err());
+
+        let mut mapping = HashMap::new();
+        mapping.insert("a".to_string(), "b".to_string());
+        assert!(MappingCharacterFilter::new(mapping).is_ok());
+    }
+
+    #[test]
+    fn test_mapping_character_filter_apply_large_input() {
+        let mut mapping = HashMap::new();
+        mapping.insert("リンデラ".to_string(), "Lindera".to_string());
+        let filter = MappingCharacterFilter::new(mapping).unwrap();
+
+        // Large, entirely non-matching input: the worst case for the previous
+        // O(n^2) implementation. A generous absolute wall-clock ceiling is used
+        // instead of a two-point scaling ratio, since a linear implementation
+        // finishes in low single-digit milliseconds here (leaving a huge margin)
+        // while the previous quadratic implementation would take several seconds
+        // at this size, making the ceiling a reliable regression guard without
+        // being sensitive to CI timing noise.
+        let mut text = "あ".repeat(100_000);
+        let original_len = text.len();
+
+        let start = std::time::Instant::now();
+        let mapping = filter.apply(&mut text).unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(original_len, text.len());
+        assert!(mapping.is_empty());
+        assert!(
+            elapsed.as_secs() < 3,
+            "apply() took too long ({elapsed:?}); the quadratic-scan regression may have returned"
+        );
     }
 }

--- a/lindera-analysis/src/token_filter/mapping.rs
+++ b/lindera-analysis/src/token_filter/mapping.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use daachorse::DoubleArrayAhoCorasick;
 use daachorse::DoubleArrayAhoCorasickBuilder;
+use daachorse::MatchKind;
 use serde_json::Value;
 
 use crate::token_filter::TokenFilter;
@@ -23,7 +24,25 @@ pub struct MappingTokenFilter {
 }
 
 impl MappingTokenFilter {
+    /// Create a new `MappingTokenFilter` from a surface-to-replacement mapping.
+    ///
+    /// # Arguments
+    ///
+    /// * `mapping` - A map from surface text to its replacement text. Keys must be
+    ///   non-empty; an empty key would match at every byte position under the
+    ///   leftmost-longest search strategy used by `apply`, which is never a
+    ///   meaningful mapping and is therefore rejected.
+    ///
+    /// # Returns
+    ///
+    /// A `MappingTokenFilter`, or an error if `mapping` contains an empty key or
+    /// the underlying Aho-Corasick automaton fails to build.
     pub fn new(mapping: HashMap<String, String>) -> LinderaResult<Self> {
+        if mapping.keys().any(|key| key.is_empty()) {
+            return Err(LinderaErrorKind::Args
+                .with_error(anyhow::anyhow!("mapping key must not be empty.")));
+        }
+
         let mut keyset: Vec<(&[u8], u32)> = Vec::new();
         let mut keys = mapping.keys().collect::<Vec<_>>();
         keys.sort();
@@ -32,6 +51,7 @@ impl MappingTokenFilter {
         }
 
         let trie = DoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostLongest)
             .build_with_values(keyset)
             .map_err(|err| LinderaErrorKind::Build.with_error(anyhow::anyhow!(err)))?;
 
@@ -58,42 +78,37 @@ impl TokenFilter for MappingTokenFilter {
         MAPPING_TOKEN_FILTER_NAME
     }
 
+    /// Apply the filter to each token's surface, in place.
+    ///
+    /// Performs a single leftmost-longest pass over each token's surface with the
+    /// underlying Aho-Corasick automaton: at each position the longest configured
+    /// key wins, matches never overlap, and scanning resumes immediately after
+    /// each match.
+    ///
+    /// # Arguments
+    ///
+    /// * `tokens` - The tokens to filter; each token's `surface` is replaced in
+    ///   place with the mapped text.
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            let mut result = String::new();
-            let mut start = 0_usize;
-            let len = token.surface.len();
+            let mut result = String::with_capacity(token.surface.len());
 
-            while start < len {
-                let suffix = &token.surface[start..];
-                match self
-                    .trie
-                    .find_overlapping_iter(suffix.as_bytes())
-                    .filter(|m| m.start() == 0)
-                    .last()
-                    .map(|m| m.end())
-                {
-                    Some(prefix_len) => {
-                        let surface = &token.surface[start..start + prefix_len];
-                        let replacement = &self.mapping[surface];
+            {
+                let source = token.surface.as_ref();
+                let mut cursor = 0_usize;
 
-                        result.push_str(replacement);
+                for m in self.trie.leftmost_find_iter(source) {
+                    // Keys are validated non-empty in `new`, and all keys are
+                    // valid UTF-8, so matches are non-empty, non-overlapping,
+                    // strictly ascending, and always land on char boundaries.
+                    debug_assert!(m.start() >= cursor && m.end() > m.start());
 
-                        // move start offset
-                        start += prefix_len;
-                    }
-                    None => {
-                        match suffix.chars().next() {
-                            Some(c) => {
-                                result.push(c);
-
-                                // move start offset
-                                start += c.len_utf8();
-                            }
-                            None => break,
-                        }
-                    }
+                    result.push_str(&source[cursor..m.start()]);
+                    result.push_str(&self.mapping[&source[m.start()..m.end()]]);
+                    cursor = m.end();
                 }
+
+                result.push_str(&source[cursor..]);
             }
 
             token.surface = Cow::Owned(result);
@@ -105,7 +120,20 @@ impl TokenFilter for MappingTokenFilter {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use crate::token_filter::mapping::{MappingTokenFilter, MappingTokenFilterConfig};
+
+    #[test]
+    fn test_mapping_token_filter_empty_key_rejected() {
+        let mut mapping = HashMap::new();
+        mapping.insert(String::new(), "x".to_string());
+        assert!(MappingTokenFilter::new(mapping).is_err());
+
+        let mut mapping = HashMap::new();
+        mapping.insert("a".to_string(), "b".to_string());
+        assert!(MappingTokenFilter::new(mapping).is_ok());
+    }
 
     #[test]
     fn test_mapping_token_filter_config() {
@@ -216,5 +244,48 @@ mod tests {
         assert_eq!(tokens.len(), 2);
         assert_eq!(&tokens[0].surface, "篭原");
         assert_eq!(&tokens[1].surface, "駅");
+    }
+
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_mapping_token_filter_apply_longest_match() {
+        use std::borrow::Cow;
+
+        use crate::token_filter::TokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let config_str = r#"
+        {
+            "mapping": {
+                "ab": "X",
+                "abc": "YY"
+            }
+        }
+        "#;
+        let config = serde_json::from_str::<MappingTokenFilterConfig>(config_str).unwrap();
+
+        let filter = MappingTokenFilter::from_config(&config).unwrap();
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("abcab"),
+            byte_start: 0,
+            byte_end: 5,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 0),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: None,
+        }];
+
+        filter.apply(&mut tokens).unwrap();
+
+        // "abc" (longest match at 0) wins over "ab"; "ab" (longest at 3) wins.
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(&tokens[0].surface, "YYX");
     }
 }


### PR DESCRIPTION
## Summary

- `MappingCharacterFilter::apply` and `MappingTokenFilter::apply` re-scanned
  the entire remaining suffix at every starting byte position via
  `find_overlapping_iter(...).filter(...).last()`, which cannot short-circuit.
  This made both filters O(n^2) — reproduced directly at ~900ms for a
  40,000-char non-matching input, scaling ~4x per doubling of input length.
  This is not an edge case: `MappingCharacterFilter` + `unicode_normalize` is
  the flagship combination in the project's own quickstart
  (`docs/src/concepts/filters.md`) and is bundled in
  `resources/config/lindera.yml`.
- Rebuilt both filters' tries with `MatchKind::LeftmostLongest` and replaced
  the per-position rescan with a single `leftmost_find_iter` pass. This
  daachorse mode has the exact same semantics as the original loop (leftmost,
  longest match at each position, non-overlapping, resume immediately after
  each match) but runs in O(n + matches) instead of O(n^2).
- Also rejected empty mapping keys at construction time
  (`LinderaErrorKind::Args`). An empty key was already a latent infinite-loop
  bug under the old algorithm (`input_len == 0`); under the new
  `LeftmostLongest` search it would instead produce zero-length matches at
  arbitrary byte offsets, which could panic on a non-char-boundary slice in
  multibyte text. Rejecting at construction closes both failure modes.

Found during a broader multi-agent runtime-tokenize-speed investigation
(19 findings total); this was the single highest-priority item.

Refs #800

## Test plan

- [x] All 5 existing `character_filter/mapping.rs` scenarios pass unchanged
- [x] Both existing `token_filter/mapping.rs` scenarios pass unchanged
      (including the `embed-ipadic`-gated one)
- [x] End-to-end `tokenizer::tests::test_tokenize_ipadic` (full
      `nfkc → japanese_iteration_mark → mapping` pipeline from
      `resources/config/lindera.yml`, asserting byte offsets against the
      original text) passes unchanged
- [x] Added 6 new tests to `character_filter/mapping.rs`: longest-match-wins,
      fail-link backtrack recovery, leftmost-suppresses-overlapping-key,
      multibyte shared-prefix boundary safety, empty-key rejection, and a
      linear-scaling regression test (100,000-char non-matching input
      completes within a generous absolute time ceiling)
- [x] Added 2 new tests to `token_filter/mapping.rs`: empty-key rejection and
      longest-match-wins
- [x] `cargo test -p lindera-analysis --features embed-ipadic`: 95 passed, 6
      doctests passed
- [x] `cargo fmt --all -- --check`: clean
- [x] `cargo clippy -p lindera-analysis --all-targets [--features
      embed-ipadic] -- -D warnings`: clean

Closes #800