### PR TITLE
perf(dictionary): bind the embedded dictionary data to statics

### DIFF
--- a/lindera-dictionary/src/macros.rs
+++ b/lindera-dictionary/src/macros.rs
@@ -13,6 +13,13 @@
 /// reading from the `LINDERA_WORKDIR` directory populated by the crate's
 /// build script.
 ///
+/// The data is bound to `static`s rather than `const`s deliberately. A `const`
+/// body is encoded into the crate's metadata, so a `const` here would put a copy
+/// of every dictionary byte into `lib.rmeta` at roughly 4x its size — several
+/// hundred megabytes per dictionary crate, re-read by every downstream crate.
+/// The data is private to `load()` below and never const-evaluated, so a `static`
+/// is all that is needed.
+///
 /// * `$dir` — the dictionary subdirectory inside `LINDERA_WORKDIR`
 ///   (e.g. `"/lindera-ipadic"`).
 /// * `$loader` — the public loader struct name (e.g. `EmbeddedIPADICLoader`).
@@ -25,20 +32,20 @@
 #[macro_export]
 macro_rules! embedded_dictionary {
     ($dir:literal, $loader:ident) => {
-        const CHAR_DEFINITION_DATA: &[u8] =
+        static CHAR_DEFINITION_DATA: &[u8] =
             include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/char_def.bin"));
-        const CONNECTION_DATA: &[u8] =
+        static CONNECTION_DATA: &[u8] =
             include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/matrix.mtx"));
-        const DA_DATA: &[u8] = include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/dict.da"));
-        const VALS_DATA: &[u8] =
+        static DA_DATA: &[u8] = include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/dict.da"));
+        static VALS_DATA: &[u8] =
             include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/dict.vals"));
-        const UNKNOWN_DATA: &[u8] =
+        static UNKNOWN_DATA: &[u8] =
             include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/unk.bin"));
-        const WORDS_IDX_DATA: &[u8] =
+        static WORDS_IDX_DATA: &[u8] =
             include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/dict.wordsidx"));
-        const WORDS_DATA: &[u8] =
+        static WORDS_DATA: &[u8] =
             include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/dict.words"));
-        const METADATA_DATA: &[u8] =
+        static METADATA_DATA: &[u8] =
             include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/metadata.json"));
 
         /// Loads the embedded dictionary from data baked into the binary.


### PR DESCRIPTION
`embedded_dictionary!` binds each dictionary file to a `const`:

```rust
const DA_DATA: &[u8] = include_bytes!(concat!(env!("LINDERA_WORKDIR"), $dir, "/dict.da"));
```

A `const` body is encoded into the crate's metadata, so every dictionary byte ends up in `lib.rmeta` at roughly 4x its size, and every downstream crate reads it back. The data is private to the generated `load()` and is never const-evaluated, so a `static` does the job at 1x.

Debug profile, with the three dictionaries embedded:

| crate | rmeta before | rmeta after | rlib before | rlib after |
|---|---|---|---|---|
| `lindera-ipadic` | 259.7 MB | 55.2 MB | 315.0 MB | 110.6 MB |
| `lindera-ko-dic` | 465.8 MB | 109.5 MB | 575.4 MB | 219.1 MB |
| `lindera-cc-cedict` | 102.0 MB | 27.6 MB | 129.6 MB | 55.4 MB |
| **total** | **827.5 MB** | **192.3 MB** | **1020.0 MB** | **385.1 MB** |

Metadata now matches the embedded payload exactly (192.3 MB of dictionary data, 192.3 MB of rmeta), where before it was 4.3x.

Reduced to a crate containing nothing but a 100 MB `include_bytes!`, to confirm the ratio comes from the declaration rather than anything specific to the dictionaries:

| | rlib | of which rmeta |
|---|---|---|
| `const DATA: &[u8]` | 487.5 MB | 387.5 MB |
| `static DATA: &[u8]` | 200.0 MB | 100.0 MB |

The linked output is unchanged — a release binary loading all three dictionaries is 194.8 MB either way, so this is purely build-time disk and I/O.

### Testing

`cargo test -p lindera -p lindera-dictionary -p lindera-analysis` with `embed-ipadic,embed-ko-dic,embed-cc-cedict` passes, including `mmap_dictionary_loading` and `lattice_reuse_across_dictionaries`, which exercise the embedded load path with debug assertions on — so `PrefixDictionary::load`'s `DaTrust::Trusted` invariant that the data arrives as `Data::Static` still holds. `cargo fmt --check` and `clippy -D warnings` are clean.