### PR TITLE
perf(dictionary): default to mmap loading when compiled in and finish Arc-wrapping Dictionary

### DIFF
--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -43,9 +43,9 @@ pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec!["UNK"]);
 pub struct Dictionary {
     pub prefix_dictionary: Arc<PrefixDictionary>,
     pub connection_cost_matrix: Arc<ConnectionCostMatrix>,
-    pub character_definition: CharacterDefinition,
-    pub unknown_dictionary: UnknownDictionary,
-    pub metadata: Metadata,
+    pub character_definition: Arc<CharacterDefinition>,
+    pub unknown_dictionary: Arc<UnknownDictionary>,
+    pub metadata: Arc<Metadata>,
 }
 
 impl Dictionary {
@@ -89,9 +89,14 @@ impl Dictionary {
         details
     }
 
-    /// Load dictionary from a directory containing dictionary files
+    /// Load dictionary from a directory containing dictionary files.
+    ///
+    /// When the `mmap` feature is compiled in, the connection-cost matrix
+    /// and word list are routed through memory-mapped reads by default
+    /// (#879); use [`Dictionary::load_from_path_with_options`] with
+    /// `use_mmap = false` to force eager reads.
     pub fn load_from_path(dict_path: &Path) -> LinderaResult<Self> {
-        Self::load_from_path_with_options(dict_path, false)
+        Self::load_from_path_with_options(dict_path, cfg!(feature = "mmap"))
     }
 
     /// Load dictionary from a directory with options
@@ -158,9 +163,9 @@ impl Dictionary {
         Ok(Dictionary {
             prefix_dictionary: Arc::new(prefix_dictionary),
             connection_cost_matrix: Arc::new(connection_cost_matrix),
-            character_definition,
-            unknown_dictionary,
-            metadata,
+            character_definition: Arc::new(character_definition),
+            unknown_dictionary: Arc::new(unknown_dictionary),
+            metadata: Arc::new(metadata),
         })
     }
 

--- a/lindera-dictionary/src/macros.rs
+++ b/lindera-dictionary/src/macros.rs
@@ -73,9 +73,9 @@ macro_rules! embedded_dictionary {
             Ok($crate::dictionary::Dictionary {
                 prefix_dictionary: ::std::sync::Arc::new(prefix_dictionary),
                 connection_cost_matrix: ::std::sync::Arc::new(connection_cost_matrix),
-                character_definition,
-                unknown_dictionary,
-                metadata,
+                character_definition: ::std::sync::Arc::new(character_definition),
+                unknown_dictionary: ::std::sync::Arc::new(unknown_dictionary),
+                metadata: ::std::sync::Arc::new(metadata),
             })
         }
 

--- a/lindera-nodejs/src/dictionary.rs
+++ b/lindera-nodejs/src/dictionary.rs
@@ -39,7 +39,7 @@ impl JsDictionary {
     /// Returns the full metadata object of the dictionary.
     #[napi]
     pub fn metadata(&self) -> JsMetadata {
-        JsMetadata::from(self.inner.metadata.clone())
+        JsMetadata::from((*self.inner.metadata).clone())
     }
 }
 

--- a/lindera-php/src/dictionary.rs
+++ b/lindera-php/src/dictionary.rs
@@ -162,7 +162,7 @@ impl PhpDictionary {
     ///
     /// A Metadata instance.
     pub fn metadata(&self) -> PhpMetadata {
-        PhpMetadata::from(self.inner.metadata.clone())
+        PhpMetadata::from((*self.inner.metadata).clone())
     }
 
     /// Returns a string representation.

--- a/lindera-python/src/dictionary.rs
+++ b/lindera-python/src/dictionary.rs
@@ -70,7 +70,7 @@ impl PyDictionary {
 
     /// Returns the full metadata object of the dictionary.
     pub fn metadata(&self) -> PyMetadata {
-        PyMetadata::from(self.inner.metadata.clone())
+        PyMetadata::from((*self.inner.metadata).clone())
     }
 
     fn __str__(&self) -> String {

--- a/lindera-ruby/src/dictionary.rs
+++ b/lindera-ruby/src/dictionary.rs
@@ -52,7 +52,7 @@ impl RbDictionary {
     ///
     /// The dictionary metadata.
     fn metadata(&self) -> RbMetadata {
-        RbMetadata::from(self.inner.metadata.clone())
+        RbMetadata::from((*self.inner.metadata).clone())
     }
 
     /// Returns the string representation.

--- a/lindera-trainer/src/config.rs
+++ b/lindera-trainer/src/config.rs
@@ -348,9 +348,9 @@ impl TrainerConfig {
         Ok(Dictionary {
             prefix_dictionary: Arc::new(prefix_dict),
             connection_cost_matrix: Arc::new(conn_matrix),
-            character_definition: char_def,
-            unknown_dictionary: unknown_dict,
-            metadata: Metadata::default(),
+            character_definition: Arc::new(char_def),
+            unknown_dictionary: Arc::new(unknown_dict),
+            metadata: Arc::new(Metadata::default()),
         })
     }
 

--- a/lindera-wasm/src/dictionary.rs
+++ b/lindera-wasm/src/dictionary.rs
@@ -36,7 +36,7 @@ impl JsDictionary {
 
     #[wasm_bindgen(getter)]
     pub fn metadata(&self) -> JsMetadata {
-        JsMetadata::from(self.inner.metadata.clone())
+        JsMetadata::from((*self.inner.metadata).clone())
     }
 }
 
@@ -138,9 +138,9 @@ pub fn load_dictionary_from_bytes(
     let dict = Dictionary {
         prefix_dictionary: Arc::new(prefix_dictionary),
         connection_cost_matrix: Arc::new(connection_cost_matrix),
-        character_definition,
-        unknown_dictionary,
-        metadata: meta,
+        character_definition: Arc::new(character_definition),
+        unknown_dictionary: Arc::new(unknown_dictionary),
+        metadata: Arc::new(meta),
     };
 
     Ok(JsDictionary { inner: dict })

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -249,7 +249,7 @@ pub fn resolve_embedded_loader(
 ///
 /// A `Dictionary`, or an error if loading fails.
 pub fn load_fs_dictionary(path: &Path) -> LinderaResult<Dictionary> {
-    load_fs_dictionary_with_options(path, false)
+    load_fs_dictionary_with_options(path, cfg!(feature = "mmap"))
 }
 
 /// Load a dictionary from a filesystem directory, optionally via
@@ -300,7 +300,7 @@ pub fn load_embedded_dictionary(kind: DictionaryKind) -> LinderaResult<Dictionar
 ///
 /// A `Dictionary`, or an error if the URI is invalid or loading fails.
 pub fn load_dictionary(uri: &str) -> LinderaResult<Dictionary> {
-    load_dictionary_with_options(uri, false)
+    load_dictionary_with_options(uri, cfg!(feature = "mmap"))
 }
 
 /// Load a dictionary from a URI (`embedded://<kind>`, `file://<path>`) or a

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -224,11 +224,13 @@ impl Segmenter {
     /// user dictionary loading, or tokenization process.
     pub fn from_config(config: &SegmenterConfig) -> LinderaResult<Self> {
         // Whether to route filesystem-loaded dictionaries through memory-mapped
-        // reads. Ignored for `embedded://` dictionaries. Default is false.
+        // reads. Ignored for `embedded://` dictionaries. Defaults to on when
+        // the `mmap` feature is compiled in (#879); set `"use_mmap": false`
+        // to force eager reads.
         let use_mmap = config
             .get("use_mmap")
             .and_then(Value::as_bool)
-            .unwrap_or(false);
+            .unwrap_or(cfg!(feature = "mmap"));
 
         // Load the dictionary from the config
         let dictionary = load_dictionary_with_options(

--- a/lindera/tests/mmap_dictionary_loading.rs
+++ b/lindera/tests/mmap_dictionary_loading.rs
@@ -16,7 +16,9 @@ use lindera_dictionary::dictionary::metadata::Metadata;
 
 const CHAR_DEF: &str = "\
 DEFAULT 0 1 0
+SPACE 0 1 0
 KANJI 0 0 2
+0x0020 SPACE
 0x4E00..0x9FFF KANJI
 ";
 
@@ -117,4 +119,73 @@ fn mmap_loading_matches_plain_loading_via_uri() {
 fn mmap_flag_is_ignored_for_embedded_dictionaries() {
     let result = load_dictionary_with_options("embedded://ipadic", true);
     assert!(result.is_ok());
+}
+
+/// Regression test for #879: the no-option loaders default to mmap when the
+/// `mmap` feature is compiled in, and the default must produce output
+/// identical to both explicit modes.
+#[test]
+fn default_load_matches_both_explicit_modes() {
+    use lindera::dictionary::load_fs_dictionary;
+
+    let dict = build_dictionary();
+
+    let default_dictionary = load_fs_dictionary(dict.path()).expect("default load should succeed");
+    let segmenter = Segmenter::new(Mode::Normal, default_dictionary, None);
+    let mut tokens = segmenter.segment(Cow::Borrowed("東京都")).unwrap();
+    let default_result: Vec<(String, String)> = tokens
+        .iter_mut()
+        .map(|t| {
+            let pos = t.get_detail(0).unwrap_or("").to_string();
+            (t.surface.to_string(), pos)
+        })
+        .collect();
+
+    assert_eq!(default_result, segment(dict.path(), "東京都", false));
+    assert_eq!(default_result, segment(dict.path(), "東京都", true));
+}
+
+/// Regression test for #879: `Segmenter::from_config` without a `use_mmap`
+/// key must load a filesystem dictionary with the feature-dependent default.
+#[test]
+fn from_config_without_use_mmap_defaults_and_segments() {
+    let dict = build_dictionary();
+
+    let config = serde_json::json!({
+        "dictionary": dict.path().to_str().unwrap(),
+        "mode": "normal",
+    });
+    let segmenter = Segmenter::from_config(&config).expect("from_config should succeed");
+    let tokens = segmenter.segment(Cow::Borrowed("東京都")).unwrap();
+    let surfaces: Vec<_> = tokens.into_iter().map(|t| t.surface.to_string()).collect();
+    assert_eq!(surfaces, vec!["東京".to_string(), "都".to_string()]);
+}
+
+/// Regression test for #879: `Dictionary::clone` must be fully O(1) --
+/// every field is Arc-shared, not deep-copied.
+#[test]
+fn dictionary_clone_shares_all_fields() {
+    use std::sync::Arc;
+
+    let dict_dir = build_dictionary();
+    let dictionary = load_fs_dictionary_with_options(dict_dir.path(), false).unwrap();
+    let cloned = dictionary.clone();
+
+    assert!(Arc::ptr_eq(
+        &dictionary.prefix_dictionary,
+        &cloned.prefix_dictionary
+    ));
+    assert!(Arc::ptr_eq(
+        &dictionary.connection_cost_matrix,
+        &cloned.connection_cost_matrix
+    ));
+    assert!(Arc::ptr_eq(
+        &dictionary.character_definition,
+        &cloned.character_definition
+    ));
+    assert!(Arc::ptr_eq(
+        &dictionary.unknown_dictionary,
+        &cloned.unknown_dictionary
+    ));
+    assert!(Arc::ptr_eq(&dictionary.metadata, &cloned.metadata));
 }

--- a/lindera/tests/user_dictionary_context_id_remap.rs
+++ b/lindera/tests/user_dictionary_context_id_remap.rs
@@ -205,6 +205,7 @@ fn built_metadata_carries_the_context_id_map() {
     let map = dictionary
         .metadata
         .context_id_map
+        .clone()
         .expect("a remapped build must persist its context-ID map");
 
     // Ranked by the histogram: 3 -> 1, 2 -> 2, 1 -> 3, with 0 pinned.


### PR DESCRIPTION
## Summary

Two follow-ups to #840 and #831 (candidate C14 of #875):

- **mmap by default when compiled in**: the no-option loaders (`load_dictionary`, `load_fs_dictionary`, `Dictionary::load_from_path`) and `Segmenter::from_config`'s `use_mmap` default flip from hard-coded `false` to `cfg!(feature = "mmap")` — so compiled-in mmap support (default-on for `lindera` and the CLI) is actually used for filesystem dictionaries. Explicit `_with_options(..., false)` / `"use_mmap": false` still forces eager reads; `embedded://` URIs keep ignoring the flag.
- **Arc completion**: `Dictionary`'s remaining three fields (`character_definition`, `unknown_dictionary`, `metadata`) become `Arc<...>`, making `Dictionary::clone` fully O(1). Construction sites wrapped (loader, embedded macro, trainer, wasm builder); the five bindings' metadata conversion clones the inner value explicitly; read paths are covered by deref coercion.

### Release-note draft (behavior change)

> Filesystem dictionary loads are now memory-mapped by default when the `mmap` feature is enabled (it is enabled by default for `lindera` and the CLI). This reduces peak RSS (~−21% for a CLI tokenize pass with IPADIC) and defers reading the word-details files until first use. Rebuilding or truncating a dictionary directory while a process holds it mapped can cause a SIGBUS on the next lookup — the same trade-off the `--mmap` CLI flag has always documented. Opt out with `use_mmap = false` (config) or the `_with_options` APIs. `Dictionary`'s `character_definition`, `unknown_dictionary`, and `metadata` public fields are now `Arc`-wrapped (same class of change as #831).

## Verification

- **Golden**: CLI output over bocchan.txt with a filesystem IPADIC (now taking the mmap default) is byte-identical to `main` (mecab, wakati, `--nbest 3`).
- **RSS**: peak resident set for one CLI tokenize pass **77.0 MB → 60.7 MB (−21%)**; throughput sanity (3 interleaved rounds, 5 MB input) shows no regression.
- **New tests** (self-contained fixture-dictionary suite in `mmap_dictionary_loading.rs`): default load matches both explicit modes; `from_config` without `use_mmap` loads a filesystem dictionary; `Dictionary::clone` shares all five fields by `Arc::ptr_eq`. The fixture char.def gains a SPACE category (required by `from_config`). All existing mmap/remap/golden suites green.
- fmt / clippy (`-D warnings`, incl. all five bindings) clean; full workspace builds with `--features train`.

Closes #879
Refs #875
