### PR TITLE
perf(analysis): skip allocation for already-normalized graphemes in UnicodeNormalizeCharacterFilter

### DIFF
--- a/lindera-analysis/src/character_filter/unicode_normalize.rs
+++ b/lindera-analysis/src/character_filter/unicode_normalize.rs
@@ -2,7 +2,9 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use unicode_normalization::UnicodeNormalization;
+use unicode_normalization::{
+    IsNormalized, UnicodeNormalization, is_nfc_quick, is_nfd_quick, is_nfkc_quick, is_nfkd_quick,
+};
 use unicode_segmentation::UnicodeSegmentation;
 
 use lindera::LinderaResult;
@@ -94,6 +96,26 @@ impl CharacterFilter for UnicodeNormalizeCharacterFilter {
 
         for c in text.graphemes(true) {
             let input_len = c.len();
+
+            // Fast path: skip the allocating conversion when the grapheme is
+            // already guaranteed to be normalized. `is_*_quick` never
+            // allocates (ASCII is skipped via a cheap branch, non-ASCII via
+            // table lookups only), and `IsNormalized::Yes` is a hard
+            // guarantee per the QuickCheck algorithm (UAX #15), not a
+            // heuristic -- so skipping the conversion here cannot change the
+            // result.
+            let quick = match self.kind {
+                UnicodeNormalizeKind::NFC => is_nfc_quick(c.chars()),
+                UnicodeNormalizeKind::NFD => is_nfd_quick(c.chars()),
+                UnicodeNormalizeKind::NFKC => is_nfkc_quick(c.chars()),
+                UnicodeNormalizeKind::NFKD => is_nfkd_quick(c.chars()),
+            };
+            if quick == IsNormalized::Yes {
+                filtered_text.push_str(c);
+                input_start += input_len;
+                continue;
+            }
+
             let replacement_text = match self.kind {
                 UnicodeNormalizeKind::NFC => c.nfc().collect::<String>(),
                 UnicodeNormalizeKind::NFD => c.nfd().collect::<String>(),
@@ -286,5 +308,27 @@ mod tests {
         assert_eq!(9, transform.original_end);
         assert_eq!(2, transform.filtered_start);
         assert_eq!(3, transform.filtered_end);
+    }
+
+    #[test]
+    fn test_unicode_normalize_character_filter_apply_nfkc_already_normalized_non_ascii() {
+        let config_str = r#"
+        {
+            "kind": "nfkc"
+        }
+        "#;
+        let config =
+            serde_json::from_str::<UnicodeNormalizeCharacterFilterConfig>(config_str).unwrap();
+
+        let filter = UnicodeNormalizeCharacterFilter::from_config(&config).unwrap();
+
+        // Ordinary Japanese text (hiragana/kanji) is already NFKC-normalized,
+        // so the quick-check fast path applies here (unlike the full-width
+        // ASCII examples above, which exercise the slow/allocating path).
+        let original_text = "東京都に住んでいます";
+        let mut text = original_text.to_string();
+        let mapping = filter.apply(&mut text).unwrap();
+        assert_eq!(original_text, text.as_str());
+        assert!(mapping.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `UnicodeNormalizeCharacterFilter::apply` called
  `.nfc()/.nfd()/.nfkc()/.nfkd().collect::<String>()` unconditionally
  for every grapheme cluster, allocating a fresh `String` even when the
  grapheme is already in the target normalization form. This filter is
  the first example in the project's own quickstart
  (`docs/src/concepts/filters.md`) and the first character filter
  (`kind: nfkc`) in the bundled `resources/config/lindera.yml`, so
  essentially every "getting started" user pays this cost on every
  character of every document.
- Added a quick-check fast path using `unicode-normalization`'s own
  `is_{nfc,nfd,nfkc,nfkd}_quick` functions before the allocating
  conversion. Read the vendored crate source directly to confirm these
  never allocate (ASCII is skipped via a cheap branch, non-ASCII via
  lookup tables only), and that `IsNormalized::Yes` is a hard guarantee
  under the Unicode Standard's QuickCheck algorithm (UAX #15) — not a
  heuristic — so skipping the conversion in that case is provably safe.
- This is broader than an ASCII-only fast path: many non-ASCII
  characters, including most ordinary Japanese text (hiragana,
  katakana, most kanji), are already normalized and also hit the fast
  path.

Closes #805

## Benchmark

`lindera-analysis` has no criterion bench suite, so timing was measured
via a temporary integration test (deleted before the final commit)
applying the filter (kind=nfkc) to `resources/bocchan.txt` (Japanese
text, mostly already normalized — repeated 20x for stable timing).
Interleaved min-of-8 comparison (before=`main`, after=this branch, both
release builds) to cancel this machine's known thermal throttling:

| | before | after | delta |
| --- | --- | --- | --- |
| wall-clock MIN | 116.1 ms | 98.7 ms | **-15.0%** |

6 of 8 rounds showed `after < before`.

## Test plan

- [x] All 6 existing `unicode_normalize` tests pass unchanged
- [x] Added a new test for an already-normalized non-ASCII case
      (ordinary Japanese text) to confirm the broader (non-ASCII-only)
      fast path is actually exercised
- [x] `cargo test -p lindera-analysis --features embed-ipadic` — 96
      unit + 6 doctests pass, including the end-to-end
      `test_tokenize_ipadic` (full filter pipeline)
- [x] `cargo fmt --all -- --check` / `cargo clippy -p lindera-analysis
      --all-targets -- -D warnings` — clean
- [x] Interleaved before/after benchmark shows consistent improvement