### PR TITLE
perf: fetch the dictionary with ureq instead of reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
  "paste",
  "rand 0.9.4",
  "rand_xoshiro",
- "thiserror 2.0.19",
+ "thiserror",
  "web-time",
 ]
 
@@ -142,7 +142,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.9.4",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -183,12 +183,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -364,12 +358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,16 +478,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "console"
@@ -1168,91 +1146,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hyper"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -1436,22 +1333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,50 +1372,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "jobserver"
@@ -1686,7 +1523,6 @@ name = "lindera-cc-cedict"
 version = "4.0.1"
 dependencies = [
  "lindera-dictionary",
- "tokio",
 ]
 
 [[package]]
@@ -1734,17 +1570,15 @@ dependencies = [
  "once_cell",
  "rand 0.10.2",
  "rayon",
- "reqwest",
  "rkyv",
- "rustls",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
  "tar",
  "tempfile",
- "thiserror 2.0.19",
- "tokio",
+ "thiserror",
+ "ureq",
 ]
 
 [[package]]
@@ -1752,7 +1586,6 @@ name = "lindera-ipadic"
 version = "4.0.1"
 dependencies = [
  "lindera-dictionary",
- "tokio",
 ]
 
 [[package]]
@@ -1760,7 +1593,6 @@ name = "lindera-ipadic-neologd"
 version = "4.0.1"
 dependencies = [
  "lindera-dictionary",
- "tokio",
 ]
 
 [[package]]
@@ -1768,7 +1600,6 @@ name = "lindera-jieba"
 version = "4.0.1"
 dependencies = [
  "lindera-dictionary",
- "tokio",
 ]
 
 [[package]]
@@ -1776,7 +1607,6 @@ name = "lindera-ko-dic"
 version = "4.0.1"
 dependencies = [
  "lindera-dictionary",
- "tokio",
 ]
 
 [[package]]
@@ -1849,7 +1679,6 @@ name = "lindera-unidic"
 version = "4.0.1"
 dependencies = [
  "lindera-dictionary",
- "tokio",
 ]
 
 [[package]]
@@ -1971,17 +1800,6 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2652,40 +2470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,24 +2538,13 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -2782,33 +2555,6 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3081,16 +2827,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,15 +2885,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -3224,31 +2951,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.19",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3339,112 +3046,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "tokio-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags 2.11.1",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3519,10 +3120,12 @@ dependencies = [
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3606,15 +3209,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -3770,16 +3364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,6 +3378,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3890,20 +3483,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3917,40 +3501,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3960,21 +3523,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3990,21 +3541,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4014,21 +3553,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,13 +65,6 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 strum = { version = "0.28.0", features = ["derive"] }
 strum_macros = "0.28.0"
-tokio = { version = "1.53.1", features = [
-    "rt",
-    "macros",
-    "time",
-    "sync",
-    "io-util",
-] }
 
 [profile.release]
 lto = true

--- a/lindera-cc-cedict/Cargo.toml
+++ b/lindera-cc-cedict/Cargo.toml
@@ -19,4 +19,3 @@ lindera-dictionary = { workspace = true }
 
 [build-dependencies]
 lindera-dictionary = { workspace = true, features = ["build_rs"] }
-tokio = { workspace = true }

--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
         file_name: "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz",
         input_dir: "CC-CEDICT-MeCab-0.1.0-20200409",
@@ -14,5 +13,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "aba9748b70f37feede97b70c5d37f8a0",
     };
 
-    build_embedded_dictionary(cfg!(feature = "embed-cc-cedict"), fetch_params).await
+    build_embedded_dictionary_blocking(cfg!(feature = "embed-cc-cedict"), fetch_params)
 }

--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
@@ -13,5 +13,5 @@ fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "aba9748b70f37feede97b70c5d37f8a0",
     };
 
