### PR TITLE
perf(dictionary): Arc-wrap Dictionary's two heaviest fields for O(1) clone

### DIFF
--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -9,6 +9,7 @@ pub mod unknown_dictionary;
 use std::fs;
 use std::path::Path;
 use std::str;
+use std::sync::Arc;
 
 use byteorder::{ByteOrder, LittleEndian};
 use once_cell::sync::Lazy;
@@ -33,10 +34,15 @@ use crate::viterbi::WordEntry;
 
 pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec!["UNK"]);
 
+/// `prefix_dictionary` and `connection_cost_matrix` are `Arc`-wrapped so that
+/// `Dictionary::clone()` is O(1) regardless of load method (embedded, mmap,
+/// or plain filesystem read) -- these two components dominate a dictionary's
+/// memory footprint (tens to hundreds of MB), and nothing in this codebase
+/// mutates them after construction.
 #[derive(Clone)]
 pub struct Dictionary {
-    pub prefix_dictionary: PrefixDictionary,
-    pub connection_cost_matrix: ConnectionCostMatrix,
+    pub prefix_dictionary: Arc<PrefixDictionary>,
+    pub connection_cost_matrix: Arc<ConnectionCostMatrix>,
     pub character_definition: CharacterDefinition,
     pub unknown_dictionary: UnknownDictionary,
     pub metadata: Metadata,
@@ -103,6 +109,8 @@ impl Dictionary {
     /// plain-read regardless of this flag. In short, `use_mmap` only avoids
     /// the initial file-read syscall/allocation for the two components it
     /// covers — it does not provide OS-level lazy paging for tokenization.
+    /// Separately, `Dictionary::clone()` is O(1) regardless of `use_mmap`,
+    /// since `prefix_dictionary`/`connection_cost_matrix` are `Arc`-wrapped.
     pub fn load_from_path_with_options(dict_path: &Path, use_mmap: bool) -> LinderaResult<Self> {
         // Verify that the dictionary directory exists
         if !dict_path.exists() {
@@ -148,8 +156,8 @@ impl Dictionary {
         let unknown_dictionary = UnknownDictionaryLoader::load(dict_path)?;
 
         Ok(Dictionary {
-            prefix_dictionary,
-            connection_cost_matrix,
+            prefix_dictionary: Arc::new(prefix_dictionary),
+            connection_cost_matrix: Arc::new(connection_cost_matrix),
             character_definition,
             unknown_dictionary,
             metadata,

--- a/lindera-dictionary/src/macros.rs
+++ b/lindera-dictionary/src/macros.rs
@@ -64,8 +64,8 @@ macro_rules! embedded_dictionary {
                 $crate::dictionary::unknown_dictionary::UnknownDictionary::load(UNKNOWN_DATA)?;
 
             Ok($crate::dictionary::Dictionary {
-                prefix_dictionary,
-                connection_cost_matrix,
+                prefix_dictionary: ::std::sync::Arc::new(prefix_dictionary),
+                connection_cost_matrix: ::std::sync::Arc::new(connection_cost_matrix),
                 character_definition,
                 unknown_dictionary,
                 metadata,

--- a/lindera-trainer/src/config.rs
+++ b/lindera-trainer/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::io::{BufReader, Read};
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -49,7 +50,7 @@ pub struct TrainerConfig {
 impl TrainerConfig {
     /// Access system lexicon for morphological analysis
     pub fn system_lexicon(&self) -> &PrefixDictionary {
-        &self.dict.prefix_dictionary
+        self.dict.prefix_dictionary.as_ref()
     }
 
     /// Access dictionary (for compatibility)
@@ -345,8 +346,8 @@ impl TrainerConfig {
         let conn_matrix = Self::create_minimal_connection_matrix()?;
 
         Ok(Dictionary {
-            prefix_dictionary: prefix_dict,
-            connection_cost_matrix: conn_matrix,
+            prefix_dictionary: Arc::new(prefix_dict),
+            connection_cost_matrix: Arc::new(conn_matrix),
             character_definition: char_def,
             unknown_dictionary: unknown_dict,
             metadata: Metadata::default(),

--- a/lindera-wasm/src/dictionary.rs
+++ b/lindera-wasm/src/dictionary.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use wasm_bindgen::prelude::*;
 
@@ -135,8 +136,8 @@ pub fn load_dictionary_from_bytes(
         UnknownDictionary::load(unk).map_err(|e| JsValue::from_str(&format!("unk: {e}")))?;
 
     let dict = Dictionary {
-        prefix_dictionary,
-        connection_cost_matrix,
+        prefix_dictionary: Arc::new(prefix_dictionary),
+        connection_cost_matrix: Arc::new(connection_cost_matrix),
         character_definition,
         unknown_dictionary,
         metadata: meta,

--- a/lindera/benches/bench_ipadic.rs
+++ b/lindera/benches/bench_ipadic.rs
@@ -61,6 +61,14 @@ fn bench_constructor_with_simple_userdic_ipadic(c: &mut Criterion) {
 }
 
 #[cfg(feature = "embed-ipadic")]
+fn bench_clone_ipadic(c: &mut Criterion) {
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+
+    c.bench_function("bench-clone-ipadic", |b| b.iter(|| segmenter.clone()));
+}
+
+#[cfg(feature = "embed-ipadic")]
 fn bench_tokenize_ipadic(c: &mut Criterion) {
     let dictionary = load_dictionary("embedded://ipadic").unwrap();
     let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
@@ -173,6 +181,7 @@ criterion_group!(
     benches,
     bench_constructor_ipadic,
     bench_constructor_with_simple_userdic_ipadic,
+    bench_clone_ipadic,
     bench_tokenize_ipadic,
     bench_tokenize_with_lattice_ipadic,
     bench_tokenize_with_simple_userdic_ipadic,

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -1728,6 +1728,37 @@ mod tests {
 
     #[test]
     #[cfg(feature = "embed-ipadic")]
+    fn test_dictionary_clone_shares_heavy_fields_via_arc() {
+        use std::sync::Arc;
+
+        use crate::dictionary::load_dictionary;
+
+        let dictionary = load_dictionary("embedded://ipadic").unwrap();
+        assert_eq!(Arc::strong_count(&dictionary.prefix_dictionary), 1);
+        assert_eq!(Arc::strong_count(&dictionary.connection_cost_matrix), 1);
+
+        let cloned = dictionary.clone();
+
+        // A cheap (Arc-based) clone bumps the refcount rather than
+        // allocating a new copy of the trie/cost matrix.
+        assert_eq!(Arc::strong_count(&dictionary.prefix_dictionary), 2);
+        assert_eq!(Arc::strong_count(&dictionary.connection_cost_matrix), 2);
+        assert!(Arc::ptr_eq(
+            &dictionary.prefix_dictionary,
+            &cloned.prefix_dictionary
+        ));
+        assert!(Arc::ptr_eq(
+            &dictionary.connection_cost_matrix,
+            &cloned.connection_cost_matrix
+        ));
+
+        drop(cloned);
+        assert_eq!(Arc::strong_count(&dictionary.prefix_dictionary), 1);
+        assert_eq!(Arc::strong_count(&dictionary.connection_cost_matrix), 1);
+    }
+
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
     fn test_segment_default_multiple_spaces() {
         use std::borrow::Cow;
 


### PR DESCRIPTION
## Summary

- `Dictionary`/`Segmenter` `#[derive(Clone)]` and `Tokenizer`'s manual deep-clone impl all performed a full deep copy of the whole dictionary on every `.clone()` (tens to hundreds of MB), because `prefix_dictionary` and `connection_cost_matrix` were plain owned types.
- **This is a real cost in production code paths today, not hypothetical**: `lindera-ruby`, `lindera-nodejs`, and `lindera-php`'s tokenizer constructors only receive a borrowed dictionary handle but need an owned `Dictionary` to build a `Segmenter`, so they call `dictionary.inner.clone()` — constructing N tokenizers from one dictionary handle means N full deep copies.
- Fix: Arc-wrap at the `Dictionary` struct level:
  ```rust
  pub struct Dictionary {
      pub prefix_dictionary: Arc<PrefixDictionary>,
      pub connection_cost_matrix: Arc<ConnectionCostMatrix>,
      pub character_definition: CharacterDefinition,  // unchanged, tens of KB
      pub unknown_dictionary: UnknownDictionary,       // unchanged, tens of KB
      pub metadata: Metadata,                          // unchanged, <150KB
  }
  ```
- `Segmenter` and `Tokenizer` needed **no changes at all** — both become O(1)-clone transitively.

## Design notes

Considered and rejected Arc-wrapping the two individually heaviest fields (`PrefixDictionary.da`, `ConnectionCostMatrix.costs_data`) directly instead of at the `Dictionary` level:
1. **Incomplete fix**: measured actual built dictionaries — `PrefixDictionary`'s `vals_data`/`words_data`/`words_idx_data` (the `Data::Vec` variant, used by filesystem-loaded dictionaries — exactly what the three bindings above support) would remain full deep copies, dominating the total: 66% of IPADIC's ~58MB, 55% of UniDic's ~214MB.
2. **rkyv byte-format risk**: `ConnectionCostMatrix.costs_data` has no `#[rkyv(with = ...)]` today; naively wrapping it in `Arc<Vec<i16>>` would silently pick up rkyv's native `Archive for Arc<T>` (a relative-pointer `ArchivedRc` layout) instead of the current inline `Vec<i16>` archive.

The adopted design avoids both problems: `vals_data`/`words_data`/`words_idx_data` now live behind the same `Arc` (fixing every load mode), and `PrefixDictionary`/`UserDictionary`(`.bin` rkyv format)/`ConnectionCostMatrix`'s type definitions are completely unmodified — zero byte-format risk. No hot-path regression either: `ConnectionCostMatrix::cost()`'s inner-loop `self.costs_data[cost_id]` stays a plain `Vec<i16>` index, since `segmenter.rs` dereferences the `Arc` once per `add_edges` call, not per lookup.

**Explicitly out of scope**: `Segmenter.user_dictionary: Option<UserDictionary>` is left un-Arc'd — user dictionaries are typically small (CSV-based), and Arc-wrapping it would need careful interaction with the "remap context IDs exactly once" invariant in `Segmenter::new` (via `Arc::make_mut`) for likely-negligible benefit. Left as a candidate follow-up if evidence of need appears.

## Regression test

`test_dictionary_clone_shares_heavy_fields_via_arc` (`lindera/src/segmenter.rs`) verifies `Arc::strong_count`/`Arc::ptr_eq` before/after/drop of a `Dictionary::clone()` — a structural check that sharing actually happens, not a timing-based test.

## Benchmark results (honest reporting)

Added a permanent `bench-clone-ipadic` benchmark alongside the existing `bench-constructor-ipadic`. Interleaved min-of-8 comparison (release, `embed-ipadic`):

| | before (min-of-8) | after (min-of-8) | delta |
| --- | --- | --- | --- |
| `bench-clone-ipadic` | 1.1981 ms | 5.0447 µs | **~237x faster** (99.58% reduction) |

Average across 8 rounds: ~2.245 ms → ~10.7 µs (**~210x**). All 8 after-rounds are several orders of magnitude below all 8 before-rounds — a clean, non-overlapping result, and the largest improvement found in this whole investigation, exactly matching the theoretical expectation of replacing a tens-of-MB `memcpy` with a few `Arc` refcount bumps.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features embed-ipadic -- -D warnings`
- [x] `cargo test -p lindera-dictionary` (46 unit + 3 integration + doctest)
- [x] `cargo test -p lindera --features "embed-ipadic embed-ko-dic"` (23 unit incl. new regression test + 6 golden tokenization + 1 lattice-reuse + 3 context-id-remap + 3 doctest)
- [x] `cargo test -p lindera-analysis --features embed-ipadic` (103 unit + 6 doctest)
- [x] `cargo test -p lindera-trainer` (20 unit + 1 doctest)
- [x] `cargo build --workspace --all-targets` (confirms no downstream breakage in bindings, benches, examples)

Closes #812