### PR TITLE
perf(analysis): add fast-path checks to token filters lacking them

### DIFF
--- a/lindera-analysis/src/token_filter/keep_words.rs
+++ b/lindera-analysis/src/token_filter/keep_words.rs
@@ -77,6 +77,14 @@ impl TokenFilter for KeepWordsTokenFilter {
     ///
     /// The function will return an error in the form of `LinderaResult<()>` if any issues arise during the filtering process, though normally no errors are expected in this operation.
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
+        // An empty keep-word set never matches, so every token would be
+        // removed anyway -- skip straight to clearing instead of running
+        // retain over the whole list.
+        if self.words.is_empty() {
+            tokens.clear();
+            return Ok(());
+        }
+
         tokens.retain(|token| self.words.contains(token.surface.as_ref()));
 
         Ok(())
@@ -296,5 +304,37 @@ mod tests {
         assert_eq!(&tokens[0].surface, "すもも");
         assert_eq!(&tokens[1].surface, "もも");
         assert_eq!(&tokens[2].surface, "もも");
+    }
+
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_keep_words_token_filter_apply_empty_set_removes_all() {
+        use std::borrow::Cow;
+
+        use crate::token_filter::TokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let filter = KeepWordsTokenFilter::new(std::collections::HashSet::new());
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("もも"),
+            byte_start: 0,
+            byte_end: 6,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 4294967295),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: Some(vec![Cow::Borrowed("UNK")]),
+        }];
+
+        filter.apply(&mut tokens).unwrap();
+
+        // Empty keep-word set: the early-return path must remove everything.
+        assert_eq!(tokens.len(), 0);
     }
 }

--- a/lindera-analysis/src/token_filter/lowercase.rs
+++ b/lindera-analysis/src/token_filter/lowercase.rs
@@ -38,7 +38,11 @@ impl TokenFilter for LowercaseTokenFilter {
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            token.surface = Cow::Owned(token.surface.to_lowercase());
+            // Skip the allocating case-fold for tokens with no uppercase
+            // characters (e.g. any CJK-only token), which is a no-op.
+            if token.surface.chars().any(|c| c.is_uppercase()) {
+                token.surface = Cow::Owned(token.surface.to_lowercase());
+            }
         }
 
         Ok(())
@@ -78,5 +82,39 @@ mod tests {
 
         assert_eq!(tokens.len(), 1);
         assert_eq!(&tokens[0].surface, "rust");
+    }
+
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_lowercase_token_filter_apply_cjk_no_alloc() {
+        use std::borrow::Cow;
+
+        use crate::token_filter::TokenFilter;
+        use crate::token_filter::lowercase::LowercaseTokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let filter = LowercaseTokenFilter::new();
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("東京"),
+            byte_start: 0,
+            byte_end: 6,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 4294967295),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: Some(vec![Cow::Borrowed("UNK")]),
+        }];
+
+        filter.apply(&mut tokens).unwrap();
+
+        assert_eq!(&tokens[0].surface, "東京");
+        // The fast path must leave CJK-only tokens untouched (no reallocation).
+        assert!(matches!(tokens[0].surface, Cow::Borrowed(_)));
     }
 }

--- a/lindera-analysis/src/token_filter/stop_words.rs
+++ b/lindera-analysis/src/token_filter/stop_words.rs
@@ -50,6 +50,12 @@ impl TokenFilter for StopWordsTokenFilter {
     }
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
+        // An empty stop-word set never matches, so every token would be
+        // kept anyway -- skip the retain pass entirely.
+        if self.words.is_empty() {
+            return Ok(());
+        }
+
         tokens.retain(|token| !self.words.contains(token.surface.as_ref()));
 
         Ok(())