-    build_embedded_dictionary_blocking(cfg!(feature = "embed-cc-cedict"), fetch_params)
+    build_embedded_dictionary(cfg!(feature = "embed-cc-cedict"), fetch_params)
 }

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -12,15 +12,7 @@ categories = { workspace = true }
 license = { workspace = true }
 
 [features]
-build_rs = [
-    "dep:flate2",
-    "dep:md5",
-    "dep:rand",
-    "dep:reqwest",
-    "dep:rustls",
-    "dep:tar",
-    "dep:tokio",
-]
+build_rs = ["dep:flate2", "dep:md5", "dep:rand", "dep:tar", "dep:ureq"]
 mmap = ["dep:memmap2"]
 # Experimental: instrument connection-matrix accesses to profile per-context-id
 # access frequency over a corpus (used to build a corpus-frequency remap). Off by
@@ -43,17 +35,6 @@ memchr = "2.8.3"
 memmap2 = { version = "0.9.11", optional = true }
 once_cell = { workspace = true }
 rand = { version = "0.10.2", default-features = false, optional = true }
-# `rustls` (rather than `rustls-no-provider`) would pin the aws-lc-rs provider, whose
-# `aws-lc-sys` C build dominates the compile time of every crate that embeds a dictionary.
-# The download only needs a working TLS client, so use the much smaller `ring` provider.
-reqwest = { version = "0.13.4", features = [
-    "rustls-no-provider",
-], default-features = false, optional = true }
-rustls = { version = "0.23.27", default-features = false, features = [
-    "ring",
-    "std",
-    "tls12",
-], optional = true }
 rkyv = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -61,7 +42,13 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 tar = { version = "0.4.46", optional = true }
 thiserror = "2.0.19"
-tokio = { workspace = true, optional = true }
+# The dictionary download needs nothing more than a blocking HTTPS GET. `ureq`
+# provides that without an async runtime; the `rustls` feature selects the `ring`
+# provider, keeping `aws-lc-sys` (whose C build dominates the compile time of
+# every crate that embeds a dictionary) out of the graph.
+ureq = { version = "3.3.0", default-features = false, features = [
+    "rustls",
+], optional = true }
 
 # rayon does not support wasm32-unknown-unknown (no OS threads); the connection
 # cost matrix parser falls back to a sequential path there.

--- a/lindera-dictionary/src/assets.rs
+++ b/lindera-dictionary/src/assets.rs
@@ -3,14 +3,15 @@ use std::ffi::OsString;
 use std::fs::{self, File, rename};
 use std::io::{self, Cursor, Read, Write};
 use std::path::{Path, PathBuf};
+use std::thread::sleep;
+use std::time::Duration;
 
 use flate2::read::GzDecoder;
 use log::{debug, error, info, warn};
 use md5::Context;
 use rand::{SeedableRng, rngs::SmallRng, seq::SliceRandom};
-use reqwest::Client;
 use tar::Archive;
-use tokio::time::{Duration, sleep};
+use ureq::Agent;
 
 use crate::LinderaResult;
 use crate::builder::DictionaryBuilder;
@@ -242,8 +243,13 @@ fn create_dummy_dictionary_source(
     Ok(())
 }
 
