### PR TITLE
feat(dictionary): add reader-based user dictionary build entry points

### DIFF
--- a/lindera-dictionary/src/builder.rs
+++ b/lindera-dictionary/src/builder.rs
@@ -277,6 +277,23 @@ impl DictionaryBuilder {
     }
 
     pub fn build_user_dict(&self, input_file: &Path) -> LinderaResult<UserDictionary> {
+        self.user_dictionary_builder()?.build(input_file)
+    }
+
+    /// Build a user dictionary from any reader yielding CSV data.
+    ///
+    /// Same as [`DictionaryBuilder::build_user_dict`] but without filesystem
+    /// access; see [`UserDictionaryBuilder::build_from_reader`].
+    pub fn build_user_dict_from_reader<R: std::io::Read>(
+        &self,
+        reader: R,
+    ) -> LinderaResult<UserDictionary> {
+        self.user_dictionary_builder()?.build_from_reader(reader)
+    }
+
+    fn user_dictionary_builder(
+        &self,
+    ) -> LinderaResult<crate::builder::user_dictionary::UserDictionaryBuilder> {
         let userdic_schema = self.metadata.user_dictionary_schema.clone();
         let dict_schema = self.metadata.dictionary_schema.clone();
         let default_field_value = self.metadata.default_field_value.clone();
@@ -310,7 +327,6 @@ impl DictionaryBuilder {
                 Ok(result)
             })))
             .builder()
-            .map_err(|err| LinderaErrorKind::Build.with_error(anyhow::anyhow!(err)))?
-            .build(input_file)
+            .map_err(|err| LinderaErrorKind::Build.with_error(anyhow::anyhow!(err)))
     }
 }

