### PR TITLE
perf(dictionary): skip daachorse validation for embedded prefix dictionaries

### DIFF
--- a/lindera-dictionary/src/builder/user_dictionary.rs
+++ b/lindera-dictionary/src/builder/user_dictionary.rs
@@ -13,7 +13,7 @@ use log::debug;
 
 use crate::LinderaResult;
 use crate::dictionary::UserDictionary;
-use crate::dictionary::prefix_dictionary::PrefixDictionary;
+use crate::dictionary::prefix_dictionary::{DaTrust, PrefixDictionary};
 use crate::error::LinderaErrorKind;
 use crate::viterbi::WordEntry;
 
@@ -239,7 +239,14 @@ impl UserDictionaryBuilder {
             }
         }
 
-        let dict = PrefixDictionary::load(da_bytes, vals_data, words_idx_data, words_data, false)?;
+        let dict = PrefixDictionary::load(
+            da_bytes,
+            vals_data,
+            words_idx_data,
+            words_data,
+            false,
+            DaTrust::Untrusted,
+        )?;
 
         Ok(UserDictionary { dict })
     }

--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -89,6 +89,20 @@ impl Dictionary {
     }
 
     /// Load dictionary from a directory with options
+    ///
+    /// `use_mmap` (when the `mmap` feature is enabled) routes
+    /// `connection_cost_matrix` and `prefix_dictionary` through memory-mapped
+    /// reads instead of plain file reads. This does **not** make either
+    /// component lazily memory-resident at runtime: `ConnectionCostMatrix`
+    /// always eagerly decodes into an owned `Vec<i16>`, and
+    /// `PrefixDictionary`'s double-array trie (`da`) is always eagerly
+    /// deserialized into owned daachorse structures (only
+    /// `PrefixDictionary`'s `vals_data`/`words_idx_data`/`words_data` remain
+    /// genuinely mmap-backed and are read lazily at lookup time). `metadata`
+    /// and `character_definition` and `unknown_dictionary` are always
+    /// plain-read regardless of this flag. In short, `use_mmap` only avoids
+    /// the initial file-read syscall/allocation for the two components it
+    /// covers — it does not provide OS-level lazy paging for tokenization.
     pub fn load_from_path_with_options(dict_path: &Path, use_mmap: bool) -> LinderaResult<Self> {
         // Verify that the dictionary directory exists
         if !dict_path.exists() {

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -24,6 +24,18 @@ impl WordIdx {
     }
 }
 
+/// Whether the `da_data` passed to [`PrefixDictionary::load`] is trusted to
+/// be the exact, undamaged output of `DoubleArrayAhoCorasick::serialize()`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DaTrust {
+    /// Skip daachorse's validation pass (`deserialize_unchecked`). Only for
+    /// data this crate's own build pipeline produced and embedded verbatim.
+    Trusted,
+    /// Run daachorse's full validation pass (`deserialize`). Use for any
+    /// filesystem-, network-, or caller-supplied bytes.
+    Untrusted,
+}
+
 pub struct DoubleArrayArchiver;
 
 impl ArchiveWith<DoubleArrayAhoCorasick<u32>> for DoubleArrayArchiver {
@@ -130,6 +142,9 @@ impl PrefixDictionary {
     /// * `words_idx_data` - Word index data bytes.
     /// * `words_data` - Words data bytes.
     /// * `is_system` - Whether this is a system dictionary.
+    /// * `trust` - Whether `da_data` is trusted to be the exact output of
+    ///   `DoubleArrayAhoCorasick::serialize()`, allowing the validation pass
+    ///   to be skipped. See [`DaTrust`].
     ///
     /// # Returns
     ///
@@ -140,11 +155,39 @@ impl PrefixDictionary {
         words_idx_data: impl Into<Data>,
         words_data: impl Into<Data>,
         is_system: bool,
+        trust: DaTrust,
     ) -> LinderaResult<PrefixDictionary> {
         let da_bytes = da_data.into();
-        let (da, _) = DoubleArrayAhoCorasick::deserialize(&da_bytes[..]).map_err(|err| {
-            LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err.to_string()))
-        })?;
+        let da = match trust {
+            DaTrust::Trusted => {
+                debug_assert!(
+                    matches!(da_bytes, Data::Static(_)),
+                    "DaTrust::Trusted should only be used for embedded (Data::Static) da_data"
+                );
+                // SAFETY: `da_bytes` must be the byte-exact output of this
+                // exact daachorse version's `DoubleArrayAhoCorasick::serialize()`.
+                // Only `embedded_dictionary!` (lindera-dictionary/src/macros.rs)
+                // passes `DaTrust::Trusted`, using `include_bytes!` data
+                // produced by this crate's own build pipeline
+                // (builder/prefix_dictionary.rs's write_double_array_file,
+                // which calls `.serialize()` directly and writes the bytes
+                // verbatim, with no re-encoding/compression step and no
+                // alternate producer). Note: the opt-in build cache
+                // (assets.rs, LINDERA_BUILD_DICTIONARY_CACHE_DIR) keys only
+                // on the dictionary crate's own version, not daachorse's, so
+                // bumping the pinned daachorse version while reusing a stale
+                // cache dir is a narrow, currently-unexploited path that
+                // could violate this invariant in the future.
+                unsafe { DoubleArrayAhoCorasick::deserialize_unchecked(&da_bytes[..]).0 }
+            }
+            DaTrust::Untrusted => {
+                DoubleArrayAhoCorasick::deserialize(&da_bytes[..])
+                    .map_err(|err| {
+                        LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err.to_string()))
+                    })?
+                    .0
+            }
+        };
 
         Ok(PrefixDictionary {
             da,
@@ -365,5 +408,79 @@ impl ArchivedPrefixDictionary {
                     .into_iter()
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use daachorse::DoubleArrayAhoCorasickBuilder;
+
+    use super::*;
+
+    fn build_valid_da_bytes() -> Vec<u8> {
+        let keyset: Vec<(&[u8], u32)> = vec![(b"a", 0), (b"ab", 1), (b"b", 2)];
+        let da = DoubleArrayAhoCorasickBuilder::new()
+            .build_with_values(keyset)
+            .unwrap();
+        da.serialize()
+    }
+
+    #[test]
+    fn test_prefix_dictionary_load_trusted_matches_untrusted() {
+        let da_bytes = build_valid_da_bytes();
+        // `DaTrust::Trusted` asserts (debug builds) that the input is
+        // `Data::Static`, mirroring the only real caller (the
+        // `embedded_dictionary!` macro's `include_bytes!` data). Leak the
+        // buffer to get a genuine `&'static [u8]` for this test.
+        let da_bytes_static: &'static [u8] = Box::leak(da_bytes.clone().into_boxed_slice());
+
+        let trusted = PrefixDictionary::load(
+            da_bytes_static,
+            Vec::<u8>::new(),
+            Vec::<u8>::new(),
+            Vec::<u8>::new(),
+            true,
+            DaTrust::Trusted,
+        )
+        .unwrap();
+        let untrusted = PrefixDictionary::load(
+            da_bytes,
+            Vec::<u8>::new(),
+            Vec::<u8>::new(),
+            Vec::<u8>::new(),
+            true,
+            DaTrust::Untrusted,
+        )
+        .unwrap();
+
+        let trusted_matches: Vec<_> = trusted.da.find_overlapping_iter("ab").collect();
+        let untrusted_matches: Vec<_> = untrusted.da.find_overlapping_iter("ab").collect();
+        assert_eq!(trusted_matches.len(), untrusted_matches.len());
+        assert!(!trusted_matches.is_empty());
+        for (t, u) in trusted_matches.iter().zip(untrusted_matches.iter()) {
+            assert_eq!(t.value(), u.value());
+            assert_eq!(t.start(), u.start());
+            assert_eq!(t.end(), u.end());
+        }
+    }
+
+    #[test]
+    fn test_prefix_dictionary_load_untrusted_rejects_corrupted_da_data() {
+        let mut da_bytes = build_valid_da_bytes();
+        // Truncate to well short of a valid length-prefixed record; the
+        // checked `deserialize` path must reject this rather than panic or
+        // read out of bounds.
+        da_bytes.truncate(4);
+
+        let result = PrefixDictionary::load(
+            da_bytes,
+            Vec::<u8>::new(),
+            Vec::<u8>::new(),
+            Vec::<u8>::new(),
+            true,
+            DaTrust::Untrusted,
+        );
+
+        assert!(result.is_err());
     }
 }

--- a/lindera-dictionary/src/loader/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/loader/connection_cost_matrix.rs
@@ -27,6 +27,12 @@ impl ConnectionCostMatrixLoader {
 
     /// Load connection cost matrix using memory-mapped file.
     ///
+    /// Note: mmap only avoids the initial file-read syscall/allocation.
+    /// [`ConnectionCostMatrix::load`] always eagerly decodes the whole buffer
+    /// into an owned `Vec<i16>` regardless of source (by design, to make the
+    /// hot-path `cost()` lookup a plain array index), so this does not make
+    /// the matrix lazily memory-resident at runtime.
+    ///
     /// # Arguments
     ///
     /// * `input_dir` - Path to the directory containing matrix.mtx.

--- a/lindera-dictionary/src/loader/prefix_dictionary.rs
+++ b/lindera-dictionary/src/loader/prefix_dictionary.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::LinderaResult;
-use crate::dictionary::prefix_dictionary::PrefixDictionary;
+use crate::dictionary::prefix_dictionary::{DaTrust, PrefixDictionary};
 #[cfg(feature = "mmap")]
 use crate::util::mmap_file;
 use crate::util::read_file;
@@ -28,10 +28,26 @@ impl PrefixDictionaryLoader {
         let words_idx_data = read_file(input_dir.join("dict.wordsidx").as_path())?;
         let words_data = read_file(input_dir.join("dict.words").as_path())?;
 
-        PrefixDictionary::load(da_data, vals_data, words_idx_data, words_data, true)
+        PrefixDictionary::load(
+            da_data,
+            vals_data,
+            words_idx_data,
+            words_data,
+            true,
+            DaTrust::Untrusted,
+        )
     }
 
     /// Load prefix dictionary using memory-mapped files.
+    ///
+    /// Note: only `vals_data`/`words_idx_data`/`words_data` end up genuinely
+    /// mmap-backed (read lazily at lookup time via `Data::Map`). `da_data` is
+    /// still eagerly copied into an owned `DoubleArrayAhoCorasick` by
+    /// [`PrefixDictionary::load`] — daachorse has no zero-copy deserialization
+    /// API — so mmap only avoids the initial file-read syscall/allocation for
+    /// that component, not runtime lazy paging. mmap'd bytes are passed with
+    /// [`DaTrust::Untrusted`], the same as a plain read: they can be
+    /// corrupted or tampered with just as easily as a regular file.
     ///
     /// # Arguments
     ///
@@ -47,6 +63,13 @@ impl PrefixDictionaryLoader {
         let words_idx_data = mmap_file(input_dir.join("dict.wordsidx").as_path())?;
         let words_data = mmap_file(input_dir.join("dict.words").as_path())?;
 
-        PrefixDictionary::load(da_data, vals_data, words_idx_data, words_data, true)
+        PrefixDictionary::load(
+            da_data,
+            vals_data,
+            words_idx_data,
+            words_data,
+            true,
+            DaTrust::Untrusted,
+        )
     }
 }

--- a/lindera-dictionary/src/macros.rs
+++ b/lindera-dictionary/src/macros.rs
@@ -50,6 +50,7 @@ macro_rules! embedded_dictionary {
                 WORDS_IDX_DATA,
                 WORDS_DATA,
                 true,
+                $crate::dictionary::prefix_dictionary::DaTrust::Trusted,
             )?;
             let connection_cost_matrix =
                 $crate::dictionary::connection_cost_matrix::ConnectionCostMatrix::load(

--- a/lindera-wasm/src/dictionary.rs
+++ b/lindera-wasm/src/dictionary.rs
@@ -9,7 +9,7 @@ use lindera::dictionary::{
 use lindera_dictionary::dictionary::character_definition::CharacterDefinition;
 use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix;
 use lindera_dictionary::dictionary::metadata::Metadata;
-use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
+use lindera_dictionary::dictionary::prefix_dictionary::{DaTrust, PrefixDictionary};
 use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
 
 use crate::metadata::JsMetadata;
@@ -124,6 +124,7 @@ pub fn load_dictionary_from_bytes(
         dict_words_idx.to_vec(),
         dict_words.to_vec(),
         true,
+        DaTrust::Untrusted,
     )
     .map_err(|e| JsValue::from_str(&format!("prefix_dict: {e}")))?;
     let connection_cost_matrix = ConnectionCostMatrix::load(matrix_mtx.to_vec())


### PR DESCRIPTION
## Summary

- `PrefixDictionary::load` always called daachorse's checked `DoubleArrayAhoCorasick::deserialize()` for the `da` trie field, even for embedded dictionaries where the bytes are `include_bytes!`-baked and were already validated once by this crate's own build pipeline. Measured `dict.da` sizes: 16MB (IPADIC), 25MB (UniDic) — a real unconditional copy+validate on every process start.
- Added a `DaTrust::{Trusted, Untrusted}` enum parameter to `PrefixDictionary::load`. `Trusted` uses daachorse 3.0.3's `deserialize_unchecked` (skipping the validation pass, with a `// SAFETY:` comment documenting the precondition); `Untrusted` keeps the existing checked `deserialize`.
- Only the `embedded_dictionary!` macro passes `Trusted`. The other four call sites (CLI/build-time user-dictionary builder, `lindera-wasm`'s `loadDictionaryFromBytes` which accepts arbitrary JS-caller-supplied bytes, and both filesystem loaders including `load_mmap`, since mmap'd bytes are exactly as tamperable as a plain read) stay `Untrusted`.
- A `debug_assert!` ties `Trusted` usage to `Data::Static` as a cheap misuse-catcher, without making that enum variant the actual source of truth (considered and rejected inferring trust implicitly from `Data::Static`, since that would conflate an orthogonal zero-copy-slice concern with a daachorse-serialize-provenance safety precondition).
- Also documented (doc comments only, no behavior change) that mmap does **not** make `ConnectionCostMatrix` or `PrefixDictionary`'s `da` trie lazily memory-resident — both are always eagerly copied into owned structures regardless of source.

## Design notes

- Verified the embedded-dictionary producer is single-path: every dictionary crate's `build.rs` funnels through `assets::build_embedded_dictionary` → `builder/prefix_dictionary.rs`'s `write_double_array_file`, which calls daachorse's `.serialize()` directly and writes the bytes verbatim (no re-encoding, no alternate producer).
- `UserDictionary::load`'s rkyv path and `double_array_serde`'s serde path both bypass `PrefixDictionary::load` entirely and go straight to checked `deserialize` — correctly untouched (user-supplied `.dict` files are genuinely untrusted, and rkyv's `DeserializeWith` can't accept extra runtime arguments anyway).
- True zero-copy deserialization for the trie (daachorse has no such API) is out of scope, per both #809's and #815's own explicit scoping — comparable in size to the already-rejected charwise-trie proposal (#779).

## Benchmark results (honest reporting)

Interleaved min-of-8 comparison (release, `embed-ipadic`) on `bench-constructor-ipadic`:

| | before (min-of-8) | after (min-of-8) | delta |
| --- | --- | --- | --- |
| `bench-constructor-ipadic` | 4.5065 ms | 2.8084 ms | **-37.7%** |

Average across 8 rounds: 4.9544 ms → 3.1580 ms (**-36.3%**). All 8 after-rounds are strictly below all 8 before-rounds — a clean, non-overlapping result even on this thermal-throttling-prone machine.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features embed-ipadic -- -D warnings`
- [x] `cargo test -p lindera-dictionary` (46 unit + 3 integration + doctest, including 2 new tests: `DaTrust::Trusted`/`Untrusted` produce identical trie results, and `Untrusted` still rejects corrupted `da_data`)
- [x] `cargo test -p lindera --features embed-ipadic` (22 unit + 4 golden tokenization + 3 context-id-remap + 3 doctest, all pass unchanged)
- [x] `cargo build --workspace` and `cargo build -p lindera-wasm` (confirms all 5 call sites across the workspace, including bindings, compile correctly)

Closes #809
Closes #815