### PR TITLE
perf(cli): reuse Lattice across tokenize invocations in the CLI read loop

### DIFF
--- a/lindera-cli/src/commands/tokenize.rs
+++ b/lindera-cli/src/commands/tokenize.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use lindera::LinderaResult;
+use lindera::dictionary::Lattice;
 use lindera::error::{LinderaError, LinderaErrorKind};
 use lindera::mode::Mode;
 use lindera::token::Token;
@@ -205,6 +206,10 @@ pub fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
     let nbest_unique = args.nbest_unique;
     let nbest_cost_threshold = args.nbest_cost_threshold;
 
+    // Reused across every line to avoid reallocating the lattice's internal
+    // buffers on each call.
+    let mut lattice = Lattice::default();
+
     loop {
         // read the text to be tokenized from stdin
         let mut text = String::new();
@@ -215,14 +220,19 @@ pub fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
         }
 
         if nbest >= 2 {
-            let results =
-                tokenizer.tokenize_nbest(text.trim(), nbest, nbest_unique, nbest_cost_threshold)?;
+            let results = tokenizer.tokenize_nbest_with_lattice(
+                text.trim(),
+                &mut lattice,
+                nbest,
+                nbest_unique,
+                nbest_cost_threshold,
+            )?;
             for (rank, (tokens, cost)) in results.into_iter().enumerate() {
                 println!("NBEST {} (cost={})", rank + 1, cost);
                 write_output(output_format, tokens)?;
             }
         } else {
-            let tokens = tokenizer.tokenize(text.trim())?;
+            let tokens = tokenizer.tokenize_with_lattice(text.trim(), &mut lattice)?;
             write_output(output_format, tokens)?;
         }
     }


### PR DESCRIPTION
## Summary

- `lindera-cli`'s `tokenize` command — the primary user-facing entry
  point — reads input line-by-line and previously called
  `tokenizer.tokenize()`/`tokenizer.tokenize_nbest()` inside the loop,
  both of which internally construct a fresh `Lattice::default()` on
  every single call, discarding the buffer-reuse machinery `Lattice`
  exists for.
- The reuse-capable counterparts (`tokenize_with_lattice`,
  `tokenize_nbest_with_lattice`) already existed in `lindera-analysis`
  but were unused by the CLI. This PR hoists a single `Lattice` above
  the read loop and switches both call sites (single-best and n-best)
  to use it.
- Scoped to this low-risk CLI-only fix per the issue's suggestion;
  making buffer reuse the *default* for the library API itself (e.g.
  via interior mutability) is a separate, larger consideration left for
  a future issue.

Closes #803

## Verification

- Diffed full tokenization output of `resources/bocchan.txt` (538
  lines) between before/after release builds — byte-for-byte identical,
  both for the single-best path and for `-N 3` n-best output.
- `cargo test -p lindera-cli` — 4/4 pass.
- `cargo fmt --all -- --check` / `cargo clippy -p lindera-cli
  --all-targets --features embed-ipadic -- -D warnings` — clean.

## Benchmark

`lindera-cli` has no criterion bench suite, so timing was measured
directly on the built release binary (interleaved min-of-8 to cancel
this machine's known thermal throttling — see prior PRs' benchmarking
notes) tokenizing `resources/bocchan.txt` end to end via stdin:

| | before | after | delta |
| --- | --- | --- | --- |
| wall-clock MIN (8 rounds) | 0.081s | 0.077s | **-4.9%** |

All 8 rounds showed `after < before` with tight variance (0.077-0.079s
vs 0.081-0.087s) — a consistent, reproducible improvement.

## Test plan

- [x] Byte-for-byte identical CLI output before/after (single-best and n-best)
- [x] `cargo test -p lindera-cli` passes
- [x] `cargo fmt` / `cargo clippy` clean
- [x] Interleaved before/after wall-clock benchmark shows consistent improvement, no regression