@@ -270,5 +276,38 @@ mod tests {
         assert_eq!(&tokens[1].surface, "もも");
         assert_eq!(&tokens[2].surface, "もも");
         assert_eq!(&tokens[3].surface, "うち");
+    }
+
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_stop_words_token_filter_apply_empty_set_keeps_all() {
+        use std::borrow::Cow;
+
+        use crate::token_filter::TokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let filter = StopWordsTokenFilter::new(std::collections::HashSet::new());
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("もも"),
+            byte_start: 0,
+            byte_end: 6,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 4294967295),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: Some(vec![Cow::Borrowed("UNK")]),
+        }];
+
+        filter.apply(&mut tokens).unwrap();
+
+        // Empty stop-word set: the early-return path must keep everything.
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(&tokens[0].surface, "もも");
     }
 }

--- a/lindera-analysis/src/token_filter/tags.rs
+++ b/lindera-analysis/src/token_filter/tags.rs
@@ -60,6 +60,18 @@ pub(crate) fn apply_tag_filter<F>(
 ) where
     F: Fn(&mut Token<'_>) -> String,
 {
+    // An empty tag set means every token's tag is trivially "not in the
+    // set" -- resolve the outcome directly per policy without calling
+    // extract_tag (which typically reads dictionary details) for every
+    // token.
+    if tags.is_empty() {
+        match policy {
+            TagPolicy::Keep => tokens.clear(),
+            TagPolicy::Remove => {}
+        }
+        return;
+    }
+
     let mut filtered_tokens = Vec::with_capacity(tokens.len());
 
     for mut token in tokens.drain(..) {
@@ -75,4 +87,84 @@ pub(crate) fn apply_tag_filter<F>(
     }
 
     *tokens = filtered_tokens;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_apply_tag_filter_empty_set_keep_policy_removes_all_without_extracting() {
+        use std::borrow::Cow;
+        use std::cell::Cell;
+
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("もも"),
+            byte_start: 0,
+            byte_end: 6,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 4294967295),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: Some(vec![Cow::Borrowed("UNK")]),
+        }];
+
+        let tags = HashSet::new();
+        let extract_called = Cell::new(false);
+        apply_tag_filter(&mut tokens, &tags, TagPolicy::Keep, |_| {
+            extract_called.set(true);
+            String::new()
+        });
+
+        assert_eq!(tokens.len(), 0);
+        assert!(
+            !extract_called.get(),
+            "extract_tag must be skipped for an empty tag set"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_apply_tag_filter_empty_set_remove_policy_keeps_all_without_extracting() {
+        use std::borrow::Cow;
+        use std::cell::Cell;
+
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("もも"),
+            byte_start: 0,
+            byte_end: 6,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 4294967295),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: Some(vec![Cow::Borrowed("UNK")]),
+        }];
+
+        let tags = HashSet::new();
+        let extract_called = Cell::new(false);
+        apply_tag_filter(&mut tokens, &tags, TagPolicy::Remove, |_| {
+            extract_called.set(true);
+            String::new()
+        });
+
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(&tokens[0].surface, "もも");
+        assert!(
+            !extract_called.get(),
+            "extract_tag must be skipped for an empty tag set"
+        );
+    }
 }

--- a/lindera-analysis/src/token_filter/uppercase.rs
+++ b/lindera-analysis/src/token_filter/uppercase.rs
@@ -38,7 +38,11 @@ impl TokenFilter for UppercaseTokenFilter {
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            token.surface = Cow::Owned(token.surface.to_uppercase());
+            // Skip the allocating case-fold for tokens with no lowercase
+            // characters (e.g. any CJK-only token), which is a no-op.
+            if token.surface.chars().any(|c| c.is_lowercase()) {
+                token.surface = Cow::Owned(token.surface.to_uppercase());
+            }
         }
 
         Ok(())
@@ -78,5 +82,39 @@ mod tests {
 
         assert_eq!(tokens.len(), 1);
         assert_eq!(&tokens[0].surface, "RUST");
+    }
+
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_uppercase_token_filter_apply_cjk_no_alloc() {
+        use std::borrow::Cow;
+
+        use crate::token_filter::TokenFilter;
+        use crate::token_filter::uppercase::UppercaseTokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let filter = UppercaseTokenFilter::new();
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("東京"),
+            byte_start: 0,
+            byte_end: 6,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 4294967295),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: Some(vec![Cow::Borrowed("UNK")]),
+        }];
+
+        filter.apply(&mut tokens).unwrap();
+
+        assert_eq!(&tokens[0].surface, "東京");
+        // The fast path must leave CJK-only tokens untouched (no reallocation).
+        assert!(matches!(tokens[0].surface, Cow::Borrowed(_)));
     }
 }


