### PR TITLE
chore: cover all package ecosystems in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,73 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
+# Dependabot configuration for version updates.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:
+  # Rust workspace (single Cargo.lock at the repository root).
+  # Minor and patch updates are grouped into a single PR to reduce noise;
+  # major updates still get individual PRs for careful review.
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      cargo-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used in .github/workflows.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Node.js binding and WASM example (npm).
+  - package-ecosystem: npm
+    directories:
+      - /lindera-nodejs
+      - /lindera-wasm/example
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # Python binding (Poetry via the pip ecosystem).
+  - package-ecosystem: pip
+    directory: /lindera-python
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # PHP binding (Composer).
+  - package-ecosystem: composer
+    directory: /lindera-php
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # Ruby binding (Bundler; updates Gemfile and lindera.gemspec).
+  - package-ecosystem: bundler
+    directory: /lindera-ruby
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
## Background

The Dependabot configuration only covered `cargo` and `github-actions`, leaving the npm (`lindera-nodejs`, `lindera-wasm/example`), Poetry (`lindera-python`), Composer (`lindera-php`), and Bundler (`lindera-ruby`) manifests without version updates. (PR #788, which bumped `webpack-dev-server` in the WASM example, was a security update and did not require a version-update entry.)

Also, the `chore(deps):` commit message prefix relied on Dependabot inferring the convention from recent commit history rather than being configured explicitly.

## Changes

- Add version-update entries for the previously uncovered ecosystems (all weekly, since they are mostly dev dependencies):
  - `npm`: `/lindera-nodejs` and `/lindera-wasm/example` (single entry via `directories`)
  - `pip` (Poetry): `/lindera-python`
  - `composer`: `/lindera-php`
  - `bundler`: `/lindera-ruby` (Gemfile + gemspec)
- Group cargo minor/patch updates into a single PR to reduce noise (e.g. the napi-related burst of #836–#839); major updates still get individual PRs for careful review
- Group all GitHub Actions updates into a single PR
- Set the Conventional Commits message prefix explicitly (`chore` + scope → `chore(deps):` / `chore(deps-dev):`) instead of relying on Dependabot's convention detection
- Update the documentation link in the header comment

## Notes

- Grouped cargo PRs will be titled like "chore(deps): bump the cargo-minor-and-patch group with N updates" instead of one PR per dependency. Remove the `groups` section if per-dependency PRs are preferred.
- The `cargo` and `github-actions` schedules remain daily, as before.