-async fn download_with_retry(
-    client: &Client,
+/// Dictionary archives run to hundreds of megabytes, so the 10 MB default body
+/// limit does not apply here. The MD5 check below is what guards against a
+/// truncated or substituted download.
+const BODY_LIMIT: u64 = u64::MAX;
+
+fn download_with_retry(
+    agent: &Agent,
     download_urls: Vec<&str>,
     max_rounds: usize,
     expected_md5: &str,
@@ -272,11 +278,16 @@ async fn download_with_retry(
 
         for url in urls {
             debug!("Attempting to download from {url}");
-            match client.get(url).send().await {
+            match agent.get(url).call() {
                 Ok(resp) if resp.status().is_success() => {
                     debug!("HTTP download successful from {url}");
 
-                    match resp.bytes().await {
+                    match resp
+                        .into_body()
+                        .with_config()
+                        .limit(BODY_LIMIT)
+                        .read_to_vec()
+                    {
                         Ok(content) => {
                             // Calculate MD5 hash
                             let mut context = Context::new();
@@ -288,7 +299,7 @@ async fn download_with_retry(
 
                             if actual_md5 == expected_md5 {
                                 debug!("MD5 check passed from {url}");
-                                return Ok(content.to_vec());
+                                return Ok(content);
                             } else {
                                 warn!(
                                     "MD5 mismatch from {url}, Expected {expected_md5}, got {actual_md5}"
@@ -313,7 +324,7 @@ async fn download_with_retry(
             }
         }
 
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1));
     }
 
     error!("All {max_rounds} attempts failed");
@@ -356,8 +367,22 @@ fn dictionary_cache_dir_from_env() -> Option<OsString> {
     )
 }
 
-/// Fetch the necessary assets and then build the dictionary using `builder`
+/// Fetch the necessary assets and then build the dictionary using `builder`.
+///
+/// Deprecated in favour of [`fetch_blocking`]. The body is fully synchronous,
+/// so the returned future resolves without ever yielding: it exists only so
+/// that build scripts written against v4.0 keep compiling. It will be removed
+/// in v5.0.0.
+#[deprecated(
+    since = "4.1.0",
+    note = "the asset download is synchronous; use `fetch_blocking` instead. This will be removed in v5.0.0"
+)]
 pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaResult<()> {
+    fetch_blocking(params, builder)
+}
+
+/// Fetch the necessary assets and then build the dictionary using `builder`
+pub fn fetch_blocking(params: FetchParams, builder: DictionaryBuilder) -> LinderaResult<()> {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=Cargo.toml");
     // `metadata.json` drives build-time behavior (schema, flags such as
@@ -499,21 +524,14 @@ pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaRe
             let tmp_download_path =
                 Path::new(&build_dir).join(params.file_name.to_owned() + ".download");
 
-            // reqwest is built with `rustls-no-provider`, so rustls has no compiled-in
-            // default provider and `ClientConfig::builder()` would panic without one.
-            // Installing it is idempotent across the dictionary crates that share a
-            // process, hence the ignored result: a second call returns Err.
-            let _ = rustls::crypto::ring::default_provider().install_default();
-
-            // Download a tarball
-            let client = Client::builder()
+            // Download a tarball. `http_status_as_error` is turned off so that a
+            // non-2xx response is reported per URL and the next mirror is tried,
+            // rather than aborting the round.
+            let agent: Agent = Agent::config_builder()
                 .user_agent(format!("Lindera/{}", env!("CARGO_PKG_VERSION")))
+                .http_status_as_error(false)
                 .build()
-                .map_err(|err| {
-                    LinderaErrorKind::Io
-                        .with_error(anyhow::anyhow!(err))
-                        .add_context("Failed to build HTTP client")
-                })?;
+                .into();
 
             debug!("Downloading {:?}", params.download_urls);
             let mut dest = File::create(tmp_download_path.as_path()).map_err(|err| {
@@ -524,12 +542,11 @@ pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaRe
                     ))
             })?;
             let content = download_with_retry(
-                &client,
+                &agent,
                 params.download_urls.to_vec(),
                 MAX_ROUND,
                 params.md5_hash,
             )
-            .await
             .map_err(|err| {
                 LinderaErrorKind::Io
                     .with_error(anyhow::anyhow!("{err}"))
@@ -655,7 +672,31 @@ const CONTEXT_ID_FREQ_FILE: &str = "context_id_freq.txt";
 /// no cache override is set via `LINDERA_BUILD_DICTIONARY_CACHE_DIR` (or its
 /// deprecated alias `LINDERA_DICTIONARIES_PATH`), this is a no-op so the
 /// crate builds without downloading any data.
+///
+/// Deprecated in favour of [`build_embedded_dictionary_blocking`]. The body is
+/// fully synchronous, so the returned future resolves without ever yielding: it
+/// exists only so that build scripts written against v4.0 keep compiling. It
+/// will be removed in v5.0.0.
+#[deprecated(
+    since = "4.1.0",
+    note = "the dictionary build is synchronous; use `build_embedded_dictionary_blocking` instead. This will be removed in v5.0.0"
+)]
 pub async fn build_embedded_dictionary(
+    embed_enabled: bool,
+    params: FetchParams,
+) -> Result<(), Box<dyn Error>> {
+    build_embedded_dictionary_blocking(embed_enabled, params)
+}
+
+/// Reads `metadata.json` from the crate root, fetches and builds the
+/// dictionary described by `params`, and embeds the result under
+/// `LINDERA_WORKDIR`.
+///
+/// When the crate's embed feature is disabled (`embed_enabled == false`) and
+/// no cache override is set via `LINDERA_BUILD_DICTIONARY_CACHE_DIR` (or its
+/// deprecated alias `LINDERA_DICTIONARIES_PATH`), this is a no-op so the
+/// crate builds without downloading any data.
+pub fn build_embedded_dictionary_blocking(
     embed_enabled: bool,
     params: FetchParams,
 ) -> Result<(), Box<dyn Error>> {
@@ -673,7 +714,7 @@ pub async fn build_embedded_dictionary(
         builder = builder.with_context_id_freq(CONTEXT_ID_FREQ_FILE);
     }
 
-    fetch(params, builder).await?;
+    fetch_blocking(params, builder)?;
 
     Ok(())
 }

--- a/lindera-dictionary/src/assets.rs
+++ b/lindera-dictionary/src/assets.rs
@@ -369,20 +369,18 @@ fn dictionary_cache_dir_from_env() -> Option<OsString> {
 
 /// Fetch the necessary assets and then build the dictionary using `builder`.
 ///
-/// Deprecated in favour of [`fetch_blocking`]. The body is fully synchronous,
-/// so the returned future resolves without ever yielding: it exists only so
-/// that build scripts written against v4.0 keep compiling. It will be removed
-/// in v5.0.0.
-#[deprecated(
-    since = "4.1.0",
-    note = "the asset download is synchronous; use `fetch_blocking` instead. This will be removed in v5.0.0"
-)]
-pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaResult<()> {
-    fetch_blocking(params, builder)
-}
-
-/// Fetch the necessary assets and then build the dictionary using `builder`
-pub fn fetch_blocking(params: FetchParams, builder: DictionaryBuilder) -> LinderaResult<()> {
+/// # Arguments
+///
+/// * `params` - Describes the asset to fetch (archive name, mirrors, MD5 hash)
+///   and the input/output directory layout of the dictionary build.
+/// * `builder` - Dictionary builder that turns the extracted MeCab sources into
+///   the Lindera dictionary format.
+///
+/// # Returns
+///
+/// `Ok(())` once the dictionary has been built into the output directory, or a
+/// `LinderaError` if the download, extraction, or build fails.
+pub fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaResult<()> {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=Cargo.toml");
     // `metadata.json` drives build-time behavior (schema, flags such as
@@ -673,30 +671,19 @@ const CONTEXT_ID_FREQ_FILE: &str = "context_id_freq.txt";
 /// deprecated alias `LINDERA_DICTIONARIES_PATH`), this is a no-op so the
 /// crate builds without downloading any data.
 ///
-/// Deprecated in favour of [`build_embedded_dictionary_blocking`]. The body is
-/// fully synchronous, so the returned future resolves without ever yielding: it
-/// exists only so that build scripts written against v4.0 keep compiling. It
-/// will be removed in v5.0.0.
-#[deprecated(
-    since = "4.1.0",
-    note = "the dictionary build is synchronous; use `build_embedded_dictionary_blocking` instead. This will be removed in v5.0.0"
-)]
-pub async fn build_embedded_dictionary(
-    embed_enabled: bool,
-    params: FetchParams,
-) -> Result<(), Box<dyn Error>> {
-    build_embedded_dictionary_blocking(embed_enabled, params)
-}
-
-/// Reads `metadata.json` from the crate root, fetches and builds the
-/// dictionary described by `params`, and embeds the result under
-/// `LINDERA_WORKDIR`.
+/// # Arguments
 ///
-/// When the crate's embed feature is disabled (`embed_enabled == false`) and
-/// no cache override is set via `LINDERA_BUILD_DICTIONARY_CACHE_DIR` (or its
-/// deprecated alias `LINDERA_DICTIONARIES_PATH`), this is a no-op so the
-/// crate builds without downloading any data.
-pub fn build_embedded_dictionary_blocking(
+/// * `embed_enabled` - Whether the calling crate's embed feature is enabled,
+///   i.e. whether the built dictionary is compiled into the binary.
+/// * `params` - Describes the asset to fetch (archive name, mirrors, MD5 hash)
+///   and the input/output directory layout of the dictionary build.
+///
+/// # Returns
+///
+/// `Ok(())` once the dictionary has been built, or when the build was skipped
+/// because neither the embed feature nor a cache override is set. Returns an
+/// error if `metadata.json` cannot be read or the dictionary build fails.
+pub fn build_embedded_dictionary(
     embed_enabled: bool,
     params: FetchParams,
 ) -> Result<(), Box<dyn Error>> {
@@ -714,7 +701,7 @@ pub fn build_embedded_dictionary_blocking(
         builder = builder.with_context_id_freq(CONTEXT_ID_FREQ_FILE);
     }
 
-    fetch_blocking(params, builder)?;
+    fetch(params, builder)?;
 
     Ok(())
 }

--- a/lindera-ipadic-neologd/Cargo.toml
+++ b/lindera-ipadic-neologd/Cargo.toml
@@ -25,4 +25,3 @@ lindera-dictionary = { workspace = true }
 
 [build-dependencies]
 lindera-dictionary = { workspace = true, features = ["build_rs"] }
-tokio = { workspace = true }

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
         file_name: "mecab-ipadic-neologd-0.0.7-20200820.tar.gz",
         input_dir: "mecab-ipadic-neologd-0.0.7-20200820",
@@ -14,5 +13,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "3561f0e76980a842dc828b460a8cae96",
     };
 
-    build_embedded_dictionary(cfg!(feature = "embed-ipadic-neologd"), fetch_params).await
+    build_embedded_dictionary_blocking(cfg!(feature = "embed-ipadic-neologd"), fetch_params)
 }

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
@@ -13,5 +13,5 @@ fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "3561f0e76980a842dc828b460a8cae96",
     };
 
-    build_embedded_dictionary_blocking(cfg!(feature = "embed-ipadic-neologd"), fetch_params)
+    build_embedded_dictionary(cfg!(feature = "embed-ipadic-neologd"), fetch_params)
 }

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -19,4 +19,3 @@ lindera-dictionary = { workspace = true }
 
 [build-dependencies]
 lindera-dictionary = { workspace = true, features = ["build_rs"] }
-tokio = { workspace = true }

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
@@ -13,5 +13,5 @@ fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "a95c409f12f1023fce8ef91f991ef042",
     };
 