### PR DESCRIPTION
## Summary

Adds fast-path early returns to 5 token filters in `lindera-analysis`
that previously did unconditional per-token work even when the
configured filter parameters made the outcome trivial or a no-op:

- **`lowercase.rs`/`uppercase.rs`**: `to_lowercase()`/`to_uppercase()`
  ran unconditionally, allocating even for CJK-only tokens where the
  transform is a no-op. Added a `chars().any(is_uppercase/is_lowercase)`
  guard before the allocating call.
- **`stop_words.rs`**: with an empty configured word set,
  `HashSet::contains` is always false, so every token is always kept —
  the `retain()` pass itself was unnecessary work. Early-return when
  the set is empty.
- **`keep_words.rs`**: inverse — an empty set means every token is
  always removed. Early-return to `tokens.clear()` instead of running
  `retain()`.
- **`tags.rs::apply_tag_filter`** (shared by `japanese_keep_tags`/
  `japanese_stop_tags`/`korean_keep_tags`/`korean_stop_tags`): the real
  cost here isn't just `HashSet::contains` (cheap even empty), it's
  that `extract_tag` — which typically calls
  `Token::details()`/`get_detail()` — was called for every token
  regardless. Added an empty-set early return that skips calling
  `extract_tag` at all.

Originally bundled with #816 (segmenter.rs/viterbi.rs cleanups) per the
linked investigation, but split into this separate PR after
benchmarking showed #816 had no measurable effect while this PR's
changes showed large, consistent wins — see #816 for that item's
follow-up.

Closes #817

## Benchmark

`lindera-analysis` has no bench suite, so a temporary integration test
(deleted before the final commit) measured each fast path's most
favorable scenario (empty word/tag set, or CJK-heavy 70,000-token
input) via interleaved before/after comparison, 8 rounds:

| scenario | before (range across 8 rounds) | after (range across 8 rounds) | delta |
| --- | --- | --- | --- |
| `stop_words` (empty set, all kept) | 313.9–523.9 µs | 28–40 ns | **~10,000x faster**, consistent 8/8 |
| `lowercase` (70,000 CJK-only tokens) | 4.76–5.47 ms | 798 µs–1.21 ms | **~6x faster**, consistent 8/8 |
| `keep_words` (empty set, all removed) | 738.7–879.9 µs | 747.9–808.6 µs | within noise — `Vec::clear()` and a fully-removing `retain()` both pay the same dominant per-`Token` drop cost |

`keep_words`'s lack of improvement is reported honestly rather than
omitted: dropping 70,000 `Token`s (each holding a `Cow<str>` and other
fields) dominates regardless of whether the removal path is
`clear()` or `retain()`, so this specific fast path mostly helps
readability/intent rather than measured speed. It's kept because it's
correct and low-risk, not because it's fast.

## Test plan

- [x] All existing tests for `lowercase`/`uppercase`/`stop_words`/
      `keep_words` and the tag-based filters
      (`japanese_keep_tags`/`japanese_stop_tags`/`korean_keep_tags`/
      `korean_stop_tags`, including `embed-ko-dic`-gated apply tests)
      pass unchanged
- [x] New tests: CJK-only token stays `Cow::Borrowed` (no allocation)
      for `lowercase`/`uppercase`; empty-set behavior for
      `stop_words`/`keep_words`; `apply_tag_filter` empty-set tests for
      both `TagPolicy` variants asserting `extract_tag` is never called
- [x] `cargo test -p lindera-analysis --features embed-ipadic` (103
      unit + 6 doctests) and `--features embed-ko-dic` (korean tag
      filter apply tests) pass
- [x] `cargo fmt --all -- --check` / `cargo clippy -p lindera-analysis
      --all-targets --features embed-ipadic -- -D warnings` — clean