### PR TITLE
perf(cli): buffer tokenize output instead of per-token println!

### DIFF
--- a/lindera-cli/src/commands/tokenize.rs
+++ b/lindera-cli/src/commands/tokenize.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -113,48 +113,105 @@ impl FromStr for Format {
     }
 }
 
-/// Writes tokens to stdout in the requested output format.
-fn write_output(format: Format, tokens: Vec<Token>) -> LinderaResult<()> {
+/// Writes tokens to the given writer in the requested output format.
+///
+/// # Arguments
+///
+/// * `writer` - The destination for the formatted output (typically a buffered stdout lock).
+/// * `format` - The output format to render the tokens in.
+/// * `tokens` - The tokens produced for one input line.
+/// * `details_buf` - A scratch buffer reused across tokens for joining detail fields.
+///
+/// # Returns
+///
+/// `Ok(())` on success, or an I/O / serialization error wrapped in `LinderaError`.
+fn write_output<W: Write>(
+    writer: &mut W,
+    format: Format,
+    tokens: Vec<Token>,
+    details_buf: &mut String,
+) -> LinderaResult<()> {
     match format {
-        Format::Mecab => mecab_output(tokens),
-        Format::Json => json_output(tokens),
-        Format::Wakati => wakati_output(tokens),
+        Format::Mecab => mecab_output(writer, tokens, details_buf),
+        Format::Json => json_output(writer, tokens),
+        Format::Wakati => wakati_output(writer, tokens),
     }
 }
 
-fn mecab_output(mut tokens: Vec<Token>) -> LinderaResult<()> {
+/// Writes tokens in the MeCab format: one `surface\tdetails` line per token,
+/// terminated by an `EOS` line.
+///
+/// # Arguments
+///
+/// * `writer` - The destination for the formatted output.
+/// * `tokens` - The tokens produced for one input line.
+/// * `details_buf` - A scratch buffer reused across tokens for joining detail fields.
+///
+/// # Returns
+///
+/// `Ok(())` on success, or an I/O error wrapped in `LinderaError`.
+fn mecab_output<W: Write>(
+    writer: &mut W,
+    mut tokens: Vec<Token>,
+    details_buf: &mut String,
+) -> LinderaResult<()> {
     for token in tokens.iter_mut() {
-        let details = token.details().join(",");
-        println!("{}\t{}", token.surface.as_ref(), details);
+        details_buf.clear();
+        for (i, detail) in token.details().iter().enumerate() {
+            if i > 0 {
+                details_buf.push(',');
+            }
+            details_buf.push_str(detail);
+        }
+        writeln!(writer, "{}\t{}", token.surface.as_ref(), details_buf).map_err(io_err)?;
     }
-    println!("EOS");
+    writeln!(writer, "EOS").map_err(io_err)?;
 
     Ok(())
 }
 
-fn json_output(mut tokens: Vec<Token>) -> LinderaResult<()> {
+/// Writes tokens as a pretty-printed JSON array of token objects.
+///
+/// # Arguments
+///
+/// * `writer` - The destination for the formatted output.
+/// * `tokens` - The tokens produced for one input line.
+///
+/// # Returns
+///
+/// `Ok(())` on success, or an I/O / serialization error wrapped in `LinderaError`.
+fn json_output<W: Write>(writer: &mut W, mut tokens: Vec<Token>) -> LinderaResult<()> {
     let mut json_tokens = Vec::new();
     for token in tokens.iter_mut() {
         let token_value = token.as_value();
         json_tokens.push(token_value);
     }
 
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&json_tokens)
-            .map_err(|err| { LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)) })?
-    );
+    serde_json::to_writer_pretty(&mut *writer, &json_tokens)
+        .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+    writeln!(writer).map_err(io_err)?;
 
     Ok(())
 }
 
-fn wakati_output(tokens: Vec<Token>) -> LinderaResult<()> {
+/// Writes tokens in the wakati format: surfaces separated by single spaces on
+/// one line.
+///
+/// # Arguments
+///
+/// * `writer` - The destination for the formatted output.
+/// * `tokens` - The tokens produced for one input line.
+///
+/// # Returns
+///
+/// `Ok(())` on success, or an I/O error wrapped in `LinderaError`.
+fn wakati_output<W: Write>(writer: &mut W, tokens: Vec<Token>) -> LinderaResult<()> {
     let mut it = tokens.iter().peekable();
     while let Some(token) = it.next() {
         if it.peek().is_some() {
-            print!("{} ", token.surface.as_ref());
+            write!(writer, "{} ", token.surface.as_ref()).map_err(io_err)?;
         } else {
-            println!("{}", token.surface.as_ref());
+            writeln!(writer, "{}", token.surface.as_ref()).map_err(io_err)?;
         }
     }
 
@@ -220,9 +277,19 @@ pub fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
     // buffers on each call.
     let mut lattice = Lattice::default();
 
+    // Buffer all output on a locked stdout: the default line-buffered stdout
+    // would otherwise issue one write syscall per output line.
+    let stdout = io::stdout();
+    let mut writer = BufWriter::new(stdout.lock());
+
+    // Reused across every line/token to avoid per-line and per-token
+    // reallocations.
+    let mut text = String::new();
+    let mut details_buf = String::new();
+
     loop {
         // read the text to be tokenized from stdin
-        let mut text = String::new();
+        text.clear();
         let size = reader.read_line(&mut text).map_err(io_err)?;
         if size == 0 {
             // EOS
@@ -238,14 +305,18 @@ pub fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
                 nbest_cost_threshold,
             )?;
             for (rank, (tokens, cost)) in results.into_iter().enumerate() {
-                println!("NBEST {} (cost={})", rank + 1, cost);
-                write_output(output_format, tokens)?;
+                writeln!(writer, "NBEST {} (cost={})", rank + 1, cost).map_err(io_err)?;
+                write_output(&mut writer, output_format, tokens, &mut details_buf)?;
             }
         } else {
             let tokens = tokenizer.tokenize_with_lattice(text.trim(), &mut lattice)?;
-            write_output(output_format, tokens)?;
+            write_output(&mut writer, output_format, tokens, &mut details_buf)?;
         }
     }
+
+    // Surface write errors instead of letting the implicit flush on drop
+    // swallow them.
+    writer.flush().map_err(io_err)?;
 
     Ok(())
 }