-    build_embedded_dictionary_blocking(cfg!(feature = "embed-ipadic"), fetch_params)
+    build_embedded_dictionary(cfg!(feature = "embed-ipadic"), fetch_params)
 }

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
         file_name: "mecab-ipadic-2.7.0-20250920.tar.gz",
         input_dir: "mecab-ipadic-2.7.0-20250920",
@@ -14,5 +13,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "a95c409f12f1023fce8ef91f991ef042",
     };
 
-    build_embedded_dictionary(cfg!(feature = "embed-ipadic"), fetch_params).await
+    build_embedded_dictionary_blocking(cfg!(feature = "embed-ipadic"), fetch_params)
 }

--- a/lindera-jieba/Cargo.toml
+++ b/lindera-jieba/Cargo.toml
@@ -19,4 +19,3 @@ lindera-dictionary = { workspace = true }
 
 [build-dependencies]
 lindera-dictionary = { workspace = true, features = ["build_rs"] }
-tokio = { workspace = true }

--- a/lindera-jieba/build.rs
+++ b/lindera-jieba/build.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
@@ -13,5 +13,5 @@ fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "749dc1ab25a035e141d014cd3c1cf8e9",
     };
 
-    build_embedded_dictionary_blocking(cfg!(feature = "embed-jieba"), fetch_params)
+    build_embedded_dictionary(cfg!(feature = "embed-jieba"), fetch_params)
 }

