### PR TITLE
perf: small allocation cleanups in Token and Lattice

### DIFF
--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -324,6 +324,14 @@ pub struct Lattice {
     nbest_capacity: usize,
     /// The text length (in bytes) of the last set_text/set_text_nbest call
     last_text_len: usize,
+
+    // Scratch buffers for the Aho-Corasick match pre-scan in set_text/set_text_nbest.
+    // Reused across calls (like the fields above) instead of being reallocated per
+    // call, since set_text runs once per sentence rather than once per document.
+    /// Linked-list head table: matches_head[start_idx] -> index into matches_store.
+    matches_head: Vec<usize>,
+    /// Linked-list node pool: (match end offset, word entry, next node index).
+    matches_store: Vec<(usize, WordEntry, usize)>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -486,8 +494,12 @@ impl Lattice {
         // Pre-scan text with Aho-Corasick to report all matches
         // Optimization: Use flat vectors instead of Vec<Vec<_>> to avoid many small allocations.
         // Linked list structure: matches_head[start_idx] -> index in matches_store
-        let mut matches_head = vec![usize::MAX; len + 1];
-        let mut matches_store: Vec<(usize, WordEntry, usize)> = Vec::with_capacity(len * 10);
+        // Buffers are Lattice fields reused across calls; refill matches_head (its
+        // contents are meaningful, unlike ends_at's empty-Vec slots) and clear
+        // matches_store (a plain append-only pool).
+        self.matches_head.clear();
+        self.matches_head.resize(len + 1, usize::MAX);
+        self.matches_store.clear();
 
         // System dictionary scan
         for m in dict.da.find_overlapping_iter(text) {
@@ -502,10 +514,10 @@ impl Lattice {
                     let entry_offset = WordEntry::SERIALIZED_LEN * (i as usize);
                     if entry_offset + WordEntry::SERIALIZED_LEN <= data_slice.len() {
                         let entry = WordEntry::deserialize(&data_slice[entry_offset..], true);
-                        if start < matches_head.len() {
-                            let next = matches_head[start];
-                            matches_head[start] = matches_store.len();
-                            matches_store.push((m.end(), entry, next));
+                        if start < self.matches_head.len() {
+                            let next = self.matches_head[start];
+                            self.matches_head[start] = self.matches_store.len();
+                            self.matches_store.push((m.end(), entry, next));
                         }
                     }
                 }
@@ -525,10 +537,10 @@ impl Lattice {
                         let entry_offset = WordEntry::SERIALIZED_LEN * (i as usize);
                         if entry_offset + WordEntry::SERIALIZED_LEN <= data_slice.len() {
                             let entry = WordEntry::deserialize(&data_slice[entry_offset..], false);
-                            if start < matches_head.len() {
-                                let next = matches_head[start];
-                                matches_head[start] = matches_store.len();
-                                matches_store.push((m.end(), entry, next));
+                            if start < self.matches_head.len() {
+                                let next = self.matches_head[start];
+                                self.matches_head[start] = self.matches_store.len();
+                                self.matches_store.push((m.end(), entry, next));
                             }
                         }
                     }
@@ -548,10 +560,10 @@ impl Lattice {
             let mut found: bool = false;
 
             // Use cached matches
-            if start < matches_head.len() {
-                let mut match_idx = matches_head[start];
+            if start < self.matches_head.len() {
+                let mut match_idx = self.matches_head[start];
                 while match_idx != usize::MAX {
-                    let (end, word_entry, next) = matches_store[match_idx];
+                    let (end, word_entry, next) = self.matches_store[match_idx];
 
                     let prefix_len = end - start;
                     let kanji_only = self.is_kanji_all(char_idx, prefix_len);
@@ -1016,8 +1028,12 @@ impl Lattice {
         let mut unknown_word_end: Option<usize> = None;
 
         // Pre-scan text with Aho-Corasick
-        let mut matches_head = vec![usize::MAX; len + 1];
-        let mut matches_store: Vec<(usize, WordEntry, usize)> = Vec::with_capacity(len * 10);
+        // Buffers are Lattice fields reused across calls; refill matches_head (its
+        // contents are meaningful, unlike ends_at's empty-Vec slots) and clear
+        // matches_store (a plain append-only pool).
+        self.matches_head.clear();
+        self.matches_head.resize(len + 1, usize::MAX);
+        self.matches_store.clear();
 
         // System dictionary scan
         for m in dict.da.find_overlapping_iter(text) {
@@ -1031,10 +1047,10 @@ impl Lattice {
                     let entry_offset = WordEntry::SERIALIZED_LEN * (i as usize);
                     if entry_offset + WordEntry::SERIALIZED_LEN <= data_slice.len() {
                         let entry = WordEntry::deserialize(&data_slice[entry_offset..], true);
-                        if start < matches_head.len() {
-                            let next = matches_head[start];
-                            matches_head[start] = matches_store.len();
-                            matches_store.push((m.end(), entry, next));
+                        if start < self.matches_head.len() {
+                            let next = self.matches_head[start];
+                            self.matches_head[start] = self.matches_store.len();
+                            self.matches_store.push((m.end(), entry, next));
                         }
                     }
                 }
@@ -1054,10 +1070,10 @@ impl Lattice {
                         let entry_offset = WordEntry::SERIALIZED_LEN * (i as usize);
                         if entry_offset + WordEntry::SERIALIZED_LEN <= data_slice.len() {
                             let entry = WordEntry::deserialize(&data_slice[entry_offset..], false);
-                            if start < matches_head.len() {
-                                let next = matches_head[start];
-                                matches_head[start] = matches_store.len();
-                                matches_store.push((m.end(), entry, next));
+                            if start < self.matches_head.len() {
+                                let next = self.matches_head[start];
+                                self.matches_head[start] = self.matches_store.len();
+                                self.matches_store.push((m.end(), entry, next));
                             }
                         }
                     }
@@ -1074,10 +1090,10 @@ impl Lattice {
 
             let mut found: bool = false;
 
-            if start < matches_head.len() {
-                let mut match_idx = matches_head[start];
+            if start < self.matches_head.len() {
+                let mut match_idx = self.matches_head[start];
                 while match_idx != usize::MAX {
-                    let (end, word_entry, next) = matches_store[match_idx];
+                    let (end, word_entry, next) = self.matches_store[match_idx];
 
                     let prefix_len = end - start;
                     let kanji_only = self.is_kanji_all(char_idx, prefix_len);

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -385,9 +385,6 @@ impl Lattice {
             self.capacity = text_len;
             self.ends_at.resize(text_len + 1, Vec::new());
         }
-        for vec in &mut self.ends_at {
-            vec.clear();
-        }
     }
 
     fn set_capacity_nbest(&mut self, text_len: usize) {
@@ -395,9 +392,6 @@ impl Lattice {
         if self.nbest_capacity <= text_len {
             self.nbest_capacity = text_len;
             self.all_paths.resize(text_len + 1, Vec::new());
-        }
-        for vec in &mut self.all_paths {
-            vec.clear();
         }
     }
 

--- a/lindera/src/token.rs
+++ b/lindera/src/token.rs
@@ -186,7 +186,8 @@ impl<'a> Token<'a> {
     /// - If details are available and the provided index is valid, the detail at the specified index is returned as `Some(&str)`.
     /// - If the index is out of range, `None` is returned.
     pub fn get_detail(&mut self, index: usize) -> Option<&str> {
-        self.details().get(index).copied()
+        self.ensure_details();
+        self.details.as_ref()?.get(index).map(|c| c.as_ref())
     }
 
     /// Sets the token's detail at the specified index with the provided value.


### PR DESCRIPTION
## Summary

Three small, independent, low-risk performance fixes from the 2026-07-25
tokenize-speed investigation (19 findings total; this PR covers the
"low-risk/high-effort-ratio" subset the user selected to implement next,
following #800/#801 which fixed the top-priority O(n^2) bug).

- **#807**: `Lattice::set_capacity`/`set_capacity_nbest` cleared
  `ends_at`/`all_paths` twice per call — `self.clear()` already does it;
  the second loop was provably dead work. Deleted it.
- **#804**: `Lattice::set_text`/`set_text_nbest`'s Aho-Corasick match
  pre-scan buffers (`matches_head`, `matches_store`) were local
  variables, freshly heap-allocated on every call, unlike every other
  `Lattice` buffer which is a reused struct field. `set_text` runs once
  per sentence (not once per document), so this churn compounds across a
  document. Promoted both to `Lattice` fields, reused across calls the
  same way `ends_at` already is.
- **#802**: `Token::get_detail()` allocated a full `Vec<&str>`
  (`self.details().get(index).copied()`) just to read one field.
  `get()` calls `get_detail()` internally, paying the same cost. Both
  now index directly into the already-cached `self.details`. Exercised
  2-3 times per token by several commonly-enabled token filters
  (`japanese_base_form`, `japanese_reading_form`, `korean_reading_form`,
  tag-based filters via `get()`).

Each fix is a separate commit; see individual commit messages and the
linked issues (#807, #804, #802) for implementation-level detail and
per-fix rationale.

## Benchmark results

Machine has known thermal throttling (see prior investigation's
benchmarking notes), so single-run criterion comparisons aren't
reliable. Used an interleaved before(`main`)/after(this branch) A/B
harness — alternate the two release+`embed-ipadic` bench binaries, 8
rounds, take min-of-8 per side (min = least-throttled sample) — against
`lindera/benches/bench_ipadic.rs`:

| bench | before min | after min | delta | primarily exercises |
| --- | --- | --- | --- | --- |
| bench-tokenize-ipadic (short text, fresh lattice) | 14.645 µs | 14.422 µs | **-1.5%** | #802, #807 |
| bench-tokenize-with-lattice-ipadic (reused Lattice) | 11.889 µs | 11.169 µs | **-6.1%** | #804 |
| bench-tokenize-long-text-ipadic (many sentence splits) | 29.415 ms | 29.561 ms | +0.5% (within noise) | #804, #807 |
| bench-tokenize-details-long-text-ipadic (`details()`-heavy) | 49.656 ms | 46.851 ms | **-5.6%** | #802 |

3 of 4 benchmarks show a clear improvement; the fourth is flat within
this machine's measurement noise (round-to-round variance on that bench
reaches tens of percent). No benchmark regressed.

Closes #807
Closes #804
Closes #802

## Test plan

- [x] `cargo test -p lindera-dictionary` (44 unit + 3 integration + 1 doctest) — pass
- [x] `cargo test -p lindera --features embed-ipadic` (22 unit + 4 golden
      tokenization + 3 context-id-remap + 3 doctests) — pass, tokenization
      output byte-for-byte unchanged
- [x] `cargo test -p lindera-analysis --features embed-ipadic` (95 unit + 6
      doctests) — pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p lindera-dictionary -p lindera --all-targets [--features
      embed-ipadic] -- -D warnings` — clean
- [x] Interleaved before/after benchmark comparison (see above) — no
      regression, 3/4 benches improved