### PR TITLE
fix(dictionary): invalidate Lattice::char_category_cache on every clear

### DIFF
--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -373,6 +373,14 @@ impl Lattice {
         }
         self.char_info_buffer.clear();
         self.categories_buffer.clear();
+        // `char_category_cache` is keyed only by codepoint, with no identity
+        // of the `CharacterDefinition` it was filled from. Since a `Lattice`
+        // can be reused across `Segmenter`s built from different
+        // dictionaries, the cache must be invalidated every call rather than
+        // persisting across `set_text`/`set_text_nbest` invocations -- an
+        // ASCII codepoint's `CategoryId` is not portable between
+        // dictionaries with different char.def category orderings.
+        self.char_category_cache.clear();
     }
 
     #[inline]

--- a/lindera/tests/lattice_reuse_across_dictionaries.rs
+++ b/lindera/tests/lattice_reuse_across_dictionaries.rs
@@ -1,0 +1,85 @@
+//! A reused `Lattice` must not leak state between `Segmenter`s built from
+//! different dictionaries.
+//!
+//! `Lattice::char_category_cache` used to memoize ASCII `CategoryId`s keyed
+//! only by codepoint, with no identity of the `CharacterDefinition` that
+//! populated it, and it was never cleared. `CategoryId`s are allocated in
+//! char.def declaration order, which differs between dictionaries (IPADIC:
+//! `DEFAULT, SPACE, KANJI, SYMBOL, NUMERIC, ALPHA, ...`; ko-dic:
+//! `DEFAULT, SPACE, HANJA, KANJI, SYMBOL, NUMERIC, ALPHA, ...`), so reusing a
+//! `Lattice` across dictionaries silently reinterpreted a cached ASCII
+//! category under the second dictionary's category table.
+//!
+//! This test tokenizes the same ASCII-containing text with an IPADIC
+//! `Segmenter` and then a ko-dic `Segmenter`, through one reused `Lattice`,
+//! and asserts each result equals what a fresh `Lattice` produces.
+
+#![cfg(all(feature = "embed-ipadic", feature = "embed-ko-dic"))]
+
+use std::borrow::Cow;
+
+use lindera::dictionary::{Lattice, load_dictionary};
+use lindera::mode::Mode;
+use lindera::segmenter::Segmenter;
+
+const TEXT: &str = "Hello 世界";
+
+/// Extracts `(surface, first POS detail)` per token, since the bug this
+/// test guards against changes the unknown-word POS tag looked up for an
+/// ASCII character (IPADIC's `ALPHA` = `CategoryId(5)`, misread as ko-dic's
+/// `NUMERIC` = `CategoryId(5)` in ko-dic's own table) without necessarily
+/// changing token boundaries -- ko-dic's `NUMERIC`/`ALPHA` share identical
+/// `invoke`/`group`/`length` char.def flags, so only the POS tag (`SL` vs
+/// `SN`) reveals the misattribution, not `surface` alone.
+fn surfaces_and_pos(mut tokens: Vec<lindera::token::Token>) -> Vec<(String, String)> {
+    tokens
+        .iter_mut()
+        .map(|t| {
+            let pos = t.get_detail(0).unwrap_or("").to_string();
+            (t.surface.to_string(), pos)
+        })
+        .collect()
+}
+
+#[test]
+fn test_lattice_reuse_across_dictionaries_matches_fresh_lattice() {
+    let ipadic_segmenter = Segmenter::new(
+        Mode::Normal,
+        load_dictionary("embedded://ipadic").unwrap(),
+        None,
+    );
+    let ko_dic_segmenter = Segmenter::new(
+        Mode::Normal,
+        load_dictionary("embedded://ko-dic").unwrap(),
+        None,
+    );
+
+    // Fresh-`Lattice` baseline for each dictionary.
+    let mut fresh_ipadic_lattice = Lattice::default();
+    let expected_ipadic = ipadic_segmenter
+        .segment_with_lattice(Cow::Borrowed(TEXT), &mut fresh_ipadic_lattice)
+        .unwrap();
+
+    let mut fresh_ko_dic_lattice = Lattice::default();
+    let expected_ko_dic = ko_dic_segmenter
+        .segment_with_lattice(Cow::Borrowed(TEXT), &mut fresh_ko_dic_lattice)
+        .unwrap();
+
+    // Reused `Lattice` across both dictionaries, IPADIC first.
+    let mut shared_lattice = Lattice::default();
+    let actual_ipadic = ipadic_segmenter
+        .segment_with_lattice(Cow::Borrowed(TEXT), &mut shared_lattice)
+        .unwrap();
+    let actual_ko_dic = ko_dic_segmenter
+        .segment_with_lattice(Cow::Borrowed(TEXT), &mut shared_lattice)
+        .unwrap();
+
+    assert_eq!(
+        surfaces_and_pos(actual_ipadic),
+        surfaces_and_pos(expected_ipadic)
+    );
+    assert_eq!(
+        surfaces_and_pos(actual_ko_dic),
+        surfaces_and_pos(expected_ko_dic)
+    );
+}