--- a/lindera-jieba/build.rs
+++ b/lindera-jieba/build.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
         file_name: "mecab-jieba-0.1.1.tar.gz",
         input_dir: "mecab-jieba-0.1.1",
@@ -14,5 +13,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "749dc1ab25a035e141d014cd3c1cf8e9",
     };
 
-    build_embedded_dictionary(cfg!(feature = "embed-jieba"), fetch_params).await
+    build_embedded_dictionary_blocking(cfg!(feature = "embed-jieba"), fetch_params)
 }

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -19,4 +19,3 @@ lindera-dictionary = { workspace = true }
 
 [build-dependencies]
 lindera-dictionary = { workspace = true, features = ["build_rs"] }
-tokio = { workspace = true }

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
@@ -13,5 +13,5 @@ fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "b996764e91c96bc89dc32ea208514a96",
     };
 
-    build_embedded_dictionary_blocking(cfg!(feature = "embed-ko-dic"), fetch_params)
+    build_embedded_dictionary(cfg!(feature = "embed-ko-dic"), fetch_params)
 }

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
         file_name: "mecab-ko-dic-2.1.1-20180720.tar.gz",
         input_dir: "mecab-ko-dic-2.1.1-20180720",
@@ -14,5 +13,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "b996764e91c96bc89dc32ea208514a96",
     };
 