--- a/lindera-cli/tests/cli.rs
+++ b/lindera-cli/tests/cli.rs
@@ -134,6 +134,65 @@ mod with_ipadic {
     }
 
     #[test]
+    fn tokenize_mecab_output_exact_format() {
+        // Locks the exact MeCab output shape produced through the buffered
+        // writer: one `surface\tdetails` line per token, a terminating `EOS`
+        // line, and a trailing newline.
+        let output = lindera()
+            .args(["tokenize", "--dict", "embedded://ipadic"])
+            .write_stdin("関西国際空港限定トートバッグ\n")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.ends_with("EOS\n"), "got: {stdout}");
+        let lines: Vec<&str> = stdout.lines().collect();
+        assert_eq!(lines.len(), 4, "3 tokens + EOS, got: {stdout}");
+        assert!(lines[0].starts_with("関西国際空港\t"), "got: {stdout}");
+        for line in &lines[..3] {
+            let (_, details) = line
+                .split_once('\t')
+                .expect("token line must contain a tab");
+            assert!(
+                details.contains(','),
+                "details must be comma-joined, got: {line}"
+            );
+        }
+        assert_eq!(lines[3], "EOS");
+    }
+
+    #[test]
+    fn tokenize_multiline_input_keeps_per_line_order() {
+        // Output for multiple input lines must arrive complete and in order
+        // through the buffered writer, with one EOS per input line.
+        let output = lindera()
+            .args(["tokenize", "--dict", "embedded://ipadic"])
+            .write_stdin("すもももももももものうち\n関西国際空港\n")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(stdout.matches("EOS\n").count(), 2, "got: {stdout}");
+        let first_segment = stdout.split("EOS\n").next().unwrap();
+        assert!(first_segment.contains("すもも\t"), "got: {stdout}");
+        assert!(!first_segment.contains("関西国際空港"), "got: {stdout}");
+    }
+
+    #[test]
+    fn tokenize_nbest_headers() {
+        let output = lindera()
+            .args(["tokenize", "--dict", "embedded://ipadic", "--nbest", "2"])
+            .write_stdin("関西国際空港\n")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(stdout.starts_with("NBEST 1 (cost="), "got: {stdout}");
+        assert!(stdout.contains("\nNBEST 2 (cost="), "got: {stdout}");
+        assert!(stdout.ends_with("EOS\n"), "got: {stdout}");
+    }
+
+    #[test]
     fn tokenize_with_mmap_flag_parses_and_output_is_unchanged() {
         // --mmap has no effect on an embedded:// dictionary, but the flag
         // must still parse and produce identical output.


### PR DESCRIPTION
## Summary

The tokenize command printed each token with `println!` on Rust's line-buffered stdout, issuing **one write syscall per output line** (strace: 69,971 writes for one pass of bocchan.txt; Vibrato's tokenize CLI: 892). This PR routes all output through a `BufWriter` around a locked stdout and removes the remaining per-line/per-token allocations in the output path:

- All four output functions (`write_output`/`mecab_output`/`json_output`/`wakati_output`) are generic over `&mut W: Write`; `tokenize()` locks stdout once, wraps it in a `BufWriter`, routes everything (including `NBEST k (cost=...)` headers) through it, and flushes explicitly so write errors surface as `LinderaResult` instead of being swallowed by the implicit flush on drop.
- The mecab `details().join(",")` per-token `String` allocation is replaced with a reused scratch buffer; the input line `String` is hoisted out of the read loop; `json_output` uses `serde_json::to_writer_pretty` (identical bytes, no intermediate `String`).

CLI-only change; no library code touched.

## Verification

- **Golden output**: byte-identical (`cmp`) to the pre-change binary (`0ac51302`) over bocchan.txt with a locally built IPADIC dictionary: mecab, wakati, json, mecab + `--keep-whitespace`, `--nbest 3`.
- **Syscalls**: 69,971 → **888** writes (~1/79).
- **Benchmark** (5 MB input, mecab → /dev/null, alternating A/B after warmup, quiet machine): min-of-5 **1.07 s → 0.84 s (−21.5%)**, faster in all 5 rounds. Meets the ≥15% acceptance criterion of #876.
- **Tests**: 3 new integration tests (exact mecab line shape + terminating EOS, multi-line per-line EOS ordering, NBEST header format) in the existing `assert_cmd` + `embed-ipadic`-gated suite; `cargo test -p lindera-cli --features embed-ipadic --test cli` 12 passed; fmt and clippy (`--all-targets -D warnings`, default and `embed-ipadic`) clean.

Closes #876
Refs #875