--- a/lindera-dictionary/src/builder/user_dictionary.rs
+++ b/lindera-dictionary/src/builder/user_dictionary.rs
@@ -41,20 +41,36 @@ pub struct UserDictionaryBuilder {
 }
 
 impl UserDictionaryBuilder {
+    /// Build a user dictionary from a CSV file.
+    ///
+    /// This is a thin wrapper around [`UserDictionaryBuilder::build_from_reader`]
+    /// that opens `input_file` and annotates any error with its path.
     pub fn build(&self, input_file: &Path) -> LinderaResult<UserDictionary> {
         debug!("reading {input_file:?}");
 
+        let file = File::open(input_file).map_err(|err| {
+            LinderaErrorKind::Io
+                .with_error(anyhow::anyhow!(err))
+                .add_context(format!(
+                    "Failed to open user dictionary CSV file: {input_file:?}"
+                ))
+        })?;
+
+        self.build_from_reader(file)
+            .map_err(|err| err.add_context(format!("In user dictionary file: {input_file:?}")))
+    }
+
+    /// Build a user dictionary from any reader yielding CSV data.
+    ///
+    /// Unlike [`UserDictionaryBuilder::build`], this needs no filesystem access,
+    /// so callers holding the CSV in memory (WASM, sandboxed hosts that mediate
+    /// file reads through a capability layer, dictionaries fetched over the
+    /// network, tests using inline fixtures) can build without a temporary file.
+    pub fn build_from_reader<R: io::Read>(&self, reader: R) -> LinderaResult<UserDictionary> {
         let mut rdr = csv::ReaderBuilder::new()
             .has_headers(false)
             .flexible(self.flexible_csv)
-            .from_path(input_file)
-            .map_err(|err| {
-                LinderaErrorKind::Io
-                    .with_error(anyhow::anyhow!(err))
-                    .add_context(format!(
-                        "Failed to open user dictionary CSV file: {input_file:?}"
-                    ))
-            })?;
+            .from_reader(reader);
 
         let mut rows: Vec<StringRecord> = vec![];
         for (line_num, result) in rdr.records().enumerate() {
@@ -62,9 +78,8 @@ impl UserDictionaryBuilder {
                 LinderaErrorKind::Content
                     .with_error(anyhow::anyhow!(err))
                     .add_context(format!(
-                        "Failed to parse CSV record at line {} in file: {:?}",
-                        line_num + 1,
-                        input_file
+                        "Failed to parse CSV record at line {}",
+                        line_num + 1
                     ))
             })?;
             rows.push(record);
@@ -299,4 +314,74 @@ pub fn build_user_dictionary(user_dict: UserDictionary, output_file: &Path) -> L
     })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SIMPLE_CSV: &str = "東京スカイツリー,カスタム名詞,トウキョウスカイツリー\n\
+                              とうきょうスカイツリー,カスタム名詞,トウキョウスカイツリー\n";
+
+    fn builder() -> UserDictionaryBuilder {
+        UserDictionaryBuilderOptions::default()
+            .builder()
+            .expect("default user dictionary builder options are valid")
+    }
+
+    /// `build_from_reader` accepts in-memory CSV, so callers without filesystem
+    /// access (WASM, capability-mediated hosts) do not need a temporary file.
+    #[test]
+    fn build_from_reader_accepts_in_memory_csv() {
+        let user_dict = builder()
+            .build_from_reader(SIMPLE_CSV.as_bytes())
+            .expect("building from an in-memory reader should succeed");
+
+        // Both surfaces made it into the trie.
+        assert!(
+            user_dict.dict.prefix("東京スカイツリー").next().is_some(),
+            "surface from the in-memory CSV should be present in the built dictionary"
+        );
+    }
+
+    /// The reader path and the file path must produce identical dictionaries;
+    /// otherwise `build` would silently diverge from its own extracted core.
+    #[test]
+    fn build_from_reader_matches_build_from_path() {
+        let dir = std::env::temp_dir().join(format!(
+            "lindera_user_dict_reader_parity_{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let csv_path = dir.join("user_dict.csv");
+        fs::write(&csv_path, SIMPLE_CSV).expect("write temp csv");
+
+        let from_path = builder().build(&csv_path).expect("build from path");
+        let from_reader = builder()
+            .build_from_reader(SIMPLE_CSV.as_bytes())
+            .expect("build from reader");
+
+        assert_eq!(
+            from_path.dict.vals_data.as_ref(),
+            from_reader.dict.vals_data.as_ref(),
+            "reader and path paths must build byte-identical value data"
+        );
+        assert_eq!(
+            from_path.dict.words_data.as_ref(),
+            from_reader.dict.words_data.as_ref(),
+            "reader and path paths must build byte-identical word data"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A row that is neither the short user form nor the full dictionary form
+    /// is rejected identically through the reader path.
+    #[test]
+    fn build_from_reader_rejects_wrong_field_count() {
+        match builder().build_from_reader("surface,1,2,3,4\n".as_bytes()) {
+            Ok(_) => panic!("a row with an unsupported field count must be rejected"),
+            Err(err) => assert_eq!(err.kind(), LinderaErrorKind::Content),
+        }
+    }
 }

--- a/lindera-dictionary/src/loader/user_dictionary.rs
+++ b/lindera-dictionary/src/loader/user_dictionary.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::path::Path;
 
 use crate::LinderaResult;
@@ -22,5 +23,18 @@ impl UserDictionaryLoader {
         path: P,
     ) -> LinderaResult<UserDictionary> {
         builder.build_user_dict(path.as_ref())
+    }
+
+    /// Load user dictionary from any reader yielding CSV data.
+    ///
+    /// Filesystem-free counterpart of [`UserDictionaryLoader::load_from_csv`],
+    /// for callers that already hold the CSV in memory. Note that the binary
+    /// (`.bin`) format already has such an entry point in
+    /// [`UserDictionary::load`].
+    pub fn load_from_csv_reader<R: io::Read>(
+        builder: DictionaryBuilder,
+        reader: R,
+    ) -> LinderaResult<UserDictionary> {
+        builder.build_user_dict_from_reader(reader)
     }
 }


### PR DESCRIPTION
## Motivation

Building a user dictionary currently requires a filesystem path. `UserDictionaryBuilder::build` takes `&Path` and immediately does `csv::ReaderBuilder::…::from_path`; everything after that is pure in-memory work.

That is a problem for callers that hold the CSV in memory but cannot (or should not) touch the filesystem:

- WASM targets, where `lindera-wasm` already has to route dictionary loading through byte arrays;
- hosts that mediate all file access through a capability/sandbox layer, so the CSV arrives as `Vec<u8>` and writing it back out to a temp file would defeat the sandbox;
- dictionaries fetched over the network or embedded in the binary;
- tests that would rather use an inline fixture than a temp file.

The binary (`.bin`) format already has a byte-level entry point in `UserDictionary::load(&[u8])` — this PR gives the CSV format the same courtesy.

## What this changes

Three additive entry points, mirroring the existing path-based ones:

| Existing (path) | Added (reader) |
| --- | --- |
| `UserDictionaryBuilder::build(&Path)` | `UserDictionaryBuilder::build_from_reader<R: io::Read>(R)` |
| `DictionaryBuilder::build_user_dict(&Path)` | `DictionaryBuilder::build_user_dict_from_reader<R: io::Read>(R)` |
| `UserDictionaryLoader::load_from_csv(builder, path)` | `UserDictionaryLoader::load_from_csv_reader<R: io::Read>(builder, R)` |

`build` is now a thin wrapper: it opens the file and delegates to `build_from_reader`, then annotates any error with the file path so existing diagnostics keep their context. The dictionary-building logic itself is untouched and lives in exactly one place.

`DictionaryBuilder` grows a small private `user_dictionary_builder()` helper so the path and reader variants share the same option wiring instead of duplicating it.

**No public API is removed or changed.** No behavior change on the existing path.

## Tests

Three unit tests in `builder/user_dictionary.rs`:

- `build_from_reader_accepts_in_memory_csv` — the surfaces land in the trie.
- `build_from_reader_matches_build_from_path` — the two paths produce byte-identical `vals_data` and `words_data`. This is the one that matters: it pins `build` to its own extracted core, so the reader path cannot silently drift.
- `build_from_reader_rejects_wrong_field_count` — errors still surface through the reader path.

`cargo test -p lindera-dictionary` → 54 passed, 0 failed. `cargo clippy -p lindera-dictionary --all-targets -- -D warnings` → clean. `cargo fmt --check` → clean.

## Unrelated observation

While writing the tests I noticed that a CSV row with fewer fields than the short user form (e.g. a single bare `surface`) panics rather than returning an error — `row[3]` / `row[1]` index into a `StringRecord` that has only one field, and `csv`'s `Index` impl unwraps internally. It reproduces on `main` through the existing path-based `build` too, so it is not introduced here and I left it alone to keep this PR focused. Happy to send a separate PR turning it into a `LinderaErrorKind::Content` error if you would like.
