### PR TITLE
perf(dictionary): O(1) BMP char category lookup via a flat load-time table

### DIFF
--- a/lindera-dictionary/src/builder/character_definition.rs
+++ b/lindera-dictionary/src/builder/character_definition.rs
@@ -244,11 +244,7 @@ impl CharacterDefinitionBuilder {
             category_names[category_id.0] = category_name.clone();
         }
         let mapping = self.build_lookup_table();
-        CharacterDefinition {
-            category_definitions: self.category_definition.clone(),
-            category_names,
-            mapping,
-        }
+        CharacterDefinition::new(self.category_definition.clone(), category_names, mapping)
     }
 
     pub fn build(

--- a/lindera-dictionary/src/dictionary/character_definition.rs
+++ b/lindera-dictionary/src/dictionary/character_definition.rs
@@ -61,15 +61,98 @@ impl<T: Copy + Clone> LookupTable<T> {
     }
 }
 
+/// Number of codepoints covered by the flat category table (the Basic
+/// Multilingual Plane).
+const FLAT_TABLE_LEN: usize = 0x10000;
+
+/// Maximum categories per codepoint representable in a packed `flat_index`
+/// entry (8 bits of length).
+const FLAT_MAX_ROW_LEN: usize = 0xFF;
+
+/// Maximum pool offset representable in a packed `flat_index` entry (24 bits).
+const FLAT_MAX_OFFSET: usize = (1 << 24) - 1;
+
 #[derive(Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
 
 pub struct CharacterDefinition {
     pub category_definitions: Vec<CategoryData>,
     pub category_names: Vec<String>,
     pub mapping: LookupTable<CategoryId>,
+    /// Concatenation of the `mapping` rows in row order; the backing pool
+    /// sliced by `flat_index`. Runtime-only: skipped by serde and rkyv (a
+    /// trailing zero-sized member in the archived layout), rebuilt at load.
+    #[serde(skip)]
+    #[rkyv(with = ::rkyv::with::Skip)]
+    flat_categories: Vec<CategoryId>,
+    /// Per-BMP-codepoint packed `offset << 8 | len` into `flat_categories`,
+    /// `FLAT_TABLE_LEN` entries; empty when the table is not built, in which
+    /// case lookups fall back to the `mapping` binary search. Runtime-only:
+    /// skipped by serde and rkyv, rebuilt at load.
+    #[serde(skip)]
+    #[rkyv(with = ::rkyv::with::Skip)]
+    flat_index: Vec<u32>,
 }
 
 impl CharacterDefinition {
+    /// Creates a definition from its parsed parts and builds the flat
+    /// BMP category table.
+    ///
+    /// # Arguments
+    ///
+    /// * `category_definitions` - Per-category invoke/group/length flags.
+    /// * `category_names` - Category names in `CategoryId` order.
+    /// * `mapping` - Codepoint-range to category-set lookup table.
+    ///
+    /// # Returns
+    ///
+    /// A `CharacterDefinition` ready for O(1) BMP category lookups.
+    pub fn new(
+        category_definitions: Vec<CategoryData>,
+        category_names: Vec<String>,
+        mapping: LookupTable<CategoryId>,
+    ) -> Self {
+        let mut definition = CharacterDefinition {
+            category_definitions,
+            category_names,
+            mapping,
+            flat_categories: Vec::new(),
+            flat_index: Vec::new(),
+        };
+        definition.build_flat_table();
+        definition
+    }
+
+    /// Builds the flat BMP category table from `mapping`.
+    ///
+    /// Leaves the table empty (falling back to the binary search) if a row
+    /// exceeds the packed-entry limits, which no real char.def can reach.
+    fn build_flat_table(&mut self) {
+        let mut pool: Vec<CategoryId> = Vec::new();
+        // One packed (offset, len) per mapping row, in row order.
+        let mut packed_rows: Vec<u32> = Vec::with_capacity(self.mapping.values.len());
+        for row in &self.mapping.values {
+            let offset = pool.len();
+            if row.len() > FLAT_MAX_ROW_LEN || offset > FLAT_MAX_OFFSET {
+                return;
+            }
+            pool.extend_from_slice(row);
+            packed_rows.push(((offset as u32) << 8) | row.len() as u32);
+        }
+
+        let mut index = Vec::with_capacity(FLAT_TABLE_LEN);
+        for cp in 0..FLAT_TABLE_LEN as u32 {
+            let row_idx = self
+                .mapping
+                .boundaries
+                .binary_search(&cp)
+                .unwrap_or_else(|val| val - 1);
+            index.push(packed_rows[row_idx]);
+        }
+
+        self.flat_categories = pool;
+        self.flat_index = index;
+    }
+
     pub fn categories(&self) -> &[String] {
         &self.category_names[..]
     }
@@ -77,9 +160,13 @@ impl CharacterDefinition {
     pub fn load(char_def_data: &[u8]) -> LinderaResult<CharacterDefinition> {
         let mut aligned = rkyv::util::AlignedVec::<16>::new();
         aligned.extend_from_slice(char_def_data);
-        rkyv::from_bytes::<CharacterDefinition, rkyv::rancor::Error>(&aligned).map_err(|err| {
-            LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err.to_string()))
-        })
+        let mut definition = rkyv::from_bytes::<CharacterDefinition, rkyv::rancor::Error>(&aligned)
+            .map_err(|err| {
+                LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err.to_string()))
+            })?;
+        // The flat table is not serialized; rebuild it after deserialization.
+        definition.build_flat_table();
+        Ok(definition)
     }
 
     pub fn lookup_definition(&self, category_id: CategoryId) -> &CategoryData {
@@ -98,13 +185,25 @@ impl CharacterDefinition {
     }
 
     pub fn lookup_categories(&self, c: char) -> &[CategoryId] {
-        self.mapping.eval(c as u32)
+        let cp = c as u32;
+        if (cp as usize) < FLAT_TABLE_LEN && !self.flat_index.is_empty() {
+            // O(1) fast path: one indexed load plus a slice into the pool,
+            // returning exactly the slice the binary search would.
+            let packed = self.flat_index[cp as usize];
+            let offset = (packed >> 8) as usize;
+            let len = (packed & 0xFF) as usize;
+            &self.flat_categories[offset..offset + len]
+        } else {
+            self.mapping.eval(cp)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::dictionary::character_definition::LookupTable;
+    use crate::dictionary::character_definition::{
+        CategoryData, CategoryId, CharacterDefinition, LookupTable,
+    };
 
     #[test]
     fn test_lookup_table() {
@@ -120,6 +219,80 @@ mod tests {
             let mut v = Vec::default();
             funct(i, &mut v);
             assert_eq!(lookup_table.eval(i), &v[..]);
+        }
+    }
+
+    /// Builds a small multi-category definition whose ranges cross the
+    /// codepoint space, including a multi-category row and a boundary
+    /// beyond the BMP.
+    fn test_definition() -> CharacterDefinition {
+        let mapping = LookupTable::from_fn(
+            vec![0u32, 0x80, 0x3040, 0x4E00, 0x20000],
+            &|c, buff: &mut Vec<CategoryId>| {
+                if c >= 0x20000 {
+                    buff.push(CategoryId(3));
+                } else if c >= 0x4E00 {
+                    // Multi-category row: order must be preserved.
+                    buff.push(CategoryId(2));
+                    buff.push(CategoryId(1));
+                } else if c >= 0x3040 {
+                    buff.push(CategoryId(1));
+                } else if c >= 0x80 {
+                    buff.push(CategoryId(3));
+                } else {
+                    buff.push(CategoryId(0));
+                }
+            },
+        );
+        let categories = vec![
+            CategoryData {
+                invoke: false,
+                group: true,
+                length: 0,
+            };
+            4
+        ];
+        let names = vec!["A".into(), "B".into(), "C".into(), "D".into()];
+        CharacterDefinition::new(categories, names, mapping)
+    }
+
+    /// Regression test for #878 stage 2: the flat BMP table must return
+    /// exactly the slice (contents and order) the binary search returns,
+    /// for every codepoint including the astral fallback.
+    #[test]
+    fn test_flat_table_matches_binary_search_for_all_chars() {
+        let definition = test_definition();
+        assert!(
+            !definition.flat_index.is_empty(),
+            "flat table should be built"
+        );
+        for cp in 0..=0x10FFFFu32 {
+            let Some(c) = char::from_u32(cp) else {
+                continue; // surrogate range
+            };
+            assert_eq!(
+                definition.lookup_categories(c),
+                definition.mapping.eval(cp),
+                "mismatch at U+{cp:04X}"
+            );
+        }
+    }
+
+    /// Regression test for #878 stage 2: the flat table is skipped during
+    /// serialization and rebuilt by `load()`, and lookups survive the
+    /// round-trip unchanged.
+    #[test]
+    fn test_flat_table_rebuilt_after_rkyv_round_trip() {
+        let definition = test_definition();
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&definition).unwrap();
+        let reloaded = CharacterDefinition::load(&bytes).unwrap();
+        assert!(!reloaded.flat_index.is_empty(), "load() must rebuild");
+        for cp in [0u32, 0x41, 0x80, 0x3042, 0x4E8C, 0xFFFF, 0x20B9F] {
+            let c = char::from_u32(cp).unwrap();
+            assert_eq!(
+                reloaded.lookup_categories(c),
+                definition.lookup_categories(c)
+            );
         }
     }
 }

--- a/lindera-dictionary/src/dictionary/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/dictionary/connection_cost_matrix.rs
@@ -81,6 +81,23 @@ impl ConnectionCostMatrix {
         }
     }
 
