### PR TITLE
fix(analysis): stop substituting `*` into the surface form of unknown words

### DIFF
--- a/lindera-analysis/src/token_filter/japanese_base_form.rs
+++ b/lindera-analysis/src/token_filter/japanese_base_form.rs
@@ -39,17 +39,24 @@ impl TokenFilter for JapaneseBaseFormTokenFilter {
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            // Skip tokens with "UNK" in the first detail
-            if let Some(pos) = token.get_detail(0)
-                && pos == "UNK"
-            {
+            // Skip unknown tokens. Their details come from `unk.def`, so the
+            // first one is a real part of speech rather than the `UNK` sentinel
+            // this used to test for.
+            if token.word_id.is_unknown() {
                 continue;
             }
 
-            if let Some(base_form) = token.get("base_form") {
+            // `*` is the MeCab placeholder for an absent field, and `details` is
+            // padded with it to the schema width, so an entry that carries no
+            // base form yields `Some("*")` rather than `None`.
+            if let Some(base_form) = token.get("base_form")
+                && base_form != "*"
+            {
                 token.surface = Cow::Owned(base_form.to_string());
             }
-            if let Some(base_form) = token.get("orthographic_base_form") {
+            if let Some(base_form) = token.get("orthographic_base_form")
+                && base_form != "*"
+            {
                 token.surface = Cow::Owned(base_form.to_string());
             }
         }
@@ -169,5 +176,72 @@ mod tests {
         assert_eq!(tokens[1].surface, "に");
         assert_eq!(tokens[2].surface, "ある");
         assert_eq!(tokens[3].surface, "ます");
+    }
+
+    // A word that is not in the dictionary takes its details from `unk.def`, so
+    // its part of speech is a real one and its base form is the placeholder `*`.
+    // Neither may be substituted into the surface form.
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn test_japanese_base_form_token_filter_keeps_surface_without_base_form() {
+        use std::borrow::Cow;
+
+        use crate::token_filter::TokenFilter;
+        use crate::token_filter::japanese_base_form::JapaneseBaseFormTokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let filter = JapaneseBaseFormTokenFilter::new();
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        // The details an out-of-vocabulary word receives from `unk.def`: a real
+        // part of speech, then `*` for every remaining field.
+        let unknown_details = vec![
+            Cow::Borrowed("名詞"),
+            Cow::Borrowed("固有名詞"),
+            Cow::Borrowed("組織"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+        ];
+
+        let mut tokens: Vec<Token> = vec![
+            // Out of vocabulary, so skipped by the unknown-word guard.
+            Token {
+                surface: Cow::Borrowed("asci"),
+                byte_start: 0,
+                byte_end: 4,
+                position: 0,
+                position_length: 1,
+                word_id: WordId::new(LexType::Unknown, 3),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: Some(unknown_details.clone()),
+            },
+            // In the dictionary, but carries no base form, so skipped by the
+            // placeholder guard.
+            Token {
+                surface: Cow::Borrowed("("),
+                byte_start: 4,
+                byte_end: 5,
+                position: 1,
+                position_length: 1,
+                word_id: WordId::new(LexType::System, 3),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: Some(unknown_details),
+            },
+        ];
+
+        filter.apply(&mut tokens).unwrap();
+
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].surface, "asci");
+        assert_eq!(tokens[1].surface, "(");
     }
 }

--- a/lindera-analysis/src/token_filter/japanese_reading_form.rs
+++ b/lindera-analysis/src/token_filter/japanese_reading_form.rs
@@ -50,8 +50,8 @@ impl TokenFilter for JapaneseReadingFormTokenFilter {
     /// # Process
     ///
     /// 1. **Token Detail Check**:
-    ///    - For each token in the vector, the function checks the first detail (`get_detail(0)`).
-    ///    - If the first detail is `"UNK"`, the token is skipped and no further processing is done for that token.
+    ///    - For each token in the vector, the function checks whether the word came from the unknown-word dictionary.
+    ///    - If it did, the token is skipped and no further processing is done for that token.
     ///
     /// 2. **Dictionary Type Handling**:
     ///    - Depending on the `config.kind` (which determines the type of dictionary used), the function selects the appropriate index in the token's details:
@@ -72,14 +72,19 @@ impl TokenFilter for JapaneseReadingFormTokenFilter {
     /// Returns a `LinderaResult<()>` if there is an issue during token processing or text conversion. However, under normal circumstances, it should process without errors.
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            // Skip unknown tokens
-            if let Some(pos) = token.get_detail(0)
-                && pos == "UNK"
-            {
+            // Skip unknown tokens. Their details come from `unk.def`, so the
+            // first one is a real part of speech rather than the `UNK` sentinel
+            // this used to test for.
+            if token.word_id.is_unknown() {
                 continue;
             }
 
-            if let Some(reading) = token.get("reading") {
+            // `*` is the MeCab placeholder for an absent field, and `details` is
+            // padded with it to the schema width, so an entry that carries no
+            // reading yields `Some("*")` rather than `None`.
+            if let Some(reading) = token.get("reading")
+                && reading != "*"
+            {
                 token.surface = Cow::Owned(reading.to_string());
             }
         }
@@ -167,5 +172,72 @@ mod tests {
         assert_eq!(&tokens[0].surface, "ハネダクウコウ");
         assert_eq!(&tokens[1].surface, "ゲンテイ");
         assert_eq!(&tokens[2].surface, "トートバッグ");
+    }
+
+    // A word that is not in the dictionary takes its details from `unk.def`, so
+    // its part of speech is a real one and its reading is the placeholder `*`.
+    // Neither may be substituted into the surface form.
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn test_japanese_reading_form_token_filter_keeps_surface_without_reading() {
+        use std::borrow::Cow;
+
+        use crate::token_filter::TokenFilter;
+        use crate::token_filter::japanese_reading_form::JapaneseReadingFormTokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let filter = JapaneseReadingFormTokenFilter::new();
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        // The details an out-of-vocabulary word receives from `unk.def`: a real
+        // part of speech, then `*` for every remaining field.
+        let unknown_details = vec![
+            Cow::Borrowed("名詞"),
+            Cow::Borrowed("固有名詞"),
+            Cow::Borrowed("組織"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+        ];
+
+        let mut tokens: Vec<Token> = vec![
+            // Out of vocabulary, so skipped by the unknown-word guard.
+            Token {
+                surface: Cow::Borrowed("asci"),
+                byte_start: 0,
+                byte_end: 4,
+                position: 0,
+                position_length: 1,
+                word_id: WordId::new(LexType::Unknown, 3),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: Some(unknown_details.clone()),
+            },
+            // In the dictionary, but carries no reading, so skipped by the
+            // placeholder guard.
+            Token {
+                surface: Cow::Borrowed("("),
+                byte_start: 4,
+                byte_end: 5,
+                position: 1,
+                position_length: 1,
+                word_id: WordId::new(LexType::System, 3),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: Some(unknown_details),
+            },
+        ];
+
+        filter.apply(&mut tokens).unwrap();
+
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(&tokens[0].surface, "asci");
+        assert_eq!(&tokens[1].surface, "(");
     }
 }

--- a/lindera-analysis/src/token_filter/korean_reading_form.rs
+++ b/lindera-analysis/src/token_filter/korean_reading_form.rs
@@ -38,13 +38,19 @@ impl TokenFilter for KoreanReadingFormTokenFilter {
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            if let Some(pos) = token.get_detail(0)
-                && pos == "UNK"
-            {
+            // Skip unknown tokens. Their details come from `unk.def`, so the
+            // first one is a real part of speech rather than the `UNK` sentinel
+            // this used to test for.
+            if token.word_id.is_unknown() {
                 continue;
             }
 
-            if let Some(reading) = token.get("reading") {
+            // `*` is the MeCab placeholder for an absent field, and `details` is
+            // padded with it to the schema width, so an entry that carries no
+            // reading yields `Some("*")` rather than `None`.
+            if let Some(reading) = token.get("reading")
+                && reading != "*"
+            {
                 token.surface = Cow::Owned(reading.to_string());
             }
         }
@@ -265,5 +271,71 @@ mod tests {
         assert_eq!(&tokens[6].surface, "수");
         assert_eq!(&tokens[7].surface, "있");
         assert_eq!(&tokens[8].surface, "습니다");
+    }
+
+    // A word that is not in the dictionary takes its details from `unk.def`, so
+    // its part of speech is a real one and its reading is the placeholder `*`.
+    // Neither may be substituted into the surface form.
+    #[test]
+    #[cfg(feature = "embed-ko-dic")]
+    fn test_korean_reading_form_token_filter_keeps_surface_without_reading() {
+        use std::borrow::Cow;
+
+        use crate::token_filter::TokenFilter;
+        use crate::token_filter::korean_reading_form::KoreanReadingFormTokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let filter = KoreanReadingFormTokenFilter::new();
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
+
+        // The details an out-of-vocabulary word receives from `unk.def`: a real
+        // part of speech, then `*` for every remaining field.
+        let unknown_details = vec![
+            Cow::Borrowed("SY"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+            Cow::Borrowed("*"),
+        ];
+
+        let mut tokens: Vec<Token> = vec![
+            // Out of vocabulary, so skipped by the unknown-word guard.
+            Token {
+                surface: Cow::Borrowed("!"),
+                byte_start: 0,
+                byte_end: 1,
+                position: 0,
+                position_length: 1,
+                word_id: WordId::new(LexType::Unknown, 3),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: Some(unknown_details.clone()),
+            },
+            // In the dictionary, but carries no reading, so skipped by the
+            // placeholder guard.
+            Token {
+                surface: Cow::Borrowed("."),
+                byte_start: 1,
+                byte_end: 2,
+                position: 1,
+                position_length: 1,
+                word_id: WordId::new(LexType::System, 3),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: Some(unknown_details),
+            },
+        ];
+
+        filter.apply(&mut tokens).unwrap();
+
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(&tokens[0].surface, "!");
+        assert_eq!(&tokens[1].surface, ".");
     }
 }


### PR DESCRIPTION
## The bug

All three of `japanese_reading_form`, `korean_reading_form` and `japanese_base_form` open with the same guard:

```rust
if let Some(pos) = token.get_detail(0)
    && pos == "UNK"
{
    continue;
}
```

That guard no longer matches anything. `Token::ensure_details` resolves an unknown word through `unknown_word_details()`, so its first detail is a real part of speech read out of `unk.def`, not the `UNK` sentinel being compared against. The token falls through to the substitution — and since `details` is padded with the MeCab placeholder `*` to the schema width, `get("reading")` returns `Some("*")` where it previously returned `None`:

```
surface="日本語" unknown=false detail0=Some("名詞") reading=Some("ニホンゴ")
surface="asci"   unknown=true  detail0=Some("名詞") reading=Some("*")
surface="일본"    unknown=true  detail0=Some("記号") reading=Some("*")
surface="("      unknown=true  detail0=Some("名詞") reading=Some("*")
```

The filter writes it in. Every out-of-vocabulary token — Latin, digits, punctuation, Korean text under the Japanese tokenizer — comes out of `reading_form` as a literal asterisk. `日本語` still reads correctly as `ニホンゴ`; it is only the unknown words that are destroyed, which is what makes it easy to miss.

## The fix

Two guards replace the dead one:

- `word_id.is_unknown()` — what the original string comparison was reaching for, now asked of the field that actually carries the answer.
- `reading != "*"` — the placeholder check, which the unknown-word guard alone does not cover. ko-dic has *system* entries for punctuation with no reading field, so `.`, `,`, `(`, `!` and `…` are already replaced by `*` under `korean_reading_form` today, independently of the above. This fixes that too.

`japanese_base_form` gets the same treatment for `base_form` and `orthographic_base_form`.

## Measurements

I dumped the full token stream — text, byte offsets, position, position length — for the Japanese, Korean and Chinese tokenizers across all eight `keep_whitespace`/NFKC/`reading_form` combinations over a 29-string CJK corpus, and compared the output against lindera 1.5.1, which predates the details change:

| | records differing from 1.5.1 |
|---|---|
| `reading_form` off | 0 |
| `reading_form` on, filters as they stand | **614**, every one replaced by `"*"` |
| `reading_form` on, with this change | 96, none of them `"*"` |

The remaining 96 all run the other way: in each, 1.5.1 emitted `"*"` and the patched build emits the real character. They are the ko-dic punctuation case above.

## Tests

Three regression tests, one per filter, each covering both an out-of-vocabulary token and an in-vocabulary entry whose field is the placeholder. All three fail on `main` with `left: "*"`.

- `cargo test -p lindera-analysis --features embed-ipadic,embed-ko-dic` — 110 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.

## Context

Found while preparing a 1.5.1 → 4.x upgrade for [pg_search](https://github.com/paradedb/paradedb), which embeds ipadic, ko-dic and cc-cedict and exposes `reading_form` as an index option. Since tokenization decides what is written into a BM25 index, an upgrade that silently rewrites unknown words to `*` would corrupt every index built with it. Holding our bump until this lands.

Follows #847 and #848; unrelated to either.