### PR TITLE
chore: bump version to 5.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-analysis"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "daachorse",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-binding-core"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera",
  "lindera-analysis",
@@ -1520,14 +1520,14 @@ dependencies = [
 
 [[package]]
 name = "lindera-cc-cedict"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-cli"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-crf"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1583,35 +1583,35 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-ipadic-neologd"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-jieba"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-ko-dic"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-nodejs"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-php"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ext-php-rs",
  "lindera",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-python"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-ruby"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-trainer"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "daachorse",
@@ -1676,14 +1676,14 @@ dependencies = [
 
 [[package]]
 name = "lindera-unidic"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-wasm"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "js-sys",
  "lindera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.0"
+version = "5.0.1"
 edition = "2024"
 description = "A morphological analysis libraries and command line interface."
 documentation = "https://docs.rs/lindera"
@@ -38,24 +38,24 @@ anyhow = "1.0.104"
 byteorder = "1.5.0"
 csv = "1.4.0"
 daachorse = "4.0.0"
-lindera = { version = "5.0.0", path = "lindera" }
-lindera-analysis = { version = "5.0.0", path = "lindera-analysis" }
-lindera-binding-core = { version = "5.0.0", path = "lindera-binding-core" }
-lindera-crf = { version = "5.0.0", path = "lindera-crf" }
-lindera-cc-cedict = { version = "5.0.0", path = "lindera-cc-cedict" }
-lindera-cli = { version = "5.0.0", path = "lindera-cli" }
-lindera-dictionary = { version = "5.0.0", path = "lindera-dictionary" }
-lindera-trainer = { version = "5.0.0", path = "lindera-trainer" }
-lindera-ipadic = { version = "5.0.0", path = "lindera-ipadic" }
-lindera-ipadic-neologd = { version = "5.0.0", path = "lindera-ipadic-neologd" }
-lindera-jieba = { version = "5.0.0", path = "lindera-jieba" }
-lindera-ko-dic = { version = "5.0.0", path = "lindera-ko-dic" }
-lindera-nodejs = { version = "5.0.0", path = "lindera-nodejs" }
-lindera-python = { version = "5.0.0", path = "lindera-python" }
-lindera-ruby = { version = "5.0.0", path = "lindera-ruby" }
-lindera-unidic = { version = "5.0.0", path = "lindera-unidic" }
-lindera-php = { version = "5.0.0", path = "lindera-php" }
-lindera-wasm = { version = "5.0.0", path = "lindera-wasm" }
+lindera = { version = "5.0.1", path = "lindera" }
+lindera-analysis = { version = "5.0.1", path = "lindera-analysis" }
+lindera-binding-core = { version = "5.0.1", path = "lindera-binding-core" }
+lindera-crf = { version = "5.0.1", path = "lindera-crf" }
+lindera-cc-cedict = { version = "5.0.1", path = "lindera-cc-cedict" }
+lindera-cli = { version = "5.0.1", path = "lindera-cli" }
+lindera-dictionary = { version = "5.0.1", path = "lindera-dictionary" }
+lindera-trainer = { version = "5.0.1", path = "lindera-trainer" }
+lindera-ipadic = { version = "5.0.1", path = "lindera-ipadic" }
+lindera-ipadic-neologd = { version = "5.0.1", path = "lindera-ipadic-neologd" }
+lindera-jieba = { version = "5.0.1", path = "lindera-jieba" }
+lindera-ko-dic = { version = "5.0.1", path = "lindera-ko-dic" }
+lindera-nodejs = { version = "5.0.1", path = "lindera-nodejs" }
+lindera-python = { version = "5.0.1", path = "lindera-python" }
+lindera-ruby = { version = "5.0.1", path = "lindera-ruby" }
+lindera-unidic = { version = "5.0.1", path = "lindera-unidic" }
+lindera-php = { version = "5.0.1", path = "lindera-php" }
+lindera-wasm = { version = "5.0.1", path = "lindera-wasm" }
 log = "0.4.33"
 num_cpus = "1.17.0"
 once_cell = "1.21.4"

--- a/docs/ja/src/lindera-wasm/tokenizer_api.md
+++ b/docs/ja/src/lindera-wasm/tokenizer_api.md
@@ -271,7 +271,7 @@ lindera-wasm パッケージのバージョン文字列を返します。
 ```javascript
 import { version } from 'lindera-wasm-web-ipadic';
 
-console.log(version()); // 例: "5.0.0"
+console.log(version()); // 例: "5.0.1"
 ```
 
 ## 列挙型とユーティリティクラス

--- a/docs/src/lindera-wasm/tokenizer_api.md
+++ b/docs/src/lindera-wasm/tokenizer_api.md
@@ -271,7 +271,7 @@ Returns the version string of the lindera-wasm package.
 ```javascript
 import { version } from 'lindera-wasm-web-ipadic';
 
-console.log(version()); // e.g., "5.0.0"
+console.log(version()); // e.g., "5.0.1"
 ```
 
 ## Enums and Utility Classes

--- a/lindera-nodejs/index.js
+++ b/lindera-nodejs/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-android-arm64')
         const bindingPackageVersion = require('lindera-nodejs-android-arm64/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-android-arm-eabi')
         const bindingPackageVersion = require('lindera-nodejs-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-win32-x64-gnu')
         const bindingPackageVersion = require('lindera-nodejs-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-win32-x64-msvc')
         const bindingPackageVersion = require('lindera-nodejs-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-win32-ia32-msvc')
         const bindingPackageVersion = require('lindera-nodejs-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-win32-arm64-msvc')
         const bindingPackageVersion = require('lindera-nodejs-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('lindera-nodejs-darwin-universal')
       const bindingPackageVersion = require('lindera-nodejs-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-darwin-x64')
         const bindingPackageVersion = require('lindera-nodejs-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-darwin-arm64')
         const bindingPackageVersion = require('lindera-nodejs-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-freebsd-x64')
         const bindingPackageVersion = require('lindera-nodejs-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-freebsd-arm64')
         const bindingPackageVersion = require('lindera-nodejs-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-x64-musl')
           const bindingPackageVersion = require('lindera-nodejs-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-x64-gnu')
           const bindingPackageVersion = require('lindera-nodejs-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-arm64-musl')
           const bindingPackageVersion = require('lindera-nodejs-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-arm64-gnu')
           const bindingPackageVersion = require('lindera-nodejs-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-arm-musleabihf')
           const bindingPackageVersion = require('lindera-nodejs-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-arm-gnueabihf')
           const bindingPackageVersion = require('lindera-nodejs-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-loong64-musl')
           const bindingPackageVersion = require('lindera-nodejs-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-loong64-gnu')
           const bindingPackageVersion = require('lindera-nodejs-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-riscv64-musl')
           const bindingPackageVersion = require('lindera-nodejs-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-riscv64-gnu')
           const bindingPackageVersion = require('lindera-nodejs-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-linux-ppc64-gnu')
         const bindingPackageVersion = require('lindera-nodejs-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-linux-s390x-gnu')
         const bindingPackageVersion = require('lindera-nodejs-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-openharmony-arm64')
         const bindingPackageVersion = require('lindera-nodejs-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-openharmony-x64')
         const bindingPackageVersion = require('lindera-nodejs-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-openharmony-arm')
         const bindingPackageVersion = require('lindera-nodejs-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '5.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('lindera-nodejs-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '5.0.0') {
-            throw new Error(`WASI binding package version mismatch, expected 5.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.0.1') {
+            throw new Error(`WASI binding package version mismatch, expected 5.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('lindera-nodejs-wasm32-wasi')

--- a/lindera-nodejs/package.json
+++ b/lindera-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lindera-nodejs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Node.js bindings for Lindera morphological analysis engine",
   "main": "index.js",
   "types": "index.d.ts",

--- a/lindera-ruby/lindera.gemspec
+++ b/lindera-ruby/lindera.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "lindera"
-  spec.version = "5.0.0"
+  spec.version = "5.0.1"
   spec.authors = ["Lindera contributors"]
   spec.summary = "Ruby bindings for Lindera morphological analysis engine"
   spec.description = "Ruby bindings for Lindera, a morphological analysis library for CJK text (Japanese, Korean, Chinese)."

--- a/lindera-wasm/example/package.json
+++ b/lindera-wasm/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lindera-wasm-example",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Example project for Lindera WASM",
   "scripts": {
     "start": "webpack serve --config webpack.config.js",


### PR DESCRIPTION
## Summary

- Bump workspace and all inter-crate dependency versions from 5.0.0 to 5.0.1
- Bump lindera-nodejs npm package, lindera-ruby gem, and lindera-wasm example package versions to 5.0.1
- Update version check strings in the generated lindera-nodejs entry point (`index.js`) to match the package version (napi-rs embeds the package.json version into the generated version checks)
- Update `version()` output examples in the WASM tokenizer API docs (en/ja)

Same structure as the previous version bump (#857), excluding its one-time README/migration doc changes.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -- -D warnings`: pass (all crates compile as 5.0.1, zero warnings)
- `cargo metadata --offline`: Cargo.lock is consistent with the updated manifests
- No remaining `5.0.0` references in version-bearing files (toml / json / js / gemspec / lock); `"5.0"` notations in README/installation docs need no change for a patch release