-    build_embedded_dictionary(cfg!(feature = "embed-ko-dic"), fetch_params).await
+    build_embedded_dictionary_blocking(cfg!(feature = "embed-ko-dic"), fetch_params)
 }

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -19,4 +19,3 @@ lindera-dictionary = { workspace = true }
 
 [build-dependencies]
 lindera-dictionary = { workspace = true, features = ["build_rs"] }
-tokio = { workspace = true }

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
@@ -13,5 +13,5 @@ fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "f4502a563e1da44747f61dcd2b269e35",
     };
 
-    build_embedded_dictionary_blocking(cfg!(feature = "embed-unidic"), fetch_params)
+    build_embedded_dictionary(cfg!(feature = "embed-unidic"), fetch_params)
 }

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
-use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary};
+use lindera_dictionary::assets::{FetchParams, build_embedded_dictionary_blocking};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let fetch_params = FetchParams {
         file_name: "unidic-mecab-2.1.2.tar.gz",
         input_dir: "unidic-mecab-2.1.2",
@@ -14,5 +13,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
         md5_hash: "f4502a563e1da44747f61dcd2b269e35",
     };
 
-    build_embedded_dictionary(cfg!(feature = "embed-unidic"), fetch_params).await
+    build_embedded_dictionary_blocking(cfg!(feature = "embed-unidic"), fetch_params)
 }


### PR DESCRIPTION
## What

Every crate that embeds a dictionary runs `lindera-dictionary` with `build_rs` in its build script, and that feature pulls `reqwest`, which brings hyper, tower, tokio and the icu/idna stack with it. The build script does one thing with all of that: a single blocking GET of a tarball, MD5-checked, once per build. A build script has no concurrency to exploit, so the async runtime is compiled and never used.

