### PR TITLE
feat(release): add musl builds for Linux CLI binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,6 +379,14 @@ jobs:
             target: aarch64-unknown-linux-gnu
             archive: .zip
             extension: ""
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            archive: .zip
+            extension: ""
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            archive: .zip
+            extension: ""
           - runner: macos-latest
             target: aarch64-apple-darwin
             archive: .zip
@@ -416,6 +424,13 @@ jobs:
       - name: Add msbuild to PATH
         if: startsWith(matrix.platform.runner, 'windows')
         uses: microsoft/setup-msbuild@v3
+
+      # lindera-cli is pure Rust, so rustc's self-contained linking can build the musl
+      # targets without an external musl toolchain. Install musl-tools anyway so the
+      # build keeps working if a C dependency is ever introduced.
+      - name: Install musl tools
+        if: endsWith(matrix.platform.target, '-musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Compile
         run: cargo build -p lindera-cli --release --target=${{ matrix.platform.target }}


### PR DESCRIPTION
## Summary

Add musl builds for the Linux release binaries. Two targets are added to the `build` job matrix in `.github/workflows/release.yml`, publishing fully statically linked CLI binaries alongside the existing glibc ones:

- `x86_64-unknown-linux-musl` (ubuntu-latest)
- `aarch64-unknown-linux-musl` (ubuntu-24.04-arm, same native arm64 runner as the existing gnu entry)

Artifacts follow the existing naming convention (`lindera-<target>-vX.Y.Z.zip`) and are uploaded by the unchanged Unix archive/upload steps.

## Details

- `lindera-cli` has no `-sys` crates in its dependency tree (pure Rust), so rustc's self-contained linking builds the musl targets without an external musl toolchain
- `musl-tools` is installed only for musl targets (`if: endsWith(matrix.platform.target, '-musl')`) as a safeguard in case a C dependency is ever introduced; the rationale is recorded as a comment in the workflow
- No documentation update is needed — the docs do not enumerate target triples

## Verification

- Local build on x86_64 Linux (without musl-gcc) succeeded with default features (`mmap` + `train`):
  `cargo build -p lindera-cli --release --target x86_64-unknown-linux-musl`
- The resulting binary is `static-pie linked` (`ldd`: statically linked) and `lindera --version` prints `lindera 5.1.0`
- Workflow YAML parses successfully
- `aarch64-unknown-linux-musl` could not be verified locally (x86_64 host, no cross linker), but CI runs it on a native arm64 runner — the same configuration (native host + self-contained linking) as the verified x86_64 case. It can be confirmed with a `workflow_dispatch` run before the next tag if desired

## Notes

- `release.yml` is triggered by tag pushes / `workflow_dispatch`, so this change is not exercised by PR CI; the first real run happens on the next release

Closes #891
