### PR TITLE
fix(dictionary): pre-size all newly-grown ends_at slots, not just the last

### DIFF
--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -401,8 +401,12 @@ impl Lattice {
             self.capacity = text_len;
             // Pre-size newly-grown slots (like Vibrato's reset_vec) to
             // avoid a couple of small reallocations the first time a busy
-            // position accumulates several edges.
-            self.ends_at.resize(text_len + 1, Vec::with_capacity(16));
+            // position accumulates several edges. `resize_with` is required
+            // here: `resize` fills new slots with clones of its template
+            // value, and cloning an empty Vec allocates capacity 0, so only
+            // the moved-in last slot would actually be pre-sized (#827).
+            self.ends_at
+                .resize_with(text_len + 1, || Vec::with_capacity(16));
         }
     }
 
@@ -1241,7 +1245,7 @@ impl Lattice {
 
 #[cfg(test)]
 mod tests {
-    use crate::viterbi::{LexType, WordEntry, WordId};
+    use crate::viterbi::{Lattice, LexType, WordEntry, WordId};
 
     #[test]
     fn test_word_entry() {
@@ -1252,5 +1256,38 @@ mod tests {
         assert_eq!(WordEntry::SERIALIZED_LEN, buffer.len());
         let word_entry2 = WordEntry::deserialize(&buffer[..], true);
         assert_eq!(word_entry, word_entry2);
+    }
+
+    /// Regression test for #827: `Vec::resize` clones its template value
+    /// into all but the last new slot, and cloning an empty Vec yields
+    /// capacity 0, so only the last slot was actually pre-sized. Every
+    /// newly-grown `ends_at` slot must get the intended pre-size, both on
+    /// the initial growth and on a later, larger growth.
+    #[test]
+    fn test_set_capacity_presizes_all_new_slots() {
+        let mut lattice = Lattice::default();
+
+        lattice.set_capacity(5);
+        assert_eq!(lattice.ends_at.len(), 6);
+        for (i, slot) in lattice.ends_at.iter().enumerate() {
+            assert!(
+                slot.capacity() >= 16,
+                "slot {} has capacity {} < 16 after initial growth",
+                i,
+                slot.capacity()
+            );
+        }
+
+        // Growing an already-used lattice must pre-size the appended slots too.
+        lattice.set_capacity(10);
+        assert_eq!(lattice.ends_at.len(), 11);
+        for (i, slot) in lattice.ends_at.iter().enumerate() {
+            assert!(
+                slot.capacity() >= 16,
+                "slot {} has capacity {} < 16 after second growth",
+                i,
+                slot.capacity()
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`Vec::resize(new_len, value)` fills all but the last new slot with clones of `value`, and cloning an empty `Vec` allocates capacity 0. So `ends_at.resize(text_len + 1, Vec::with_capacity(16))` (introduced in #826) only pre-sized the moved-in last slot — every other newly-grown slot got capacity 0, exactly as if it were `Vec::new()`.

This PR replaces the call with `resize_with(text_len + 1, || Vec::with_capacity(16))`, so the closure runs once per new slot and every slot actually gets the intended capacity 16. The comment now explains why `resize_with` is required. As a side effect, calls that add no new slots (a sentence whose length equals the current high-water mark) no longer allocate and immediately drop the unused template `Vec`.

A repo-wide audit confirmed this is the only instance of this bug class: all other `resize` calls with non-scalar fill values use empty collections (clone-equivalent) or `Copy` types.

## Changes

- `lindera-dictionary/src/viterbi.rs`: `Lattice::set_capacity` now uses `resize_with`; comment updated.
- Added regression test `test_set_capacity_presizes_all_new_slots`: asserts every `ends_at` slot has `capacity() >= 16` after both the initial growth and a later, larger growth. The test fails against the previous implementation (slots 0..text_len had capacity 0).

## Verification

- `cargo fmt -p lindera-dictionary -- --check`: clean
- `cargo clippy -p lindera-dictionary --all-targets`: no warnings
- `cargo test -p lindera-dictionary`: 47 + 3 + 1 passed
- `cargo test -p lindera --features embed-ipadic` (incl. golden tokenization): 24 + 4 + 3 + 3 passed

## Benchmark (acceptance criteria)

Interleaved min-of-8 (release, `embed-ipadic`, before/after binaries alternated, pinned to one core; this machine has severe thermal throttling, so min-of-N of the mid estimates is used):

| bench | before MIN | after MIN | delta |
| --- | --- | --- | --- |
| bench-tokenize-ipadic (short, fresh lattice) | 15.133 µs | 15.643 µs | +3.4% |
| bench-tokenize-long-text-ipadic (bocchan.txt) | 28.106 ms | 27.636 ms | -1.7% |

The two benches disagree in sign and both deltas are within this machine's noise floor — **no measurable difference either way**, consistent with the original #826 result. Reported honestly per the issue's acceptance criteria; the fix is kept because it makes the code do what its comment and #826 intended, adds a regression test, and no regression is demonstrated.

Closes #827