This switches the download to `ureq` — a blocking client over the same rustls — and drops the `#[tokio::main]` wrapper from the six dictionary build scripts. `ureq`'s `rustls` feature already selects the `ring` provider, so the explicit provider install added in #847 is no longer needed and the direct `rustls` dependency goes with it. `tokio` leaves the workspace entirely.

Net 57 units out of the graph:

- **removed (61)** — `tokio`, `tokio-macros`, `tokio-rustls`, `hyper`, `hyper-rustls`, `hyper-util`, `reqwest`, `tower`, `tower-http`, `tower-layer`, `tower-service`, `http-body`, `http-body-util`, the `futures-*` crates, `mio`, `socket2`, the whole `icu_*`/`idna`/`zerovec`/`yoke` set, `rustls-platform-verifier`, `security-framework`, `tracing`, `url`, and the rest of the transitive tail
- **added (4)** — `ureq`, `ureq-proto`, `utf8-zero`, `webpki-roots`

## Measurement

`cargo build -p lindera-ko-dic --features embed-ko-dic`, clean target dir, macOS arm64, 8 cores. Both runs include the full 49.7 MB download.

| | wall | CPU | units |
|---|---|---|---|
| before | 2m00s | 378s | 142 |
| after | **1m04s** | **208s** | **85** |

46% off a from-scratch dictionary build, on top of the 49% from #847.

Narrowing to just the build-dependency graph, `cargo build -p lindera-dictionary --features build_rs` goes 36.8s → 25.5s wall and 197s → 133s CPU.

## Compatibility — breaking

Per @mosuka's review, the break is taken now rather than deferred: `fetch` and `build_embedded_dictionary` are plain synchronous functions. The first draft kept them as deprecated `async` wrappers over `fetch_blocking` / `build_embedded_dictionary_blocking`, but since the next release from `main` is v5.0.0, those wrappers would have shipped in the very release that removes them. The `_blocking` names are gone with them, and both entry points gained the `# Arguments` / `# Returns` doc sections this file already uses elsewhere.

**BREAKING CHANGE:** `lindera_dictionary::assets::fetch` and `build_embedded_dictionary` are no longer `async`. Build scripts that awaited them should call them directly and can drop their async runtime — which is the point of the PR, and what the six in-tree build scripts now do.

## Behavioural notes

- `http_status_as_error` is turned off so a non-2xx response is still logged per URL and the next mirror tried, which is what the `reqwest` status arm did. Leaving it on would collapse that into a generic error and lose the status.
- The body limit is set explicitly: `ureq` defaults to 10 MB and the archives run well past it (ko-dic is 49.7 MB). MD5 remains the integrity check, as before.
- Roots come from `webpki-roots` rather than the platform verifier. For a fixed set of `Lindera.dev` asset URLs that is if anything more predictable, and it is what drops `security-framework` on macOS.

## Verification

- `cargo test -p lindera --features embed-ipadic,embed-ko-dic` — 40 passed, 0 failed. (The `test_segment_with_simple_userdic_bin_ipadic` failure noted in #847 and #848 is gone since #851 regenerated the fixtures.)
- `cargo test -p lindera-dictionary --features build_rs` — passes.
- `cargo clippy -p lindera-dictionary --features build_rs --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Downloads are real, not cache hits: clean builds of `lindera-cc-cedict` (8.2 MB), `lindera-jieba` and `lindera-ko-dic` (49.7 MB) each fetch, MD5-check and build the dictionary. ko-dic exercises the raised body limit.
- `tokio` no longer appears anywhere in the workspace.

## Context

Same thread as #847 and #848 — profiling build times for [pg_search](https://github.com/paradedb/paradedb), which embeds the CJK dictionaries. With `aws-lc-sys` gone, the reqwest stack was the largest remaining block of build-script compile time.