### PR DESCRIPTION
## Summary

- `Lattice::char_category_cache` memoized ASCII/Latin-1 `CategoryId`s keyed only by codepoint, with no identity of the `CharacterDefinition` that populated it, and was never invalidated — `Lattice::clear()` cleared every other per-call buffer but not this one, and its lazy-init guard only fires once per `Lattice`'s lifetime.
- Since `Lattice` is public and designed to be reused across `segment_with_lattice`/`segment_nbest_with_lattice` calls (e.g. the CLI's stdin read loop), nothing prevented reusing the same `Lattice` across `Segmenter`s built from different dictionaries. `CategoryId`s are assigned in char.def declaration order, which differs per dictionary — confirmed IPADIC's `ALPHA` is `CategoryId(5)`, but ko-dic's `CategoryId(5)` is `NUMERIC` (ko-dic's order inserts `HANJA` before `KANJI`) — so a cached ASCII category from one dictionary was silently reinterpreted under the next dictionary's table, producing wrong POS tags (or, with a dictionary that has fewer categories than the one that populated the cache, an out-of-bounds panic).
- Fix: clear `char_category_cache` inside `Lattice::clear()`, which already runs unconditionally at the top of every `set_capacity`/`set_capacity_nbest` call. This was the recommended fix per the issue investigation (option 1), since prior profiling (#806) already established this cache's performance contribution is unmeasurable even when correctly maintained — codepoints >= 256 (the vast majority of Japanese text) never hit it at all.

## Regression test

`lindera/tests/lattice_reuse_across_dictionaries.rs` tokenizes `"Hello 世界"` with an IPADIC `Segmenter`, then a ko-dic `Segmenter`, through one reused `Lattice`, comparing `(surface, POS)` against each dictionary's fresh-`Lattice` result.

Verified this test fails on the pre-fix code with exactly the predicted symptom:
```
left:  [("Hello", "SN"), ("世界", "NNG")]
right: [("Hello", "SL"), ("世界", "NNG")]
```
"Hello" gets ko-dic's `NUMERIC` POS tag (`SN`) instead of the correct `ALPHA` tag (`SL`), because the stale cache entry populated by the IPADIC run leaks into the ko-dic run. Passes after the fix.

## Benchmark (honest reporting)

The fix adds a `Vec::clear()` call per sentence, so I ran an interleaved before/after comparison on `bench-tokenize-long-text-ipadic` (6 rounds). Results were noisy and inconclusive on this thermal-throttling-prone machine — one before-round measured 51.7ms while the rest of both sides clustered 76-108ms, most likely a measurement artifact from a shortened warm-up rather than a real effect. No clear signal either way. This is consistent with #806's own finding that this cache's performance contribution was already unmeasurable (0 samples in a 16K-sample profile) even when the cache worked "correctly," so a fix that makes it correct isn't expected to move the needle. Landing this as a correctness fix regardless of the inconclusive perf signal — the underlying bug (wrong POS/category assignment across dictionaries) is real and silent.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p lindera-dictionary -p lindera --all-targets --features "embed-ipadic embed-ko-dic" -- -D warnings`
- [x] `cargo test -p lindera-dictionary` (46 unit + 3 integration + doctest)
- [x] `cargo test -p lindera --features "embed-ipadic embed-ko-dic"` (22 unit + 6 golden tokenization + 1 new regression test + 3 context-id-remap + 3 doctest)
- [x] `cargo test -p lindera-analysis --features embed-ipadic` (103 unit + 6 doctest)
- [x] `cargo build --workspace` (confirms no downstream breakage in bindings)

Closes #828