### PR TITLE
refactor(dictionary): replace NBestGenerator's per-edge linear scan with binary search

### DIFF
--- a/lindera-dictionary/src/nbest.rs
+++ b/lindera-dictionary/src/nbest.rs
@@ -112,13 +112,22 @@ impl<'a> NBestGenerator<'a> {
             let current_idx = self.elements.len();
             self.elements.push(current.clone());
 
-            // Expand: for each predecessor path of this edge
+            // Expand: for each predecessor path of this edge.
+            //
+            // `paths_at(byte_pos)` is always partitioned into contiguous,
+            // strictly-ascending-by-`edge_index` runs: every push site
+            // (`add_edge_in_lattice_nbest`'s Normal/Decompose branches and
+            // `set_text_nbest`'s EOS-connect block, all in viterbi.rs) writes
+            // every `PathEntry` for one edge in a single loop, using
+            // `ends_at[stop_index].len()` at call time as that edge's index,
+            // before any other edge targeting the same `stop_index` can push
+            // into this same `all_paths[stop_index]` vector. So the target
+            // edge's entries form one contiguous run, locatable via binary
+            // search instead of a full linear scan.
             let paths = self.lattice.paths_at(byte_pos);
-            for path_entry in paths {
-                if path_entry.edge_index() != edge_index as u16 {
-                    continue; // Not a path to this edge
-                }
-
+            let start = paths.partition_point(|p| p.edge_index() < edge_index as u16);
+            let end = paths.partition_point(|p| p.edge_index() <= edge_index as u16);
+            for path_entry in &paths[start..end] {
                 let left_pos = path_entry.left_pos() as usize;
                 let left_index = path_entry.left_index() as usize;
 

--- a/lindera/benches/bench_ipadic.rs
+++ b/lindera/benches/bench_ipadic.rs
@@ -75,12 +75,7 @@ fn bench_segment_nbest_ipadic(c: &mut Criterion) {
 
     c.bench_function("bench-segment-nbest-ipadic", |b| {
         b.iter(|| {
-            segmenter.segment_nbest(
-                Cow::Borrowed("すもももももももものうち"),
-                5,
-                false,
-                None,
-            )
+            segmenter.segment_nbest(Cow::Borrowed("すもももももももものうち"), 5, false, None)
         })
     });
 }

--- a/lindera/benches/bench_ipadic.rs
+++ b/lindera/benches/bench_ipadic.rs
@@ -69,6 +69,23 @@ fn bench_clone_ipadic(c: &mut Criterion) {
 }
 
 #[cfg(feature = "embed-ipadic")]
+fn bench_segment_nbest_ipadic(c: &mut Criterion) {
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+
+    c.bench_function("bench-segment-nbest-ipadic", |b| {
+        b.iter(|| {
+            segmenter.segment_nbest(
+                Cow::Borrowed("すもももももももものうち"),
+                5,
+                false,
+                None,
+            )
+        })
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
 fn bench_tokenize_ipadic(c: &mut Criterion) {
     let dictionary = load_dictionary("embedded://ipadic").unwrap();
     let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
@@ -187,6 +204,7 @@ criterion_group!(
     bench_tokenize_with_simple_userdic_ipadic,
     bench_tokenize_long_text_ipadic,
     bench_tokenize_details_long_text_ipadic,
+    bench_segment_nbest_ipadic,
 );
 
 #[cfg(feature = "embed-ipadic")]


### PR DESCRIPTION
## Summary

- `NBestGenerator::next()` (`lindera-dictionary/src/nbest.rs`) fetched ALL `PathEntry` records for a byte position (`lattice.paths_at(byte_pos)`) and linearly filtered for the ones matching the current `edge_index`, for every popped queue element — `O(edges_at_pos × total_paths_at_pos)` work instead of `O(total_paths_at_pos)`.
- Traced every `all_paths[...].push(...)` site in `viterbi.rs` (exactly 3: `add_edge_in_lattice_nbest`'s Normal/Decompose branches, and `set_text_nbest`'s EOS-connect block). Each computes `edge_index` once as `ends_at[stop_index].len()` at call time, then pushes every `PathEntry` for that one edge in a single contiguous loop before any other edge targeting the same `stop_index` can push into the same `all_paths[stop_index]` vector. **Consequence: `all_paths[pos]` is always naturally partitioned into contiguous, strictly-ascending-by-`edge_index` runs** — no sort is ever needed, the data is already grouped by construction.
- Replaced the linear filter with two `slice::partition_point` calls to locate the exact `[start, end)` range for the target `edge_index` — `O(log n)` instead of `O(n)` per lookup, entirely self-contained in `nbest.rs` with zero changes to `viterbi.rs`, `PathEntry`, or the `all_paths` data structure. Documented the push-order invariant this relies on in a code comment, since it's a non-obvious cross-file contract a future change to the push sites could silently break.

This is confirmed off the default single-best tokenize path entirely — `Segmenter::segment`/`segment_with_lattice` call `set_text`, never `set_text_nbest` (`all_paths` is populated only by the latter) — so it only affects `segment_nbest`/`tokenize_nbest` callers.

## Test plan

- Did not add a dedicated unit test for the `partition_point` logic itself since `PathEntry`'s fields are private to `viterbi.rs`, making it unconstructable from `nbest.rs`; relying instead on:
  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy -p lindera-dictionary --all-targets --all-features -- -D warnings`
  - [x] `cargo test -p lindera-dictionary` (all pass)
  - [x] `cargo test -p lindera --features "embed-ipadic embed-ko-dic"` — including the 5 segmenter n-best tests and the `ipadic_nbest` golden snapshot, which pins **exact costs and candidate ordering** — passed unchanged, so the algorithm swap produces byte-identical output
  - [x] `cargo test -p lindera-analysis --features embed-ipadic` — including `test_tokenize_nbest_1best_matches_tokenize`/`test_tokenize_nbest_multiple_results` — pass unchanged
  - [x] `cargo build --workspace --all-targets --features embed-ipadic`

## Benchmark (honest reporting)

Added a permanent `bench-segment-nbest-ipadic` benchmark alongside the existing IPADIC benches, using a maximally-ambiguous short text (`"すもももももももものうち"`, n=5). Interleaved min-of-8:

| | before (min-of-8) | after (min-of-8) | delta |
| --- | --- | --- | --- |
| `bench-segment-nbest-ipadic` | 7.3027 µs | 7.2936 µs | within noise, no measurable improvement |

This matches the issue's own prediction: typical inputs have few competing paths per byte position, where a short linear scan and a two-step binary search cost about the same in practice. The algorithmic complexity fix is still correct (verified via the push-order invariant above) and would matter for larger N or more heavily-contested byte positions. Filed as `refactor` rather than `perf` to accurately reflect what was measured — same honest-reporting practice as prior issues in this investigation (#813, #816).

Acceptance criteria are met regardless of the micro-benchmark result: `next()` no longer does `O(edges × paths)` work, existing n-best tests pass unchanged, and the default single-best tokenize path is untouched.

Closes #818