### PR TITLE
chore: ignore NAPI platform packages in npm dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,12 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # NAPI-RS platform packages in optionalDependencies are 0.0.0
+      # placeholders in the repository; the release workflow rewrites
+      # them to the actual version at publish time. They must never be
+      # bumped in-repo.
+      - dependency-name: lindera-nodejs-*
 
   # Python binding (Poetry via the pip ecosystem).
   - package-ecosystem: pip


### PR DESCRIPTION
## Background

Enabling npm version updates in #861 caused Dependabot to open PRs #862–#866, bumping the `lindera-nodejs-*` `optionalDependencies` in `lindera-nodejs/package.json` from `0.0.0` to `4.0.1`.

Those entries are intentional placeholders: the release workflow rewrites them to the actual version at publish time (verified: the published `lindera-nodejs@5.0.1` on npm has all of them at `5.0.1`). Bumping them in the repository would break the release flow — and the proposed `4.0.1` is even older than the currently published `5.0.1`.

## Changes

- Add an `ignore` rule for `lindera-nodejs-*` to the npm update entry so Dependabot never touches the platform-package placeholders

PRs #862–#866 will be closed manually; with this rule merged, Dependabot will not recreate them.

Refs #861