+    /// Returns the contiguous cost row for a fixed backward (right-context)
+    /// id, so callers relaxing many forward ids against the same backward id
+    /// pay the offset computation and bounds check once.
+    ///
+    /// # Arguments
+    ///
+    /// * `backward_id` - The backward context id selecting the row.
+    ///
+    /// # Returns
+    ///
+    /// A `forward_size`-long slice indexed directly by forward context id.
+    #[inline]
+    pub fn row(&self, backward_id: u32) -> &[i16] {
+        let start = (backward_id * self.forward_size) as usize;
+        &self.costs_data[start..start + self.forward_size as usize]
+    }
+
     #[inline]
     pub fn cost(&self, forward_id: u32, backward_id: u32) -> i32 {
         // Context-id access profiling (feature `ctxfreq`); compiled out by default.

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -317,14 +317,6 @@ pub struct Lattice {
     ends_at: Vec<Vec<Edge>>, // Now stores edges directly
     char_info_buffer: Vec<CharData>,
     categories_buffer: Vec<CategoryId>,
-    /// Lazily-filled per-codepoint category cache for codepoints < 256.
-    /// Entries are validated per slot against `char_category_cache_epoch`,
-    /// so invalidation is O(1) and the per-slot buffers are reused across
-    /// sentences instead of being freed and reallocated (#878).
-    char_category_cache: Vec<CharCategoryCacheSlot>,
-    /// Current generation of `char_category_cache`; bumped by `clear()` to
-    /// invalidate every slot at once.
-    char_category_cache_epoch: u64,
 
     // N-Best fields (only populated when set_text_nbest is called)
     all_paths: Vec<Vec<PathEntry>>,
@@ -339,16 +331,6 @@ pub struct Lattice {
     matches_head: Vec<usize>,
     /// Linked-list node pool: (match end offset, word entry, next node index).
     matches_store: Vec<(usize, WordEntry, usize)>,
-}
-
-/// One entry of `Lattice::char_category_cache`.
-#[derive(Clone, Default)]
-struct CharCategoryCacheSlot {
-    /// Generation this entry was filled at; the entry is stale whenever this
-    /// differs from `Lattice::char_category_cache_epoch`.
-    epoch: u64,
-    /// Cached categories for the codepoint (possibly empty).
-    categories: Vec<CategoryId>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -407,16 +389,6 @@ impl Lattice {
         );
         self.char_info_buffer.clear();
         self.categories_buffer.clear();
-        // `char_category_cache` is keyed only by codepoint, with no identity
-        // of the `CharacterDefinition` it was filled from. Since a `Lattice`
-        // can be reused across `Segmenter`s built from different
-        // dictionaries, the cache must be invalidated every call rather than
-        // persisting across `set_text`/`set_text_nbest` invocations -- an
-        // ASCII codepoint's `CategoryId` is not portable between
-        // dictionaries with different char.def category orderings. Bumping
-        // the generation invalidates every slot in O(1) while keeping the
-        // per-slot buffers allocated for reuse (#878).
-        self.char_category_cache_epoch += 1;
     }
 
     #[inline]
@@ -476,32 +448,15 @@ impl Lattice {
         self.char_info_buffer.clear();
         self.categories_buffer.clear();
 
-        if self.char_category_cache.is_empty() {
-            // Allocated once per lattice lifetime; clear() only bumps the
-            // epoch, so this vector and its per-slot buffers persist.
-            self.char_category_cache
-                .resize_with(256, CharCategoryCacheSlot::default);
-        }
-
         for (byte_offset, c) in text.char_indices() {
             let categories_start = self.categories_buffer.len() as u32;
 
-            if (c as u32) < 256 {
-                let slot = &mut self.char_category_cache[c as usize];
-                if slot.epoch != self.char_category_cache_epoch {
-                    slot.categories.clear();
-                    slot.categories
-                        .extend_from_slice(char_definitions.lookup_categories(c));
-                    slot.epoch = self.char_category_cache_epoch;
-                }
-                for &category in slot.categories.iter() {
-                    self.categories_buffer.push(category);
-                }
-            } else {
-                let categories = char_definitions.lookup_categories(c);
-                for &category in categories {
-                    self.categories_buffer.push(category);
-                }
+            // Category lookup is O(1) for BMP codepoints via the flat table
+            // built at dictionary load (#878), so no per-lattice cache is
+            // needed.
+            let categories = char_definitions.lookup_categories(c);
+            for &category in categories {
+                self.categories_buffer.push(category);
             }
 
             let categories_len = (self.categories_buffer.len() as u32 - categories_start) as u16;
@@ -1040,32 +995,15 @@ impl Lattice {
         self.char_info_buffer.clear();
         self.categories_buffer.clear();
 
-        if self.char_category_cache.is_empty() {
-            // Allocated once per lattice lifetime; clear() only bumps the
-            // epoch, so this vector and its per-slot buffers persist.
-            self.char_category_cache
-                .resize_with(256, CharCategoryCacheSlot::default);
-        }
-
         for (byte_offset, c) in text.char_indices() {
             let categories_start = self.categories_buffer.len() as u32;
 
-            if (c as u32) < 256 {
-                let slot = &mut self.char_category_cache[c as usize];
-                if slot.epoch != self.char_category_cache_epoch {
-                    slot.categories.clear();
-                    slot.categories
-                        .extend_from_slice(char_definitions.lookup_categories(c));
-                    slot.epoch = self.char_category_cache_epoch;
-                }
-                for &category in slot.categories.iter() {
-                    self.categories_buffer.push(category);
-                }
-            } else {
-                let categories = char_definitions.lookup_categories(c);
-                for &category in categories {
-                    self.categories_buffer.push(category);
-                }
+            // Category lookup is O(1) for BMP codepoints via the flat table
+            // built at dictionary load (#878), so no per-lattice cache is
+            // needed.
+            let categories = char_definitions.lookup_categories(c);
+            for &category in categories {
+                self.categories_buffer.push(category);
             }
 
             let categories_len = (self.categories_buffer.len() as u32 - categories_start) as u16;
@@ -1424,41 +1362,6 @@ mod tests {
         assert_eq!(offsets.len(), 1);
         assert_eq!(offsets[0].0, 0);
         assert_eq!(offsets[0].1, WordId::new(LexType::System, 42));
-    }
-
-    /// Regression test for #878 stage 1: `clear()` must invalidate every
-    /// `char_category_cache` slot (epoch bump) without freeing the slot
-    /// buffers or shrinking the 256-entry vector — the per-sentence
-    /// dealloc/rebuild churn is what this change removes.
-    #[test]
-    fn test_char_category_cache_epoch_invalidates_without_dealloc() {
-        use crate::dictionary::character_definition::CategoryId;
-
-        let mut lattice = Lattice::default();
-        lattice.set_capacity(3); // clear() runs -> epoch moves past slot default (0)
-        lattice
-            .char_category_cache
-            .resize_with(256, Default::default);
-
-        // Fill one slot as the preprocessing pass would.
-        let epoch = lattice.char_category_cache_epoch;
-        let slot = &mut lattice.char_category_cache[b'a' as usize];
-        slot.categories.push(CategoryId(5));
-        slot.epoch = epoch;
-        let capacity_before = slot.categories.capacity();
-        assert!(capacity_before > 0);
-
-        lattice.clear();
-
-        // Logically stale (cross-dictionary safety) ...
-        let slot = &lattice.char_category_cache[b'a' as usize];
-        assert_ne!(
-            slot.epoch, lattice.char_category_cache_epoch,
-            "slot must be stale after clear()"
-        );
-        // ... but physically intact: no dealloc, no header rewrite.
-        assert_eq!(slot.categories.capacity(), capacity_before);
-        assert_eq!(lattice.char_category_cache.len(), 256);
     }
 
     /// `tokens_offset_into` must clear the caller's buffer and produce the

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -327,11 +327,18 @@ pub struct Lattice {
     // Scratch buffers for the Aho-Corasick match pre-scan in set_text/set_text_nbest.
     // Reused across calls (like the fields above) instead of being reallocated per
     // call, since set_text runs once per sentence rather than once per document.
-    /// Linked-list head table: matches_head[start_idx] -> index into matches_store.
-    matches_head: Vec<usize>,
+    /// Linked-list head table: matches_head[start_idx] -> index into
+    /// matches_store; u32::MAX terminates a list (#880 shrank the element
+    /// widths to halve the per-sentence refill and walk traffic).
+    matches_head: Vec<u32>,
     /// Linked-list node pool: (match end offset, word entry, next node index).
-    matches_store: Vec<(usize, WordEntry, usize)>,
+    matches_store: Vec<(u32, WordEntry, u32)>,
 }
+
+/// Upper bound applied to every stored `path_cost` so the relaxation loops
+/// can use plain addition: one connection cost plus one penalty per step is
+/// at most 2 * 32,767, which cannot overflow from this clamp.
+const PATH_COST_CLAMP: i32 = i32::MAX - 131_072;
 
 #[derive(Clone, Copy, Debug, Default)]
 struct CharData {
@@ -507,51 +514,52 @@ impl Lattice {
         // contents are meaningful, unlike ends_at's empty-Vec slots) and clear
         // matches_store (a plain append-only pool).
         self.matches_head.clear();
-        self.matches_head.resize(len + 1, usize::MAX);
+        self.matches_head.resize(len + 1, u32::MAX);
         self.matches_store.clear();
 
         // System dictionary scan
+        let vals: &[u8] = &dict.vals_data;
         for m in dict.da.find_overlapping_iter(text) {
             let start = m.start();
             let (offset, count) = dict.decode_val(m.value());
             let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
             // Bounds check for safety, though daachorse should guarantee valid ids if built correctly
-            if offset_bytes < dict.vals_data.len() {
-                let data_slice = &dict.vals_data[offset_bytes..];
-                for i in 0..count {
-                    let entry_offset = WordEntry::SERIALIZED_LEN * (i as usize);
-                    if entry_offset + WordEntry::SERIALIZED_LEN <= data_slice.len() {
-                        let entry = WordEntry::deserialize(&data_slice[entry_offset..], true);
-                        if start < self.matches_head.len() {
-                            let next = self.matches_head[start];
-                            self.matches_head[start] = self.matches_store.len();
-                            self.matches_store.push((m.end(), entry, next));
-                        }
-                    }
+            if start < self.matches_head.len() {
+                // Take the valid prefix of the entry block with one bounds
+                // computation instead of a length check per entry (#880).
+                let avail = vals.len().saturating_sub(offset_bytes);
+                let n = (count as usize).min(avail / WordEntry::SERIALIZED_LEN);
+                let block = &vals[offset_bytes..offset_bytes + n * WordEntry::SERIALIZED_LEN];
+                let end = m.end() as u32;
+                for chunk in block.chunks_exact(WordEntry::SERIALIZED_LEN) {
+                    let entry = WordEntry::deserialize(chunk, true);
+                    let next = self.matches_head[start];
+                    self.matches_head[start] = self.matches_store.len() as u32;
+                    self.matches_store.push((end, entry, next));
                 }
             }
         }
 
         // User dictionary scan
         if let Some(ud) = user_dict {
+            let ud_vals: &[u8] = &ud.vals_data;
             for m in ud.da.find_overlapping_iter(text) {
                 let start = m.start();
                 let (offset, count) = ud.decode_val(m.value());
                 let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
-                if offset_bytes < ud.vals_data.len() {
-                    let data_slice = &ud.vals_data[offset_bytes..];
-                    for i in 0..count {
-                        let entry_offset = WordEntry::SERIALIZED_LEN * (i as usize);
-                        if entry_offset + WordEntry::SERIALIZED_LEN <= data_slice.len() {
-                            let entry = WordEntry::deserialize(&data_slice[entry_offset..], false);
-                            if start < self.matches_head.len() {
-                                let next = self.matches_head[start];
-                                self.matches_head[start] = self.matches_store.len();
-                                self.matches_store.push((m.end(), entry, next));
-                            }
-                        }
+                if start < self.matches_head.len() {
+                    let avail = ud_vals.len().saturating_sub(offset_bytes);
+                    let n = (count as usize).min(avail / WordEntry::SERIALIZED_LEN);
+                    let block =
+                        &ud_vals[offset_bytes..offset_bytes + n * WordEntry::SERIALIZED_LEN];
+                    let end = m.end() as u32;
+                    for chunk in block.chunks_exact(WordEntry::SERIALIZED_LEN) {
+                        let entry = WordEntry::deserialize(chunk, false);
+                        let next = self.matches_head[start];
+                        self.matches_head[start] = self.matches_store.len() as u32;
+                        self.matches_store.push((end, entry, next));
                     }
                 }
             }
@@ -571,14 +579,16 @@ impl Lattice {
             // Use cached matches
             if start < self.matches_head.len() {
                 let mut match_idx = self.matches_head[start];
-                while match_idx != usize::MAX {
-                    let (end, word_entry, next) = self.matches_store[match_idx];
+                while match_idx != u32::MAX {
+                    let (end, word_entry, next) = self.matches_store[match_idx as usize];
 
-                    let prefix_len = end - start;
+                    let prefix_len = end as usize - start;
                     let kanji_only = self.is_kanji_all(char_idx, prefix_len);
                     let edge = Self::create_edge(
                         word_entry, // WordEntry is Copy
-                        start, end, kanji_only,
+                        start,
+                        end as usize,
+                        kanji_only,
                     );
                     self.add_edge_in_lattice(edge, cost_matrix, search_mode);
                     found = true;
@@ -618,16 +628,15 @@ impl Lattice {
                 stop_index: len as u32,
                 ..Default::default()
             };
-            // Calculate cost for EOS
+            // Calculate cost for EOS with the row hoisted (#880).
             let left_edges = &self.ends_at[len];
             let mut best_cost = i32::MAX;
             let mut best_left = None;
-            let right_left_id = 0; // EOS default left_id
+            let cost_row = cost_matrix.row(0); // EOS default left_id
 
             for (i, left_edge) in left_edges.iter().enumerate() {
-                let left_right_id = left_edge.word_entry.right_id();
-                let conn_cost = cost_matrix.cost(left_right_id, right_left_id);
-                let path_cost = left_edge.path_cost.saturating_add(conn_cost);
+                let path_cost =
+                    left_edge.path_cost + cost_row[left_edge.word_entry.right_id() as usize] as i32;
                 if path_cost < best_cost {
                     best_cost = path_cost;
                     best_left = Some(i as u16);
@@ -709,8 +718,7 @@ impl Lattice {
         let stop_index = edge.stop_index as usize;
         let right_left_id = edge.word_entry.left_id();
 
-        let left_edges = &self.ends_at[start_index];
-        if left_edges.is_empty() {
+        if self.ends_at[start_index].is_empty() {
             return;
         }
 
@@ -719,10 +727,13 @@ impl Lattice {
 
         match mode {
             Mode::Normal => {
+                // Matrix row hoisted out of the loop; the plain additions
+                // cannot overflow thanks to PATH_COST_CLAMP (#880).
+                let left_edges = &self.ends_at[start_index];
+                let cost_row = cost_matrix.row(right_left_id);
                 for (i, left_edge) in left_edges.iter().enumerate() {
-                    let left_right_id = left_edge.word_entry.right_id();
-                    let conn_cost = cost_matrix.cost(left_right_id, right_left_id);
-                    let total_cost = left_edge.path_cost.saturating_add(conn_cost);
+                    let conn_cost = cost_row[left_edge.word_entry.right_id() as usize] as i32;
+                    let total_cost = left_edge.path_cost + conn_cost;
 
                     if total_cost < best_cost {
                         best_cost = total_cost;
@@ -731,6 +742,7 @@ impl Lattice {
                 }
             }
             Mode::Decompose(penalty) => {
+                let left_edges = &self.ends_at[start_index];
                 for (i, left_edge) in left_edges.iter().enumerate() {
                     let left_right_id = left_edge.word_entry.right_id();
                     let conn_cost = cost_matrix.cost(left_right_id, right_left_id);
@@ -749,7 +761,9 @@ impl Lattice {
         }
 
         if let Some(best_left_idx) = best_left {
-            edge.path_cost = best_cost.saturating_add(edge.word_entry.word_cost as i32);
+            edge.path_cost = best_cost
+                .saturating_add(edge.word_entry.word_cost as i32)
+                .min(PATH_COST_CLAMP);
             edge.left_index = best_left_idx;
             self.ends_at[stop_index].push(edge);
         }
@@ -853,8 +867,7 @@ impl Lattice {
         let stop_index = edge.stop_index as usize;
         let right_left_id = edge.word_entry.left_id();
 
-        let left_edges = &self.ends_at[start_index];
-        if left_edges.is_empty() {
+        if self.ends_at[start_index].is_empty() {
             return;
         }
 
@@ -866,10 +879,12 @@ impl Lattice {
 
         match mode {
             Mode::Normal => {
-                for (i, left_edge) in left_edges.iter().enumerate() {
-                    let left_right_id = left_edge.word_entry.right_id();
-                    let conn_cost = cost_matrix.cost(left_right_id, right_left_id);
-                    let total_cost = left_edge.path_cost.saturating_add(conn_cost);
+                // Same hoisted-row scan as add_edge_in_lattice (#880).
+                let cost_row = cost_matrix.row(right_left_id);
+                for i in 0..self.ends_at[start_index].len() {
+                    let left_edge = &self.ends_at[start_index][i];
+                    let total_cost = left_edge.path_cost
+                        + cost_row[left_edge.word_entry.right_id() as usize] as i32;
 
                     // Record ALL transitions for N-Best
                     self.all_paths[stop_index].push(PathEntry {
@@ -886,7 +901,8 @@ impl Lattice {
                 }
             }
             Mode::Decompose(penalty) => {
-                for (i, left_edge) in left_edges.iter().enumerate() {
+                for i in 0..self.ends_at[start_index].len() {
+                    let left_edge = &self.ends_at[start_index][i];
                     let left_right_id = left_edge.word_entry.right_id();
                     let conn_cost = cost_matrix.cost(left_right_id, right_left_id);
                     let penalty_cost = penalty.penalty(left_edge);
@@ -912,7 +928,9 @@ impl Lattice {
         }
 
         if let Some(best_left_idx) = best_left {
-            edge.path_cost = best_cost.saturating_add(edge.word_entry.word_cost as i32);
+            edge.path_cost = best_cost
+                .saturating_add(edge.word_entry.word_cost as i32)
+                .min(PATH_COST_CLAMP);
             edge.left_index = best_left_idx;
             self.ends_at[stop_index].push(edge);
         }
@@ -1051,50 +1069,51 @@ impl Lattice {
         // contents are meaningful, unlike ends_at's empty-Vec slots) and clear
         // matches_store (a plain append-only pool).
         self.matches_head.clear();
-        self.matches_head.resize(len + 1, usize::MAX);
+        self.matches_head.resize(len + 1, u32::MAX);
         self.matches_store.clear();
 
         // System dictionary scan
+        let vals: &[u8] = &dict.vals_data;
         for m in dict.da.find_overlapping_iter(text) {
             let start = m.start();
             let (offset, count) = dict.decode_val(m.value());
             let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
-            if offset_bytes < dict.vals_data.len() {
-                let data_slice = &dict.vals_data[offset_bytes..];
-                for i in 0..count {
-                    let entry_offset = WordEntry::SERIALIZED_LEN * (i as usize);
-                    if entry_offset + WordEntry::SERIALIZED_LEN <= data_slice.len() {
-                        let entry = WordEntry::deserialize(&data_slice[entry_offset..], true);
-                        if start < self.matches_head.len() {
-                            let next = self.matches_head[start];
-                            self.matches_head[start] = self.matches_store.len();
-                            self.matches_store.push((m.end(), entry, next));
-                        }
-                    }
+            if start < self.matches_head.len() {
+                // Take the valid prefix of the entry block with one bounds
+                // computation instead of a length check per entry (#880).
+                let avail = vals.len().saturating_sub(offset_bytes);
+                let n = (count as usize).min(avail / WordEntry::SERIALIZED_LEN);
+                let block = &vals[offset_bytes..offset_bytes + n * WordEntry::SERIALIZED_LEN];
+                let end = m.end() as u32;
+                for chunk in block.chunks_exact(WordEntry::SERIALIZED_LEN) {
+                    let entry = WordEntry::deserialize(chunk, true);
+                    let next = self.matches_head[start];
+                    self.matches_head[start] = self.matches_store.len() as u32;
+                    self.matches_store.push((end, entry, next));
                 }
             }
         }
 
         // User dictionary scan
         if let Some(ud) = user_dict {
+            let ud_vals: &[u8] = &ud.vals_data;
             for m in ud.da.find_overlapping_iter(text) {
                 let start = m.start();
                 let (offset, count) = ud.decode_val(m.value());
                 let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
 
-                if offset_bytes < ud.vals_data.len() {
-                    let data_slice = &ud.vals_data[offset_bytes..];
-                    for i in 0..count {
-                        let entry_offset = WordEntry::SERIALIZED_LEN * (i as usize);
-                        if entry_offset + WordEntry::SERIALIZED_LEN <= data_slice.len() {
-                            let entry = WordEntry::deserialize(&data_slice[entry_offset..], false);
-                            if start < self.matches_head.len() {
-                                let next = self.matches_head[start];
-                                self.matches_head[start] = self.matches_store.len();
-                                self.matches_store.push((m.end(), entry, next));
-                            }
-                        }
+                if start < self.matches_head.len() {
+                    let avail = ud_vals.len().saturating_sub(offset_bytes);
+                    let n = (count as usize).min(avail / WordEntry::SERIALIZED_LEN);
+                    let block =
+                        &ud_vals[offset_bytes..offset_bytes + n * WordEntry::SERIALIZED_LEN];
+                    let end = m.end() as u32;
+                    for chunk in block.chunks_exact(WordEntry::SERIALIZED_LEN) {
+                        let entry = WordEntry::deserialize(chunk, false);
+                        let next = self.matches_head[start];
+                        self.matches_head[start] = self.matches_store.len() as u32;
+                        self.matches_store.push((end, entry, next));
                     }
                 }
             }
@@ -1111,12 +1130,12 @@ impl Lattice {
 
             if start < self.matches_head.len() {
                 let mut match_idx = self.matches_head[start];
-                while match_idx != usize::MAX {
-                    let (end, word_entry, next) = self.matches_store[match_idx];
+                while match_idx != u32::MAX {
+                    let (end, word_entry, next) = self.matches_store[match_idx as usize];
 
-                    let prefix_len = end - start;
+                    let prefix_len = end as usize - start;
                     let kanji_only = self.is_kanji_all(char_idx, prefix_len);
-                    let edge = Self::create_edge(word_entry, start, end, kanji_only);
+                    let edge = Self::create_edge(word_entry, start, end as usize, kanji_only);
                     self.add_edge_in_lattice_nbest(edge, cost_matrix, search_mode);
                     found = true;
 
@@ -1155,15 +1174,14 @@ impl Lattice {
                 stop_index: len as u32,
                 ..Default::default()
             };
-            let left_edges = &self.ends_at[len];
             let mut best_cost = i32::MAX;
             let mut best_left = None;
-            let right_left_id = 0; // EOS default left_id
+            let cost_row = cost_matrix.row(0); // EOS default left_id
 
-            for (i, left_edge) in left_edges.iter().enumerate() {
-                let left_right_id = left_edge.word_entry.right_id();
-                let conn_cost = cost_matrix.cost(left_right_id, right_left_id);
-                let path_cost = left_edge.path_cost.saturating_add(conn_cost);
+            for i in 0..self.ends_at[len].len() {
+                let left_edge = &self.ends_at[len][i];
+                let path_cost =
+                    left_edge.path_cost + cost_row[left_edge.word_entry.right_id() as usize] as i32;
 
                 // Record all transitions to EOS
                 self.all_paths[len].push(PathEntry {

--- a/lindera-trainer/src/config.rs
+++ b/lindera-trainer/src/config.rs
@@ -477,11 +477,11 @@ impl TrainerConfig {
             buff.push(CategoryId(0));
         });
 
-        Ok(CharacterDefinition {
+        Ok(CharacterDefinition::new(
             category_definitions,
             category_names,
             mapping,
-        })
+        ))
     }
 
     fn build_unknown_dict_from_content(


### PR DESCRIPTION
## Summary

Stage 2 of #878. Rebased onto `main` after #885/#888 merged. **This PR now also carries the #887 commit** (matrix-row hoist + match-buffer shrink, reviewed and merged into this branch as PR #887), since #887 was based here; merging this PR lands both.

Every category lookup for a codepoint >= 256 (all CJK) ran a binary search over the char.def range boundaries plus a `Vec<Vec>` pointer chase — per char per sentence in `set_text`/`set_text_nbest`, and per non-Latin-1 char in the segmenter's whitespace recheck.

- A flat table is built at dictionary load: the `LookupTable` rows are concatenated into one category pool (row order preserved exactly) and a 65,536-entry index packs `offset << 8 | len` per BMP codepoint, so `lookup_categories` becomes one indexed load + slice returning exactly the slice the binary search would. Astral codepoints (and packing-limit overflow, impossible for real char.def files) fall back to the binary search.
- The two new `CharacterDefinition` fields are private and skipped by both serde and rkyv (trailing zero-sized member in the archived layout) — **the on-disk `char_def.bin` format is unchanged**. `load()` rebuilds the table after deserialization; a new `CharacterDefinition::new()` does the same for the builder and trainer construction sites. Note: adding private fields removes out-of-workspace struct-literal construction (both in-workspace literals migrated; real users load from binary).
- The stage-1 per-lattice epoch cache is deleted (fields, struct, unit test): the lattice no longer caches categories at all and the `< 256` special case disappears from both fill sites.

## Verification

- **Prebuilt-bytes compatibility**: a dictionary built before this change loads and produces byte-identical CLI output (`cmp`: mecab, wakati, `--keep-whitespace`, `--nbest 3` over bocchan.txt); `lattice_reuse_across_dictionaries` with embedded (downloaded prebuilt) IPADIC + ko-dic passes unchanged.
- **Tests**: exhaustive equivalence of the flat path vs `mapping.eval` for every `char` (incl. astral fallback and a multi-category row whose order must be preserved); rkyv round-trip proving `load()` rebuilds the skipped table. Both red-verified. `cargo test -p lindera-dictionary` 53 passed; fmt/clippy (`-D warnings`, incl. trainer) clean.
- **Benchmark** (interleaved vs the stage-1 binary, 4 alternating rounds × min-of-10, path-loaded IPADIC, quiet machine): bocchan.txt 19.66 ms → 17.97 ms (**−8.6%**), faster in all rounds. **Cumulative vs `main`: 24.27 ms → 17.97 ms (−26.0%)** for #884 + #885 + this PR.

Closes #878
Closes #880
Refs #875
