### PR TITLE
perf(dictionary): epoch-stamp the char category cache instead of rebuilding it per sentence

### DIFF
--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -317,7 +317,14 @@ pub struct Lattice {
     ends_at: Vec<Vec<Edge>>, // Now stores edges directly
     char_info_buffer: Vec<CharData>,
     categories_buffer: Vec<CategoryId>,
-    char_category_cache: Vec<Vec<CategoryId>>,
+    /// Lazily-filled per-codepoint category cache for codepoints < 256.
+    /// Entries are validated per slot against `char_category_cache_epoch`,
+    /// so invalidation is O(1) and the per-slot buffers are reused across
+    /// sentences instead of being freed and reallocated (#878).
+    char_category_cache: Vec<CharCategoryCacheSlot>,
+    /// Current generation of `char_category_cache`; bumped by `clear()` to
+    /// invalidate every slot at once.
+    char_category_cache_epoch: u64,
 
     // N-Best fields (only populated when set_text_nbest is called)
     all_paths: Vec<Vec<PathEntry>>,
@@ -332,6 +339,16 @@ pub struct Lattice {
     matches_head: Vec<usize>,
     /// Linked-list node pool: (match end offset, word entry, next node index).
     matches_store: Vec<(usize, WordEntry, usize)>,
+}
+
+/// One entry of `Lattice::char_category_cache`.
+#[derive(Clone, Default)]
+struct CharCategoryCacheSlot {
+    /// Generation this entry was filled at; the entry is stale whenever this
+    /// differs from `Lattice::char_category_cache_epoch`.
+    epoch: u64,
+    /// Cached categories for the codepoint (possibly empty).
+    categories: Vec<CategoryId>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -396,8 +413,10 @@ impl Lattice {
         // dictionaries, the cache must be invalidated every call rather than
         // persisting across `set_text`/`set_text_nbest` invocations -- an
         // ASCII codepoint's `CategoryId` is not portable between
-        // dictionaries with different char.def category orderings.
-        self.char_category_cache.clear();
+        // dictionaries with different char.def category orderings. Bumping
+        // the generation invalidates every slot in O(1) while keeping the
+        // per-slot buffers allocated for reuse (#878).
+        self.char_category_cache_epoch += 1;
     }
 
     #[inline]
@@ -458,21 +477,24 @@ impl Lattice {
         self.categories_buffer.clear();
 
         if self.char_category_cache.is_empty() {
-            self.char_category_cache.resize(256, Vec::new());
+            // Allocated once per lattice lifetime; clear() only bumps the
+            // epoch, so this vector and its per-slot buffers persist.
+            self.char_category_cache
+                .resize_with(256, CharCategoryCacheSlot::default);
         }
 
         for (byte_offset, c) in text.char_indices() {
             let categories_start = self.categories_buffer.len() as u32;
 
             if (c as u32) < 256 {
-                let cached = &mut self.char_category_cache[c as usize];
-                if cached.is_empty() {
-                    let cats = char_definitions.lookup_categories(c);
-                    for &category in cats {
-                        cached.push(category);
-                    }
+                let slot = &mut self.char_category_cache[c as usize];
+                if slot.epoch != self.char_category_cache_epoch {
+                    slot.categories.clear();
+                    slot.categories
+                        .extend_from_slice(char_definitions.lookup_categories(c));
+                    slot.epoch = self.char_category_cache_epoch;
                 }
-                for &category in cached.iter() {
+                for &category in slot.categories.iter() {
                     self.categories_buffer.push(category);
                 }
             } else {
@@ -1019,21 +1041,24 @@ impl Lattice {
         self.categories_buffer.clear();
 
         if self.char_category_cache.is_empty() {
-            self.char_category_cache.resize(256, Vec::new());
+            // Allocated once per lattice lifetime; clear() only bumps the
+            // epoch, so this vector and its per-slot buffers persist.
+            self.char_category_cache
+                .resize_with(256, CharCategoryCacheSlot::default);
         }
 
         for (byte_offset, c) in text.char_indices() {
             let categories_start = self.categories_buffer.len() as u32;
 
             if (c as u32) < 256 {
-                let cached = &mut self.char_category_cache[c as usize];
-                if cached.is_empty() {
-                    let cats = char_definitions.lookup_categories(c);
-                    for &category in cats {
-                        cached.push(category);
-                    }
+                let slot = &mut self.char_category_cache[c as usize];
+                if slot.epoch != self.char_category_cache_epoch {
+                    slot.categories.clear();
+                    slot.categories
+                        .extend_from_slice(char_definitions.lookup_categories(c));
+                    slot.epoch = self.char_category_cache_epoch;
                 }
-                for &category in cached.iter() {
+                for &category in slot.categories.iter() {
                     self.categories_buffer.push(category);
                 }
             } else {
@@ -1399,6 +1424,41 @@ mod tests {
         assert_eq!(offsets.len(), 1);
         assert_eq!(offsets[0].0, 0);
         assert_eq!(offsets[0].1, WordId::new(LexType::System, 42));
+    }
+
+    /// Regression test for #878 stage 1: `clear()` must invalidate every
+    /// `char_category_cache` slot (epoch bump) without freeing the slot
+    /// buffers or shrinking the 256-entry vector — the per-sentence
+    /// dealloc/rebuild churn is what this change removes.
+    #[test]
+    fn test_char_category_cache_epoch_invalidates_without_dealloc() {
+        use crate::dictionary::character_definition::CategoryId;
+
+        let mut lattice = Lattice::default();
+        lattice.set_capacity(3); // clear() runs -> epoch moves past slot default (0)
+        lattice
+            .char_category_cache
+            .resize_with(256, Default::default);
+
+        // Fill one slot as the preprocessing pass would.
+        let epoch = lattice.char_category_cache_epoch;
+        let slot = &mut lattice.char_category_cache[b'a' as usize];
+        slot.categories.push(CategoryId(5));
+        slot.epoch = epoch;
+        let capacity_before = slot.categories.capacity();
+        assert!(capacity_before > 0);
+
+        lattice.clear();
+
+        // Logically stale (cross-dictionary safety) ...
+        let slot = &lattice.char_category_cache[b'a' as usize];
+        assert_ne!(
+            slot.epoch, lattice.char_category_cache_epoch,
+            "slot must be stale after clear()"
+        );
+        // ... but physically intact: no dealloc, no header rewrite.
+        assert_eq!(slot.categories.capacity(), capacity_before);
+        assert_eq!(lattice.char_category_cache.len(), 256);
     }
 
     /// `tokens_offset_into` must clear the caller's buffer and produce the


### PR DESCRIPTION
## Summary

Stage 1 of #878. `Lattice::clear()` dropped all 256 inner `Vec`s of `char_category_cache` every sentence, and the next `set_text` re-ran `resize(256, Vec::new())` — a full dealloc/rebuild cycle per sentence (~4% of library tokenize time on short-sentence text) even though per-sentence invalidation is only needed *logically* (CategoryIds are not portable across dictionaries with different char.def orderings).

- Each cache slot now carries a generation stamp (`CharCategoryCacheSlot { epoch, categories }`) and the `Lattice` keeps a current-epoch counter: `clear()` bumps the epoch (O(1)), a slot is stale whenever its stamp differs, and the 256-slot vector plus per-slot buffers are allocated once per lattice lifetime and reused.
- Cross-dictionary semantics are unchanged — logical invalidation still happens every sentence. The derived `Default` stays safe because `clear()` always runs (via `set_capacity`) before the cache is consulted, moving the epoch past the all-zero slot stamps. Applied to both the `set_text` and `set_text_nbest` fill sites.

(Originally stacked on #884, now rebased onto `main` after its merge.)

## Verification

- **Cross-dictionary guard**: `lattice_reuse_across_dictionaries` (embed-ipadic + embed-ko-dic) passes unchanged.
- **Golden output**: CLI rebuilt on this branch is byte-identical (`cmp`) to `main` over bocchan.txt (mecab, wakati, `--keep-whitespace`, `--nbest 3`).
- **Benchmark** (interleaved vs the #884-content binary to isolate this stage, 4 alternating rounds × min-of-10, path-loaded IPADIC, quiet machine): bocchan.txt 21.76 ms → 20.26 ms (**−6.9%**), faster in all 4 rounds. Cumulative vs `main` (with #884): 24.27 ms → 20.26 ms (**−16.5%**).
- **Tests**: new dictionary-free unit test asserting slots go stale by epoch while buffers stay physically intact; red-verified against both a removed epoch bump and the old deallocating `clear()`. fmt / clippy (`--all-targets -D warnings`) clean; `cargo test -p lindera-dictionary` green.

Stage 2 (flat packed CharInfo table) stays open on #878.

Refs #878
Refs #875
