### PR TITLE
refactor(lindera): small allocation/branch cleanups in segmenter.rs and viterbi.rs

### DIFF
--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -391,7 +391,10 @@ impl Lattice {
         self.last_text_len = text_len;
         if self.capacity <= text_len {
             self.capacity = text_len;
-            self.ends_at.resize(text_len + 1, Vec::new());
+            // Pre-size newly-grown slots (like Vibrato's reset_vec) to
+            // avoid a couple of small reallocations the first time a busy
+            // position accumulates several edges.
+            self.ends_at.resize(text_len + 1, Vec::with_capacity(16));
         }
     }
 

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -335,8 +335,12 @@ impl Segmenter {
                 if ch == b'\n' || ch == b'\t' {
                     break;
                 }
-                // Check for Japanese punctuation (multi-byte)
-                if sentence_end >= 3 && sentence_end <= text_len {
+                // Check for Japanese punctuation (multi-byte). "。" and "、"
+                // share the same 2-byte UTF-8 lead (E3 80) and differ only
+                // in their last byte (0x82 / 0x81, which is exactly `ch`
+                // here), so this cheap pre-check skips the 3-byte slice
+                // comparison for ~254/256 possible byte values.
+                if (ch == 0x81 || ch == 0x82) && sentence_end >= 3 {
                     let last_3 = &text_bytes[sentence_end - 3..sentence_end];
                     if last_3 == "。".as_bytes() || last_3 == "、".as_bytes() {
                         break;
@@ -363,6 +367,7 @@ impl Segmenter {
             // Forward Viterbi implementation handles cost calculation within `set_text`.
 
             let offsets = lattice.tokens_offset();
+            tokens.reserve(offsets.len());
 
             for i in 0..offsets.len() {
                 let (byte_start, word_id) = offsets[i];
@@ -482,7 +487,11 @@ impl Segmenter {
                 if ch == b'\n' || ch == b'\t' {
                     break;
                 }
-                if sentence_end >= 3 && sentence_end <= text_len {
+                // "。" and "、" share the same 2-byte UTF-8 lead (E3 80) and
+                // differ only in their last byte (0x82 / 0x81, exactly
+                // `ch` here), so this pre-check skips the 3-byte slice
+                // comparison for ~254/256 possible byte values.
+                if (ch == 0x81 || ch == 0x82) && sentence_end >= 3 {
                     let last_3 = &text_bytes[sentence_end - 3..sentence_end];
                     if last_3 == "。".as_bytes() || last_3 == "、".as_bytes() {
                         break;


### PR DESCRIPTION
## Summary

Three small, independent cleanups identified during the analysis-speed investigation ([#795](https://github.com/lindera/lindera/issues/795)):

- `segment_with_lattice`: reserve `tokens` capacity up front once `lattice.tokens_offset()` reveals the token count, avoiding a few reallocations as the `Vec` grows (`segment_nbest_with_lattice`'s `all_results` was already pre-sized and is unaffected).
- Sentence-boundary scan (two duplicated sites): the `"。"`/`"、"` check did an unconditional 3-byte slice comparison per byte. Both characters share the same 2-byte UTF-8 lead (`E3 80`) and differ only in their last byte (`0x82` / `0x81`, which is exactly the already-read `ch`), so a cheap byte check now skips the slice comparison for ~254/256 possible values. Also dropped the `sentence_end <= text_len` condition, which is always true right after `sentence_end += 1`.
- `Lattice::set_text`: pre-size newly-grown `ends_at` slots with `Vec::with_capacity(16)` instead of `Vec::new()`, following Vibrato's `reset_vec` precedent, to avoid a couple of small reallocations the first time a busy position accumulates edges.

## Benchmark results (honest reporting)

Interleaved min-of-8 comparisons (release, `embed-ipadic`) on the existing `bench_ipadic` benches:

| Benchmark | before (min) | after (min) | delta |
| --- | --- | --- | --- |
| `bench-tokenize-long-text-ipadic` (bocchan.txt) | 26.433 ms | 27.036 ms | +2.3% (worse) |
| `bench-tokenize-ipadic` (short text) | 14.852 µs | 14.463 µs | -2.6% (better) |

The two benchmarks disagree in direction, and both deltas are close to measurement noise on this machine. **No consistent improvement was measured.** Each of the three changes is a constant-factor-per-token/per-byte improvement, small enough to be lost in noise here.

## Why merge anyway

Same rationale as #813 / #824: each change is low-risk, self-contained, and removes real (if small) redundant work per byte/token without altering behavior. Filed as `refactor`, not `perf`, since the performance benefit could not be demonstrated.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p lindera -p lindera-dictionary --all-targets --features embed-ipadic -- -D warnings`
- [x] `cargo test -p lindera --features embed-ipadic` (22 unit + 4 golden tokenization + 3 context-id-remap + 3 doctest, all pass)
- [x] `cargo test -p lindera-dictionary` (44 unit + 3 integration + doctest, all pass)

Refs #816