### PR TITLE
fix(nodejs): allow ESM imports, declare engines, correct the Node version in docs

### DIFF
--- a/lindera-nodejs/README.md
+++ b/lindera-nodejs/README.md
@@ -53,7 +53,7 @@ Download a dictionary archive (e.g. `lindera-ipadic-*.zip`) and specify the extr
 
 ## Install project dependencies
 
-- Node.js 18+ : <https://nodejs.org/>
+- Node.js `^20.17.0 || ^22.13.0 || >= 23.5.0` : <https://nodejs.org/>
 - Rust : <https://www.rust-lang.org/tools/install>
 - @napi-rs/cli : `npm install -g @napi-rs/cli`
 
@@ -76,6 +76,13 @@ npm run build
 ```
 
 ## Quick Start
+
+The examples below use CommonJS. The package is also importable from ESM — the
+same named exports are available:
+
+```javascript
+import { loadDictionary, Tokenizer } from "lindera-nodejs";
+```
 
 ### Basic Tokenization
 

--- a/lindera-nodejs/README_ja.md
+++ b/lindera-nodejs/README_ja.md
@@ -53,7 +53,7 @@ lindera-nodejs は、Lindera 形態素解析エンジンへの包括的な Node.
 
 ## プロジェクト依存関係のインストール
 
-- Node.js 18+ : <https://nodejs.org/>
+- Node.js `^20.17.0 || ^22.13.0 || >= 23.5.0` : <https://nodejs.org/>
 - Rust : <https://www.rust-lang.org/tools/install>
 - @napi-rs/cli : `npm install -g @napi-rs/cli`
 
@@ -76,6 +76,13 @@ npm run build
 ```
 
 ## クイックスタート
+
+以下の例では CommonJS を使用していますが、ESM からも同じ名前付きエクスポートを
+インポートできます:
+
+```javascript
+import { loadDictionary, Tokenizer } from "lindera-nodejs";
+```
 
 ### 基本的なトークナイズ
 

--- a/lindera-nodejs/package.json
+++ b/lindera-nodejs/package.json
@@ -6,9 +6,14 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
       "require": "./index.js",
-      "types": "./index.d.ts"
+      "default": "./index.js"
     }
+  },
+  "engines": {
+    "node": "^20.17.0 || ^22.13.0 || >= 23.5.0"
   },
   "napi": {
     "binaryName": "lindera-nodejs",
@@ -29,7 +34,7 @@
     "build": "napi build --platform --release -p lindera-nodejs",
     "build:debug": "napi build --platform -p lindera-nodejs",
     "artifacts": "napi artifacts",
-    "test": "node --test tests/test_*.js"
+    "test": "node --test tests/test_*.js tests/test_*.mjs"
   },
   "files": [
     "index.js",

--- a/lindera-nodejs/tests/test_esm.mjs
+++ b/lindera-nodejs/tests/test_esm.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+// The package entry point is CommonJS, but the `exports` map declares an `import` condition so ESM
+// consumers can `import` it directly. Node synthesises named exports from the static
+// `module.exports.X = ...` assignments napi generates.
+//
+// Without the `import` condition this file fails with ERR_PACKAGE_PATH_NOT_EXPORTED when the
+// package is consumed by name — the reason ESM users previously needed a `createRequire` shim.
+import lindera, { Tokenizer, TokenizerBuilder, loadDictionary, version } from "../index.js";
+
+// Matches the guard in test_tokenize_ipadic.js: the embedded dictionary is behind the
+// `embed-ipadic` feature, which is not on by default.
+const hasEmbeddedIpadic = (() => {
+  try {
+    loadDictionary("embedded://ipadic");
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe("ESM interop", () => {
+  it("exposes named exports to ESM importers", () => {
+    assert.strictEqual(typeof TokenizerBuilder, "function");
+    assert.strictEqual(typeof Tokenizer, "function");
+    assert.strictEqual(typeof loadDictionary, "function");
+    assert.strictEqual(typeof version, "function");
+  });
+
+  it("exposes the same bindings via the default export", () => {
+    assert.strictEqual(lindera.Tokenizer, Tokenizer);
+    assert.strictEqual(lindera.loadDictionary, loadDictionary);
+  });
+
+  it("can tokenize through an ESM-imported binding", {
+    skip: !hasEmbeddedIpadic && "embedded://ipadic not available"
+  }, () => {
+    const builder = new TokenizerBuilder();
+    builder.setMode("normal");
+    builder.setDictionary("embedded://ipadic");
+    const tokenizer = builder.build();
+    const tokens = tokenizer.tokenize("東京タワー");
+    assert.ok(tokens.length > 0);
+    assert.strictEqual(tokens[0].surface, "東京");
+  });
+});


### PR DESCRIPTION
Follow-up to #843, covering the secondary items from #832.

## ESM consumption

The `exports` map declared only a `require` condition, so `import "lindera-nodejs"` from an ESM package failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` — consumers needed a `createRequire` shim.

Adding `import` and `default` conditions fixes this **without a dual build**. `index.js` is CommonJS, but napi generates static `module.exports.X = ...` assignments (exactly the shape [`cjs-module-lexer`](https://github.com/nodejs/cjs-module-lexer) detects) so Node synthesises named ESM exports from it. Verified: 27 named exports are visible to an ESM importer, including `Tokenizer`, `loadDictionary` and `Metadata`.

`types` moves first, per TypeScript's resolution rules — conditions match in order, and a `types` entry after `import`/`require` can be shadowed.

I checked the change by testing both maps against a minimal package consumed **by name** from a `"type": "module"` project:

| exports map | result |
| --- | --- |
| `require`-only (current) | `ERR_PACKAGE_PATH_NOT_EXPORTED` |
| with `import` (this PR) | resolves, named exports present |

## `engines`

Declared as `^20.17.0 || ^22.13.0 || >= 23.5.0` — matching the floor `@napi-rs/cli` v3 already imposes, rather than inventing a looser one. CI runs `node-version: "20"`, which resolves to 20.19.x and satisfies this.

## Docs

Both READMEs said "Node.js 18+", which reached EOL in April 2025 and was below what the toolchain required regardless. Updated to the same range as `engines`, and added a short ESM usage note to each Quick Start, since the existing examples are all CommonJS.

## Test

`tests/test_esm.mjs` covers the named exports, the default export, and a tokenize call through an ESM-imported binding — so a regression in the `exports` map fails CI rather than surfacing for consumers.

It follows the existing `skip` guard for `embedded://ipadic` (behind the non-default `embed-ipadic` feature), matching `test_tokenize_ipadic.js`. The test glob was widened to include `tests/test_*.mjs`.

## Verification

- `npm test` — 17 passing, 1 skipped (the dictionary-dependent case, as expected on a default build)

## Not included

ESM-only packaging, which you noted in #832 is a breaking change for existing CJS consumers and better tracked separately. This PR keeps the package dual-consumable.
