### PR TITLE
feat(cli): add download subcommand for pre-built dictionaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,13 +10,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -242,6 +242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,11 +424,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -474,6 +484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +505,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -522,10 +544,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -623,6 +660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +694,15 @@ name = "ctor"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
 
 [[package]]
 name = "daachorse"
@@ -726,9 +781,42 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "zeroize",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1128,11 +1216,11 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1150,6 +1238,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1304,11 +1401,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1533,10 +1630,15 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "dirs",
+ "flate2",
  "lindera",
  "lindera-analysis",
  "num_cpus",
  "serde_json",
+ "tempfile",
+ "ureq",
+ "zip",
 ]
 
 [[package]]
@@ -2030,6 +2132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,11 +2178,11 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest",
+ "digest 0.11.3",
  "hmac",
 ]
 
@@ -2433,6 +2541,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,13 +2831,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2728,8 +2847,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3779,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.5.1"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "aes",
  "bzip2",

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ lindera = "5.0"
 
 Pre-built dictionaries are available from [GitHub Releases](https://github.com/lindera/lindera/releases).
 Download a dictionary archive (e.g. `lindera-ipadic-*.zip`) and specify the path when loading.
+When using the CLI, `lindera download ipadic` downloads and installs a dictionary automatically.
 
 ## Python Bindings
 

--- a/docs/ja/src/lindera-cli/commands.md
+++ b/docs/ja/src/lindera-cli/commands.md
@@ -1,10 +1,11 @@
 # コマンド
 
-Lindera CLI は5つのメインコマンドを提供します：
+Lindera CLI は6つのメインコマンドを提供します：
 
 - **list** - バイナリに埋め込まれた形態素解析辞書の一覧を表示
 - **tokenize** - テキストに対して形態素解析を実行
 - **build** - ソースCSVファイルから辞書をビルド
+- **download** - GitHub リリースページから学習済み辞書をダウンロード
 - **train** - 注釈付きコーパスデータからCRFモデルを学習
 - **export** - 学習済みモデルを辞書フォーマットにエクスポート
 
@@ -34,9 +35,10 @@ ipadic
 
 ### パラメータ
 
-- `--dict` / `-d`: 辞書のパスまたはURI（必須）
+- `--dict` / `-d`: 辞書のパス、URI、またはダウンロード済み辞書名（必須）
   - ファイルパス: `/path/to/dictionary`
   - 埋め込み: `embedded://ipadic`, `embedded://unidic`, etc.
+  - ダウンロード済み辞書名: `ipadic`, `unidic` など。`lindera download` でインストールした辞書に解決されます。同名のファイルパスが実在する場合はパスが優先されます。
 - `--output` / `-o`: 出力形式 (デフォルト: mecab)
   - `mecab`: 品詞情報を含むMeCab互換形式
   - `wakati`: スペース区切りのトークンのみ
@@ -747,6 +749,58 @@ Linderaで使用するための形態素解析辞書をCSVソースファイル�
   --metadata ./lindera-ko-dic/metadata.json \
   --user
 ```
+
+## download
+
+CLI と同じバージョンの学習済み辞書アーカイブを [GitHub リリースページ](https://github.com/lindera/lindera/releases)からダウンロードし、OS 標準のアプリケーションデータディレクトリにインストールします。
+
+### download パラメータ
+
+- 辞書名（必須）: `ipadic`, `ipadic-neologd`, `unidic`, `ko-dic`, `cc-cedict`, `jieba` のいずれか
+- `--force`: 既存の辞書を再ダウンロードして置き換える
+
+### 保存場所
+
+辞書はバージョン付きレイアウト `<データディレクトリ>/dictionaries/<バージョン>/lindera-<辞書名>/` にインストールされます。OS ごとのデフォルトのベースディレクトリ：
+
+| OS | デフォルトの場所 |
+| --- | --- |
+| Linux | `~/.local/share/lindera` |
+| macOS | `~/Library/Application Support/lindera` |
+| Windows | `%LOCALAPPDATA%\lindera` |
+
+環境変数 `LINDERA_DATA_DIR` を設定するとベースディレクトリを上書きできます。この変数はビルド時のソースキャッシュ用変数 `LINDERA_BUILD_DICTIONARY_CACHE_DIR` とは無関係です。
+
+### download の使用方法
+
+```shell
+% lindera download ipadic
+```
+
+```text
+Downloading https://github.com/lindera/lindera/releases/download/v5.1.0/lindera-ipadic-5.1.0.zip
+100% (15.1/15.1 MiB)
+Downloaded dictionary 'ipadic'
+/home/user/.local/share/lindera/dictionaries/5.1.0/lindera-ipadic
+```
+
+インストール先のパスは標準出力に出力されるため（進捗や通知は標準エラー出力）、スクリプトで取得できます：
+
+```shell
+% DICT_DIR=$(lindera download ipadic)
+```
+
+ダウンロード後は `tokenize` で辞書名を指定して参照できます：
+
+```shell
+% echo "日本語の形態素解析を行うことができます。" | lindera tokenize --dict ipadic
+```
+
+注意事項：
+
+- アーカイブのバージョンは常に CLI のバージョンと一致します。リリースが公開されていない開発版のバージョンで実行すると HTTP 404 で失敗します。
+- 整合性は HTTPS トランスポートと ZIP アーカイブ内蔵のファイルごとの CRC32 チェックサムで検証されます。
+- 最大の辞書（`ipadic-neologd`）は約 305 MB のダウンロードで、展開時にはその約 2 倍の空きディスク容量が必要です。
 
 ## train
 

--- a/docs/ja/src/lindera-cli/installation.md
+++ b/docs/ja/src/lindera-cli/installation.md
@@ -16,7 +16,21 @@ cargo経由でバイナリをインストールできます：
 
 ## 辞書の入手
 
-Lindera はバイナリに辞書を同梱していません。[GitHub Releases](https://github.com/lindera/lindera/releases) ページからビルド済み辞書を別途ダウンロードする必要があります：
+Lindera はバイナリに辞書を同梱していません。最も簡単な入手方法は `download` サブコマンドで、CLI と同じバージョンのビルド済み辞書を取得して OS 標準のアプリケーションデータディレクトリにインストールします：
+
+```shell
+% lindera download ipadic
+```
+
+ダウンロード後は辞書名で参照できます：
+
+```shell
+% echo "関西国際空港限定トートバッグ" | lindera tokenize --dict ipadic
+```
+
+利用可能な辞書名と保存場所については[コマンド](commands.md#download)を参照してください。
+
+または、[GitHub Releases](https://github.com/lindera/lindera/releases) ページからビルド済み辞書を手動でダウンロードすることもできます：
 
 ```shell
 # 例: IPADIC 辞書のダウンロードと展開
@@ -24,10 +38,10 @@ Lindera はバイナリに辞書を同梱していません。[GitHub Releases](
 % unzip lindera-ipadic-<version>.zip -d /path/to/ipadic
 ```
 
-CLI 使用時に辞書パスを指定します：
+CLI 使用時に展開した辞書パスを指定します（アーカイブには `lindera-ipadic` ディレクトリが含まれる点に注意）：
 
 ```shell
-% echo "関西国際空港限定トートバッグ" | lindera tokenize --dict /path/to/ipadic
+% echo "関西国際空港限定トートバッグ" | lindera tokenize --dict /path/to/ipadic/lindera-ipadic
 ```
 
 ## ソースからビルド

--- a/docs/ja/src/lindera-cli/tutorial.md
+++ b/docs/ja/src/lindera-cli/tutorial.md
@@ -4,10 +4,10 @@
 
 ## 1. CLIのインストール
 
-埋め込みIPADIC辞書付きでLindera CLIをインストールします：
+Lindera CLIをインストールします：
 
 ```shell
-% cargo install lindera-cli --features=embed-ipadic
+% cargo install lindera-cli
 ```
 
 インストールの確認：
@@ -16,13 +16,23 @@
 % lindera --help
 ```
 
-## 2. 埋め込み辞書を使用した基本的なトークナイズ
+## 2. 辞書のダウンロード
 
-埋め込みIPADIC辞書を使用して日本語テキストをトークナイズします：
+GitHub リリースページからビルド済みの IPADIC 辞書をダウンロードします。辞書は OS 標準のアプリケーションデータディレクトリにインストールされます：
+
+```shell
+% lindera download ipadic
+```
+
+利用可能な辞書名と保存場所については[コマンド](commands.md#download)を参照してください。
+
+## 3. 基本的なトークナイズ
+
+ダウンロードした IPADIC 辞書を辞書名で参照して、日本語テキストをトークナイズします：
 
 ```shell
 % echo "東京は日本の首都です。" | lindera tokenize \
-  --dict embedded://ipadic
+  --dict ipadic
 ```
 
 期待される出力：
@@ -38,13 +48,13 @@
 EOS
 ```
 
-## 3. 異なる出力形式を試す
+## 4. 異なる出力形式を試す
 
 ### Wakati 形式（分かち書きのみ）
 
 ```shell
 % echo "東京は日本の首都です。" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --output wakati
 ```
 
@@ -58,19 +68,19 @@ EOS
 
 ```shell
 % echo "東京は日本の首都です。" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --output json
 ```
 
 バイトオフセット、品詞タグ、読みなどの詳細なトークン情報を含むJSON配列が出力されます。
 
-## 4. Decompose モードの使用
+## 5. Decompose モードの使用
 
 Decompose モードは複合名詞を構成要素に分解します：
 
 ```shell
 % echo "関西国際空港限定トートバッグ" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --mode decompose
 ```
 
@@ -87,13 +97,13 @@ EOS
 
 Normal モードと比較すると、「関西国際空港」が1つのトークンのままになる点が異なります。
 
-## 5. 文字フィルタとトークンフィルタの適用
+## 6. 文字フィルタとトークンフィルタの適用
 
 Unicode正規化を行い、一般名詞のみを保持します：
 
 ```shell
 % echo "Ｌｉｎｄｅｒａは形態素解析ｴﾝｼﾞﾝです。" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --char-filter 'unicode_normalize:{"kind":"nfkc"}' \
   --token-filter 'japanese_keep_tags:{"tags":["名詞,一般","名詞,固有名詞,組織"]}'
 ```
@@ -114,11 +124,11 @@ Unicode正規化により全角文字が半角に変換され、Token Filter に
 
 ```shell
 % echo "すもももももももものうち" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --token-filter 'japanese_stop_tags:{"tags":["助詞","助詞,係助詞","助詞,連体化"]}'
 ```
 
-## 6. ユーザー辞書の使用
+## 7. ユーザー辞書の使用
 
 カスタム単語エントリを含むCSVファイル（例: `my_dict.csv`）を作成します：
 
@@ -130,7 +140,7 @@ Unicode正規化により全角文字が半角に変換され、Token Filter に
 
 ```shell
 % echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --user-dict ./my_dict.csv
 ```
 
@@ -140,7 +150,7 @@ Unicode正規化により全角文字が半角に変換され、Token Filter に
 
 ```shell
 % echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --user-dict ./resources/user_dict/ipadic_simple_userdic.csv
 ```
 

--- a/docs/src/lindera-cli/commands.md
+++ b/docs/src/lindera-cli/commands.md
@@ -1,10 +1,11 @@
 # Commands
 
-The Lindera CLI provides five main commands:
+The Lindera CLI provides six main commands:
 
 - **list** - List the morphological analysis dictionaries embedded in the binary
 - **tokenize** - Perform morphological analysis on text
 - **build** - Build a dictionary from source CSV files
+- **download** - Download a pre-built dictionary from the GitHub releases page
 - **train** - Train a CRF model from annotated corpus data
 - **export** - Export a trained model to dictionary format
 
@@ -34,9 +35,10 @@ Perform morphological analysis (tokenization) on Japanese, Chinese, or Korean te
 
 ### Parameters
 
-- `--dict` / `-d`: Dictionary path or URI (required)
+- `--dict` / `-d`: Dictionary path, URI, or downloaded dictionary name (required)
   - File path: `/path/to/dictionary`
   - Embedded: `embedded://ipadic`, `embedded://unidic`, etc.
+  - Downloaded dictionary name: `ipadic`, `unidic`, etc. — resolved to the dictionary installed by `lindera download`. An existing filesystem path with the same name takes precedence.
 - `--output` / `-o`: Output format (default: mecab)
   - `mecab`: MeCab-compatible format with part-of-speech info
   - `wakati`: Space-separated tokens only
@@ -747,6 +749,58 @@ For more details about user dictionary format please refer to the following URL:
   --metadata ./lindera-ko-dic/metadata.json \
   --user
 ```
+
+## download
+
+Download the pre-built dictionary archive matching the CLI version from the [GitHub releases page](https://github.com/lindera/lindera/releases) and install it under the OS-standard application data directory.
+
+### Download parameters
+
+- Dictionary name (required): one of `ipadic`, `ipadic-neologd`, `unidic`, `ko-dic`, `cc-cedict`, `jieba`
+- `--force`: Re-download and replace an existing dictionary
+
+### Storage location
+
+Dictionaries are installed under a versioned layout `<data dir>/dictionaries/<version>/lindera-<name>/`. The default base directory per OS:
+
+| OS | Default location |
+| --- | --- |
+| Linux | `~/.local/share/lindera` |
+| macOS | `~/Library/Application Support/lindera` |
+| Windows | `%LOCALAPPDATA%\lindera` |
+
+Set the `LINDERA_DATA_DIR` environment variable to override the base directory. This variable is unrelated to the build-time source cache variable `LINDERA_BUILD_DICTIONARY_CACHE_DIR`.
+
+### Download usage
+
+```shell
+% lindera download ipadic
+```
+
+```text
+Downloading https://github.com/lindera/lindera/releases/download/v5.1.0/lindera-ipadic-5.1.0.zip
+100% (15.1/15.1 MiB)
+Downloaded dictionary 'ipadic'
+/home/user/.local/share/lindera/dictionaries/5.1.0/lindera-ipadic
+```
+
+The installed path is printed to stdout (progress and notices go to stderr), so it can be captured in scripts:
+
+```shell
+% DICT_DIR=$(lindera download ipadic)
+```
+
+After downloading, the dictionary can be referenced by name in `tokenize`:
+
+```shell
+% echo "日本語の形態素解析を行うことができます。" | lindera tokenize --dict ipadic
+```
+
+Notes:
+
+- The archive version always matches the CLI version; running a development build whose version has no published release yet fails with HTTP 404.
+- Integrity is verified via the HTTPS transport and the ZIP archive's built-in per-file CRC32 checksums.
+- The largest dictionary (`ipadic-neologd`) is a ~305 MB download and requires roughly twice that amount of free disk space during extraction.
 
 ## train
 

--- a/docs/src/lindera-cli/installation.md
+++ b/docs/src/lindera-cli/installation.md
@@ -16,7 +16,21 @@ Alternatively, you can download a pre-built binary from the release page:
 
 ## Obtaining Dictionaries
 
-Lindera does not bundle dictionaries with the binary. You need to download a pre-built dictionary separately from the [GitHub Releases](https://github.com/lindera/lindera/releases) page:
+Lindera does not bundle dictionaries with the binary. The easiest way to obtain one is the `download` subcommand, which fetches the pre-built dictionary matching the CLI version and installs it under the OS-standard application data directory:
+
+```shell
+% lindera download ipadic
+```
+
+After downloading, the dictionary can be referenced by name:
+
+```shell
+% echo "関西国際空港限定トートバッグ" | lindera tokenize --dict ipadic
+```
+
+See [Commands](commands.md#download) for the available dictionary names and storage locations.
+
+Alternatively, you can download a pre-built dictionary manually from the [GitHub Releases](https://github.com/lindera/lindera/releases) page:
 
 ```shell
 # Example: download and extract the IPADIC dictionary
@@ -24,10 +38,10 @@ Lindera does not bundle dictionaries with the binary. You need to download a pre
 % unzip lindera-ipadic-<version>.zip -d /path/to/ipadic
 ```
 
-Then specify the dictionary path when using the CLI:
+Then specify the extracted dictionary path when using the CLI (note that the archive contains a `lindera-ipadic` directory):
 
 ```shell
-% echo "関西国際空港限定トートバッグ" | lindera tokenize --dict /path/to/ipadic
+% echo "関西国際空港限定トートバッグ" | lindera tokenize --dict /path/to/ipadic/lindera-ipadic
 ```
 
 ## Build from Source

--- a/docs/src/lindera-cli/tutorial.md
+++ b/docs/src/lindera-cli/tutorial.md
@@ -4,10 +4,10 @@ This tutorial walks you through the basic usage of the Lindera CLI, from install
 
 ## 1. Install the CLI
 
-Install Lindera CLI with the embedded IPADIC dictionary:
+Install Lindera CLI:
 
 ```shell
-% cargo install lindera-cli --features=embed-ipadic
+% cargo install lindera-cli
 ```
 
 Verify the installation:
@@ -16,13 +16,23 @@ Verify the installation:
 % lindera --help
 ```
 
-## 2. Basic tokenization with embedded dictionary
+## 2. Download a dictionary
 
-Tokenize Japanese text using the embedded IPADIC dictionary:
+Download the pre-built IPADIC dictionary from the GitHub releases page. It is installed under the OS-standard application data directory:
+
+```shell
+% lindera download ipadic
+```
+
+See [Commands](commands.md#download) for the available dictionary names and storage locations.
+
+## 3. Basic tokenization
+
+Tokenize Japanese text using the downloaded IPADIC dictionary, referencing it by name:
 
 ```shell
 % echo "東京は日本の首都です。" | lindera tokenize \
-  --dict embedded://ipadic
+  --dict ipadic
 ```
 
 Expected output:
@@ -38,13 +48,13 @@ Expected output:
 EOS
 ```
 
-## 3. Try different output formats
+## 4. Try different output formats
 
 ### Wakati format (word segmentation only)
 
 ```shell
 % echo "東京は日本の首都です。" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --output wakati
 ```
 
@@ -58,19 +68,19 @@ Expected output:
 
 ```shell
 % echo "東京は日本の首都です。" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --output json
 ```
 
 This produces a JSON array with detailed token information including byte offsets, part-of-speech tags, readings, and more.
 
-## 4. Use decompose mode
+## 5. Use decompose mode
 
 Decompose mode splits compound nouns into their constituent parts:
 
 ```shell
 % echo "関西国際空港限定トートバッグ" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --mode decompose
 ```
 
@@ -87,13 +97,13 @@ EOS
 
 Compare with normal mode, where "関西国際空港" remains as a single token.
 
-## 5. Apply character and token filters
+## 6. Apply character and token filters
 
 Use Unicode normalization and keep only common nouns:
 
 ```shell
 % echo "Ｌｉｎｄｅｒａは形態素解析ｴﾝｼﾞﾝです。" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --char-filter 'unicode_normalize:{"kind":"nfkc"}' \
   --token-filter 'japanese_keep_tags:{"tags":["名詞,一般","名詞,固有名詞,組織"]}'
 ```
@@ -114,11 +124,11 @@ You can also combine multiple filters:
 
 ```shell
 % echo "すもももももももものうち" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --token-filter 'japanese_stop_tags:{"tags":["助詞","助詞,係助詞","助詞,連体化"]}'
 ```
 
-## 6. Use user dictionary
+## 7. Use user dictionary
 
 Create a CSV file with custom word entries (e.g., `my_dict.csv`):
 
@@ -130,7 +140,7 @@ Tokenize with the user dictionary:
 
 ```shell
 % echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --user-dict ./my_dict.csv
 ```
 
@@ -140,7 +150,7 @@ For pre-built user dictionary examples, see:
 
 ```shell
 % echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera tokenize \
-  --dict embedded://ipadic \
+  --dict ipadic \
   --user-dict ./resources/user_dict/ipadic_simple_userdic.csv
 ```
 

--- a/lindera-cli/Cargo.toml
+++ b/lindera-cli/Cargo.toml
@@ -40,13 +40,28 @@ default = ["mmap", "train"]
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4.6.4", features = ["derive", "cargo"] }
+dirs = "6.0.0"
+# Deflate backend for the zip crate's `deflate-flate2` feature. `rust_backend`
+# selects miniz_oxide (MIT OR Zlib OR Apache-2.0), avoiding the Zlib-only
+# zlib-rs backend that zip's default `deflate` feature would pull in.
+flate2 = { version = "1.1.9", default-features = false, features = [
+    "rust_backend",
+] }
 lindera = { workspace = true }
 lindera-analysis = { workspace = true }
 num_cpus = { workspace = true }
 serde_json = { workspace = true }
+# Same configuration as lindera-dictionary's build-time dependency: blocking
+# HTTPS GET without an async runtime; `rustls` selects the ring provider,
+# keeping aws-lc-sys out of the dependency graph.
+ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
+zip = { version = "8.6.0", default-features = false, features = [
+    "deflate-flate2",
+] }
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
+tempfile = "3.27.0"
 
 [[bin]]
 name = "lindera"

--- a/lindera-cli/README.md
+++ b/lindera-cli/README.md
@@ -23,7 +23,16 @@ Alternatively, you can download a binary from the following release page:
 
 ## Dictionary
 
-Pre-built dictionaries are available from [GitHub Releases](https://github.com/lindera/lindera/releases).
+The easiest way to obtain a dictionary is the `download` subcommand, which installs the pre-built dictionary matching the CLI version under the OS-standard application data directory:
+
+```shell script
+% lindera download ipadic
+% echo "日本語の形態素解析を行うことができます。" | lindera tokenize --dict ipadic
+```
+
+Available dictionary names: `ipadic`, `ipadic-neologd`, `unidic`, `ko-dic`, `cc-cedict`, `jieba`.
+
+Alternatively, pre-built dictionaries are available from [GitHub Releases](https://github.com/lindera/lindera/releases).
 Download a dictionary archive (e.g. `lindera-ipadic-*.zip`), extract it, and specify the path with the `--dict` option.
 
 ## License

--- a/lindera-cli/src/commands/download.rs
+++ b/lindera-cli/src/commands/download.rs
@@ -1,0 +1,930 @@
+use std::fs::{self, File};
+use std::io::{self, BufWriter, IsTerminal, Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use lindera::LinderaResult;
+use lindera::error::LinderaErrorKind;
+use lindera_cli::get_version;
+
+use super::io_err;
+use crate::dictionary_registry::{
+    DATA_DIR_ENV, DOWNLOADABLE_DICTIONARIES, base_data_dir, dictionary_dir, download_url,
+    is_complete_dictionary_dir, missing_dictionary_files,
+};
+
+/// Buffer size for streaming the downloaded archive to disk.
+const CHUNK_SIZE: usize = 64 * 1024;
+
+/// Connect timeout for the download request.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Response data returned by a [`Fetcher`].
+pub(crate) struct FetchResponse {
+    /// HTTP status code of the response.
+    pub(crate) status: u16,
+    /// Value of the `Content-Length` header, when known.
+    pub(crate) content_length: Option<u64>,
+    /// Streaming reader over the response body.
+    pub(crate) reader: Box<dyn Read>,
+}
+
+/// HTTP fetch abstraction so the download logic can be unit-tested with a
+/// mock implementation instead of a network connection.
+pub(crate) trait Fetcher {
+    /// Performs an HTTP GET request.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - Absolute URL to fetch.
+    ///
+    /// # Returns
+    ///
+    /// The response status, content length, and body reader. Non-2xx statuses
+    /// are returned as data rather than errors; transport failures produce an
+    /// `Io` error.
+    fn fetch(&self, url: &str) -> LinderaResult<FetchResponse>;
+}
+
+/// [`Fetcher`] implementation backed by `ureq`.
+struct UreqFetcher {
+    /// Configured HTTP agent.
+    agent: ureq::Agent,
+}
+
+impl UreqFetcher {
+    /// Creates a fetcher with the CLI's standard HTTP configuration.
+    ///
+    /// # Returns
+    ///
+    /// A fetcher with a 30-second connect timeout, no overall timeout
+    /// (archives are up to ~305 MB), and non-2xx statuses passed through as
+    /// data (`http_status_as_error(false)`).
+    fn new() -> Self {
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .user_agent(format!("lindera-cli/{}", get_version()))
+            .timeout_connect(Some(CONNECT_TIMEOUT))
+            .http_status_as_error(false)
+            .build()
+            .into();
+
+        Self { agent }
+    }
+}
+
+impl Fetcher for UreqFetcher {
+    /// Performs the GET request with the configured agent, streaming the body
+    /// without ureq's default 10 MB read limit.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - Absolute URL to fetch.
+    ///
+    /// # Returns
+    ///
+    /// The response status, content length, and streaming body reader.
+    fn fetch(&self, url: &str) -> LinderaResult<FetchResponse> {
+        let response = self.agent.get(url).call().map_err(io_err)?;
+        let status = response.status().as_u16();
+        let body = response.into_body();
+        let content_length = body.content_length();
+        let reader = body.into_with_config().limit(u64::MAX).reader();
+
+        Ok(FetchResponse {
+            status,
+            content_length,
+            reader: Box::new(reader),
+        })
+    }
+}
+
+/// Outcome of a dictionary download request.
+#[derive(Debug)]
+pub(crate) enum DownloadOutcome {
+    /// The dictionary was downloaded and installed at the contained path.
+    Installed(PathBuf),
+    /// A complete dictionary already existed at the contained path.
+    AlreadyPresent(PathBuf),
+}
+
+#[derive(Debug, clap::Args)]
+#[clap(
+    author,
+    about = "Download a pre-built dictionary from the Lindera GitHub releases",
+    version = get_version(),
+)]
+/// Arguments for the `download` subcommand.
+pub struct DownloadArgs {
+    /// Name of the dictionary to download.
+    #[clap(
+        value_parser = clap::builder::PossibleValuesParser::new(DOWNLOADABLE_DICTIONARIES),
+        help = "Dictionary name"
+    )]
+    name: String,
+    /// Replaces an already downloaded dictionary when set.
+    #[clap(
+        long = "force",
+        help = "Re-download and replace an existing dictionary"
+    )]
+    force: bool,
+}
+
+/// Runs the `download` subcommand.
+///
+/// Downloads the pre-built dictionary archive matching the CLI's own version
+/// from the GitHub releases page and installs it under the application data
+/// directory. The installed path is printed to stdout; progress and notices go
+/// to stderr.
+///
+/// # Arguments
+///
+/// * `args` - Parsed command line arguments.
+///
+/// # Returns
+///
+/// `Ok(())` when the dictionary is installed (or already present).
+pub fn download(args: DownloadArgs) -> LinderaResult<()> {
+    let base = base_data_dir(std::env::var_os(DATA_DIR_ENV).map(PathBuf::from))?;
+    let version = get_version();
+    let fetcher = UreqFetcher::new();
+    let mut progress = progress_renderer(download_url(&args.name, version));
+
+    let outcome = download_dictionary(
+        &fetcher,
+        &args.name,
+        version,
+        &base,
+        args.force,
+        &mut progress,
+    )?;
+
+    match outcome {
+        DownloadOutcome::Installed(path) => {
+            if io::stderr().is_terminal() {
+                // Terminate the `\r`-rewritten progress line.
+                eprintln!();
+            }
+            eprintln!("Downloaded dictionary '{}'", args.name);
+            println!("{}", path.display());
+        }
+        DownloadOutcome::AlreadyPresent(path) => {
+            eprintln!(
+                "Dictionary '{}' is already downloaded; use --force to re-download it",
+                args.name
+            );
+            println!("{}", path.display());
+        }
+    }
+
+    Ok(())
+}
+
+/// Builds a progress callback that renders download progress on stderr.
+///
+/// The first invocation prints the URL being downloaded. When stderr is a
+/// terminal, subsequent invocations rewrite a single progress line via `\r`
+/// (updated on whole-percent changes, or per MiB when the total size is
+/// unknown); otherwise no per-chunk output is produced.
+///
+/// # Arguments
+///
+/// * `url` - URL shown in the initial progress line.
+///
+/// # Returns
+///
+/// A callback taking `(bytes_downloaded, total_bytes)`.
+fn progress_renderer(url: String) -> impl FnMut(u64, Option<u64>) {
+    /// Converts a byte count to MiB for display.
+    fn mib(bytes: u64) -> f64 {
+        bytes as f64 / (1024.0 * 1024.0)
+    }
+
+    let is_terminal = io::stderr().is_terminal();
+    let mut started = false;
+    let mut last_rendered: Option<u64> = None;
+
+    move |bytes, total| {
+        if !started {
+            started = true;
+            eprintln!("Downloading {url}");
+        }
+        if !is_terminal {
+            return;
+        }
+        match total {
+            Some(total) if total > 0 => {
+                let percent = bytes * 100 / total;
+                if last_rendered != Some(percent) {
+                    last_rendered = Some(percent);
+                    eprint!("\r{percent}% ({:.1}/{:.1} MiB)", mib(bytes), mib(total));
+                }
+            }
+            _ => {
+                let whole_mib = bytes / (1024 * 1024);
+                if last_rendered != Some(whole_mib) {
+                    last_rendered = Some(whole_mib);
+                    eprint!("\r{:.1} MiB", mib(bytes));
+                }
+            }
+        }
+        let _ = io::stderr().flush();
+    }
+}
+
+/// Downloads and installs a pre-built dictionary.
+///
+/// Streams the release archive to a temporary file, extracts it to a
+/// temporary directory, validates the required dictionary files, and
+/// atomically renames the result into place. Temporary files are removed on
+/// both success and error paths.
+///
+/// # Arguments
+///
+/// * `fetcher` - HTTP fetch implementation.
+/// * `name` - Downloadable dictionary name.
+/// * `version` - Crate version of the running CLI (selects the release tag).
+/// * `base_dir` - Base application data directory.
+/// * `force` - Re-download even when a complete dictionary is present.
+/// * `progress` - Callback receiving `(bytes_downloaded, total_bytes)`.
+///
+/// # Returns
+///
+/// The installation outcome with the dictionary directory path.
+pub(crate) fn download_dictionary(
+    fetcher: &dyn Fetcher,
+    name: &str,
+    version: &str,
+    base_dir: &Path,
+    force: bool,
+    progress: &mut dyn FnMut(u64, Option<u64>),
+) -> LinderaResult<DownloadOutcome> {
+    let target = dictionary_dir(base_dir, version, name);
+    if !force && is_complete_dictionary_dir(&target) {
+        return Ok(DownloadOutcome::AlreadyPresent(target));
+    }
+
+    let version_dir = target.parent().map(Path::to_path_buf).ok_or_else(|| {
+        LinderaErrorKind::Io.with_error(anyhow::anyhow!(
+            "dictionary directory has no parent: {}",
+            target.display()
+        ))
+    })?;
+    fs::create_dir_all(&version_dir).map_err(io_err)?;
+    sweep_stale_temps(&version_dir, name);
+
+    let pid = std::process::id();
+    let zip_tmp = version_dir.join(format!(".tmp-lindera-{name}-{pid}.zip"));
+    let extract_tmp = version_dir.join(format!(".tmp-lindera-{name}-{pid}.extract"));
+
+    let result = download_and_install(
+        fetcher,
+        name,
+        version,
+        &target,
+        &zip_tmp,
+        &extract_tmp,
+        progress,
+    );
+
+    // Clean up temporary files on both success and error paths.
+    let _ = fs::remove_file(&zip_tmp);
+    let _ = fs::remove_dir_all(&extract_tmp);
+
+    result.map(DownloadOutcome::Installed)
+}
+
+/// Performs the fetch → stream → extract → validate → install sequence.
+///
+/// # Arguments
+///
+/// * `fetcher` - HTTP fetch implementation.
+/// * `name` - Downloadable dictionary name.
+/// * `version` - Crate version of the running CLI.
+/// * `target` - Final installation directory.
+/// * `zip_tmp` - Temporary file receiving the streamed archive.
+/// * `extract_tmp` - Temporary directory receiving the extracted archive.
+/// * `progress` - Callback receiving `(bytes_downloaded, total_bytes)`.
+///
+/// # Returns
+///
+/// The installed dictionary directory path.
+fn download_and_install(
+    fetcher: &dyn Fetcher,
+    name: &str,
+    version: &str,
+    target: &Path,
+    zip_tmp: &Path,
+    extract_tmp: &Path,
+    progress: &mut dyn FnMut(u64, Option<u64>),
+) -> LinderaResult<PathBuf> {
+    let url = download_url(name, version);
+    let response = fetcher.fetch(&url)?;
+    match response.status {
+        200..=299 => {}
+        404 => {
+            return Err(LinderaErrorKind::NotFound.with_error(anyhow::anyhow!(
+                "dictionary archive not found: {url} (HTTP 404). Version {version} may not have a published release yet; see https://github.com/lindera/lindera/releases"
+            )));
+        }
+        status => {
+            return Err(LinderaErrorKind::Content
+                .with_error(anyhow::anyhow!("failed to download {url}: HTTP {status}")));
+        }
+    }
+
+    stream_to_file(response, zip_tmp, progress)?;
+    extract_archive(zip_tmp, extract_tmp)?;
+
+    let root = find_dictionary_root(extract_tmp, name)?;
+    let missing = missing_dictionary_files(&root);
+    if !missing.is_empty() {
+        return Err(LinderaErrorKind::Content.with_error(anyhow::anyhow!(
+            "downloaded archive is missing required dictionary files: {}",
+            missing.join(", ")
+        )));
+    }
+
+    install_extracted(&root, target)?;
+
+    Ok(target.to_path_buf())
+}
+
+/// Streams a response body to a file in fixed-size chunks.
+///
+/// # Arguments
+///
+/// * `response` - Fetch response whose body is streamed.
+/// * `dest` - Destination file path (created or truncated).
+/// * `progress` - Callback receiving `(bytes_downloaded, total_bytes)`.
+///
+/// # Returns
+///
+/// The number of bytes written.
+fn stream_to_file(
+    response: FetchResponse,
+    dest: &Path,
+    progress: &mut dyn FnMut(u64, Option<u64>),
+) -> LinderaResult<u64> {
+    let FetchResponse {
+        content_length,
+        mut reader,
+        ..
+    } = response;
+
+    let file = File::create(dest).map_err(io_err)?;
+    let mut writer = BufWriter::new(file);
+    let mut buffer = [0u8; CHUNK_SIZE];
+    let mut bytes_written: u64 = 0;
+
+    progress(0, content_length);
+    loop {
+        let read = reader.read(&mut buffer).map_err(io_err)?;
+        if read == 0 {
+            break;
+        }
+        writer.write_all(&buffer[..read]).map_err(io_err)?;
+        bytes_written += read as u64;
+        progress(bytes_written, content_length);
+    }
+    writer.flush().map_err(io_err)?;
+
+    Ok(bytes_written)
+}
+
+/// Extracts a ZIP archive into a directory.
+///
+/// The zip crate sanitizes entry paths (zip-slip protection) and verifies
+/// each entry's CRC32 checksum while reading.
+///
+/// # Arguments
+///
+/// * `zip_path` - Path of the ZIP archive.
+/// * `extract_dir` - Directory to extract into (created if needed).
+fn extract_archive(zip_path: &Path, extract_dir: &Path) -> LinderaResult<()> {
+    let file = File::open(zip_path).map_err(io_err)?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|err| {
+        LinderaErrorKind::Content.with_error(anyhow::anyhow!(
+            "failed to read the dictionary archive (the download may be corrupt; try again): {err}"
+        ))
+    })?;
+
+    archive.extract(extract_dir).map_err(|err| {
+        LinderaErrorKind::Content.with_error(anyhow::anyhow!(
+            "failed to extract the dictionary archive (the download may be corrupt; try again): {err}"
+        ))
+    })
+}
+
+/// Locates the dictionary directory inside an extracted archive.
+///
+/// Release archives contain a single top-level `lindera-<name>/` directory,
+/// but flat archives and archives with a differently named single top-level
+/// directory are tolerated for hand-built archives.
+///
+/// # Arguments
+///
+/// * `extract_dir` - Directory the archive was extracted into.
+/// * `name` - Downloadable dictionary name.
+///
+/// # Returns
+///
+/// The directory expected to contain the dictionary files.
+fn find_dictionary_root(extract_dir: &Path, name: &str) -> LinderaResult<PathBuf> {
+    let expected = extract_dir.join(format!("lindera-{name}"));
+    if expected.is_dir() {
+        return Ok(expected);
+    }
+
+    if is_complete_dictionary_dir(extract_dir) {
+        return Ok(extract_dir.to_path_buf());
+    }
+
+    let mut dirs = Vec::new();
+    for entry in fs::read_dir(extract_dir).map_err(io_err)? {
+        let entry = entry.map_err(io_err)?;
+        if entry.file_type().map_err(io_err)?.is_dir() {
+            dirs.push(entry.path());
+        }
+    }
+    if let [single] = dirs.as_slice() {
+        return Ok(single.clone());
+    }
+
+    Err(LinderaErrorKind::Content.with_error(anyhow::anyhow!(
+        "could not locate the dictionary directory inside the downloaded archive"
+    )))
+}
+
+/// Moves an extracted dictionary directory into its final location.
+///
+/// # Arguments
+///
+/// * `root` - Extracted dictionary directory (inside the temporary directory).
+/// * `target` - Final installation directory (replaced when present).
+fn install_extracted(root: &Path, target: &Path) -> LinderaResult<()> {
+    if target.exists() {
+        fs::remove_dir_all(target).map_err(io_err)?;
+    }
+
+    // `root` and `target` share the same parent version directory, so the
+    // rename is atomic on the same filesystem.
+    match fs::rename(root, target) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            // A concurrent download may have installed the dictionary between
+            // the removal and the rename; accept the winner's result.
+            if is_complete_dictionary_dir(target) {
+                Ok(())
+            } else {
+                Err(io_err(err))
+            }
+        }
+    }
+}
+
+/// Removes leftover temporary files of interrupted downloads.
+///
+/// Only entries prefixed with `.tmp-lindera-<name>-` are removed; failures
+/// are ignored (best effort). A concurrently running download of the same
+/// dictionary may lose its temporary files to this sweep and fail; the
+/// winning process still installs a consistent result.
+///
+/// # Arguments
+///
+/// * `version_dir` - Version directory holding dictionary installations.
+/// * `name` - Downloadable dictionary name whose temporaries are swept.
+fn sweep_stale_temps(version_dir: &Path, name: &str) {
+    let prefix = format!(".tmp-lindera-{name}-");
+    let Ok(entries) = fs::read_dir(version_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        if file_name.starts_with(&prefix) {
+            let path = entry.path();
+            if path.is_dir() {
+                let _ = fs::remove_dir_all(&path);
+            } else {
+                let _ = fs::remove_file(&path);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::io::Cursor;
+
+    use zip::write::SimpleFileOptions;
+
+    use crate::dictionary_registry::REQUIRED_DICTIONARY_FILES;
+
+    use super::*;
+
+    /// Fetcher returning a canned response and counting invocations.
+    struct MockFetcher {
+        status: u16,
+        body: Vec<u8>,
+        calls: Cell<usize>,
+    }
+
+    impl MockFetcher {
+        fn new(status: u16, body: Vec<u8>) -> Self {
+            Self {
+                status,
+                body,
+                calls: Cell::new(0),
+            }
+        }
+    }
+
+    impl Fetcher for MockFetcher {
+        fn fetch(&self, _url: &str) -> LinderaResult<FetchResponse> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(FetchResponse {
+                status: self.status,
+                content_length: Some(self.body.len() as u64),
+                reader: Box::new(Cursor::new(self.body.clone())),
+            })
+        }
+    }
+
+    /// Reader failing with an I/O error after yielding some bytes.
+    struct FailingReader {
+        remaining: usize,
+    }
+
+    impl Read for FailingReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.remaining == 0 {
+                return Err(io::Error::other("simulated mid-stream failure"));
+            }
+            let n = self.remaining.min(buf.len());
+            buf[..n].fill(0);
+            self.remaining -= n;
+            Ok(n)
+        }
+    }
+
+    /// Fetcher whose body reader fails mid-stream.
+    struct FailingFetcher;
+
+    impl Fetcher for FailingFetcher {
+        fn fetch(&self, _url: &str) -> LinderaResult<FetchResponse> {
+            Ok(FetchResponse {
+                status: 200,
+                content_length: Some(1024),
+                reader: Box::new(FailingReader { remaining: 512 }),
+            })
+        }
+    }
+
+    /// Builds an in-memory ZIP archive holding the given entries.
+    fn make_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        for (path, content) in entries {
+            writer.start_file(*path, options).unwrap();
+            writer.write_all(content).unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    /// Builds a valid dictionary ZIP, optionally nested under a directory.
+    fn make_dictionary_zip(top_dir: Option<&str>) -> Vec<u8> {
+        let entries: Vec<(String, &[u8])> = REQUIRED_DICTIONARY_FILES
+            .iter()
+            .map(|file| {
+                let path = match top_dir {
+                    Some(dir) => format!("{dir}/{file}"),
+                    None => (*file).to_string(),
+                };
+                (path, b"test".as_slice())
+            })
+            .collect();
+        let borrowed: Vec<(&str, &[u8])> = entries
+            .iter()
+            .map(|(path, content)| (path.as_str(), *content))
+            .collect();
+        make_zip(&borrowed)
+    }
+
+    /// No-op progress callback for tests.
+    fn no_progress() -> impl FnMut(u64, Option<u64>) {
+        |_, _| {}
+    }
+
+    /// Asserts that no temporary download entries remain in a version dir.
+    fn assert_no_temps(version_dir: &Path) {
+        if !version_dir.exists() {
+            return;
+        }
+        for entry in fs::read_dir(version_dir).unwrap().flatten() {
+            let name = entry.file_name();
+            assert!(
+                !name.to_string_lossy().starts_with(".tmp-lindera-"),
+                "leftover temp entry: {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn happy_path_installs_dictionary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetcher = MockFetcher::new(200, make_dictionary_zip(Some("lindera-ipadic")));
+        let outcome = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap();
+
+        let DownloadOutcome::Installed(path) = outcome else {
+            panic!("expected Installed outcome");
+        };
+        assert_eq!(path, tmp.path().join("dictionaries/9.9.9/lindera-ipadic"));
+        assert!(is_complete_dictionary_dir(&path));
+        assert_no_temps(path.parent().unwrap());
+    }
+
+    #[test]
+    fn already_downloaded_short_circuits_without_fetching() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = dictionary_dir(tmp.path(), "9.9.9", "ipadic");
+        fs::create_dir_all(&target).unwrap();
+        for file in REQUIRED_DICTIONARY_FILES {
+            fs::write(target.join(file), b"existing").unwrap();
+        }
+
+        let fetcher = MockFetcher::new(200, make_dictionary_zip(Some("lindera-ipadic")));
+        let outcome = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, DownloadOutcome::AlreadyPresent(_)));
+        assert_eq!(fetcher.calls.get(), 0);
+        assert_eq!(fs::read(target.join("metadata.json")).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn force_replaces_existing_dictionary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = dictionary_dir(tmp.path(), "9.9.9", "ipadic");
+        fs::create_dir_all(&target).unwrap();
+        for file in REQUIRED_DICTIONARY_FILES {
+            fs::write(target.join(file), b"existing").unwrap();
+        }
+        fs::write(target.join("marker.txt"), b"marker").unwrap();
+
+        let fetcher = MockFetcher::new(200, make_dictionary_zip(Some("lindera-ipadic")));
+        let outcome = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            true,
+            &mut no_progress(),
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, DownloadOutcome::Installed(_)));
+        assert_eq!(fetcher.calls.get(), 1);
+        assert_eq!(fs::read(target.join("metadata.json")).unwrap(), b"test");
+        assert!(!target.join("marker.txt").exists());
+    }
+
+    #[test]
+    fn http_404_reports_missing_release() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetcher = MockFetcher::new(404, Vec::new());
+        let err = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap_err();
+
+        let message = format!("{err}");
+        assert!(message.contains("HTTP 404"), "{message}");
+        assert!(
+            message.contains("https://github.com/lindera/lindera/releases"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn other_http_errors_report_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetcher = MockFetcher::new(500, Vec::new());
+        let err = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("HTTP 500"));
+    }
+
+    #[test]
+    fn mid_stream_failure_leaves_no_remnants() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = download_dictionary(
+            &FailingFetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("simulated mid-stream failure"));
+        let target = dictionary_dir(tmp.path(), "9.9.9", "ipadic");
+        assert!(!target.exists());
+        assert_no_temps(target.parent().unwrap());
+    }
+
+    #[test]
+    fn corrupt_archive_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetcher = MockFetcher::new(200, b"this is not a zip archive".to_vec());
+        let err = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err}").contains("archive"), "{err}");
+        let target = dictionary_dir(tmp.path(), "9.9.9", "ipadic");
+        assert!(!target.exists());
+        assert_no_temps(target.parent().unwrap());
+    }
+
+    #[test]
+    fn zip_slip_entry_stays_contained() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut entries: Vec<(String, &[u8])> = REQUIRED_DICTIONARY_FILES
+            .iter()
+            .map(|file| (format!("lindera-ipadic/{file}"), b"test".as_slice()))
+            .collect();
+        entries.push(("../evil.txt".to_string(), b"evil".as_slice()));
+        let borrowed: Vec<(&str, &[u8])> = entries
+            .iter()
+            .map(|(path, content)| (path.as_str(), *content))
+            .collect();
+
+        let fetcher = MockFetcher::new(200, make_zip(&borrowed));
+        let result = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        );
+
+        // The zip crate rejects entries escaping the extraction directory, so
+        // the download fails; the malicious entry must not land anywhere.
+        assert!(result.is_err());
+        let version_dir = tmp.path().join("dictionaries/9.9.9");
+        assert!(!version_dir.join("evil.txt").exists());
+        assert!(!tmp.path().join("evil.txt").exists());
+        assert_no_temps(&version_dir);
+    }
+
+    #[test]
+    fn flat_archive_is_tolerated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetcher = MockFetcher::new(200, make_dictionary_zip(None));
+        let outcome = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap();
+
+        let DownloadOutcome::Installed(path) = outcome else {
+            panic!("expected Installed outcome");
+        };
+        assert!(is_complete_dictionary_dir(&path));
+    }
+
+    #[test]
+    fn differently_named_single_top_dir_is_tolerated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetcher = MockFetcher::new(200, make_dictionary_zip(Some("custom-name")));
+        let outcome = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap();
+
+        let DownloadOutcome::Installed(path) = outcome else {
+            panic!("expected Installed outcome");
+        };
+        assert!(is_complete_dictionary_dir(&path));
+        assert_eq!(path, tmp.path().join("dictionaries/9.9.9/lindera-ipadic"));
+    }
+
+    #[test]
+    fn incomplete_archive_lists_missing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetcher = MockFetcher::new(
+            200,
+            make_zip(&[("lindera-ipadic/metadata.json", b"test".as_slice())]),
+        );
+        let err = download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap_err();
+
+        let message = format!("{err}");
+        assert!(
+            message.contains("missing required dictionary files"),
+            "{message}"
+        );
+        assert!(message.contains("unk.bin"), "{message}");
+    }
+
+    #[test]
+    fn progress_receives_content_length() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = make_dictionary_zip(Some("lindera-ipadic"));
+        let body_len = body.len() as u64;
+        let fetcher = MockFetcher::new(200, body);
+
+        let mut final_state = (0u64, None);
+        let mut progress = |bytes: u64, total: Option<u64>| {
+            final_state = (bytes, total);
+        };
+        download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut progress,
+        )
+        .unwrap();
+
+        assert_eq!(final_state, (body_len, Some(body_len)));
+    }
+
+    #[test]
+    fn stale_temps_are_swept_before_download() {
+        let tmp = tempfile::tempdir().unwrap();
+        let version_dir = tmp.path().join("dictionaries/9.9.9");
+        fs::create_dir_all(&version_dir).unwrap();
+        fs::write(version_dir.join(".tmp-lindera-ipadic-12345.zip"), b"stale").unwrap();
+        fs::create_dir_all(version_dir.join(".tmp-lindera-ipadic-12345.extract")).unwrap();
+
+        let fetcher = MockFetcher::new(200, make_dictionary_zip(Some("lindera-ipadic")));
+        download_dictionary(
+            &fetcher,
+            "ipadic",
+            "9.9.9",
+            tmp.path(),
+            false,
+            &mut no_progress(),
+        )
+        .unwrap();
+
+        assert_no_temps(&version_dir);
+    }
+}

--- a/lindera-cli/src/commands/mod.rs
+++ b/lindera-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 use lindera::error::{LinderaError, LinderaErrorKind};
 
 pub mod build;
+pub mod download;
 #[cfg(feature = "train")]
 pub mod export;
 pub mod list;

--- a/lindera-cli/src/commands/tokenize.rs
+++ b/lindera-cli/src/commands/tokenize.rs
@@ -26,7 +26,7 @@ pub struct TokenizeArgs {
         short = 'd',
         long = "dict",
         required = true,
-        help = "Dictionary directory path or URI (e.g., embedded://ipadic, /path/to/dictionary)"
+        help = "Dictionary directory path, URI, or downloaded dictionary name (e.g., embedded://ipadic, /path/to/dictionary, ipadic)"
     )]
     dict: String,
     #[clap(
@@ -221,8 +221,15 @@ fn wakati_output<W: Write>(writer: &mut W, tokens: Vec<Token>) -> LinderaResult<
 pub fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
     let mut builder = TokenizerBuilder::new()?;
 
-    // Set dictionary directory URI
-    builder.set_segmenter_dictionary(args.dict.as_str());
+    // Set dictionary directory URI. A bare downloadable dictionary name
+    // (e.g. `ipadic`) resolves to its downloaded directory; URIs and
+    // existing filesystem paths are passed through unchanged.
+    let dict_uri = crate::dictionary_registry::resolve_dictionary_arg(
+        args.dict.as_str(),
+        std::env::var_os(crate::dictionary_registry::DATA_DIR_ENV).map(PathBuf::from),
+        get_version(),
+    )?;
+    builder.set_segmenter_dictionary(dict_uri.as_str());
 
     // Set user dictionary URI
     if let Some(user_dic_uri) = args.user_dict {

--- a/lindera-cli/src/dictionary_registry.rs
+++ b/lindera-cli/src/dictionary_registry.rs
@@ -1,0 +1,351 @@
+use std::path::{Path, PathBuf};
+
+use lindera::LinderaResult;
+use lindera::error::LinderaErrorKind;
+
+/// Dictionary names accepted by `lindera download`.
+///
+/// This list is independent of the `embed-*` cargo features (unlike
+/// `DictionaryKind`, whose variants are feature-gated and absent from a
+/// default CLI build) and matches the pre-built dictionary archives published
+/// on the GitHub releases page.
+pub(crate) const DOWNLOADABLE_DICTIONARIES: [&str; 6] = [
+    "ipadic",
+    "ipadic-neologd",
+    "unidic",
+    "ko-dic",
+    "cc-cedict",
+    "jieba",
+];
+
+/// Files that make up a complete pre-built dictionary directory.
+pub(crate) const REQUIRED_DICTIONARY_FILES: [&str; 8] = [
+    "metadata.json",
+    "char_def.bin",
+    "matrix.mtx",
+    "dict.da",
+    "dict.vals",
+    "dict.wordsidx",
+    "dict.words",
+    "unk.bin",
+];
+
+/// Environment variable overriding the base application data directory used
+/// for downloaded dictionaries.
+///
+/// Unrelated to the build-time source cache variable
+/// (`LINDERA_BUILD_DICTIONARY_CACHE_DIR`).
+pub(crate) const DATA_DIR_ENV: &str = "LINDERA_DATA_DIR";
+
+/// Checks whether a name refers to a downloadable dictionary.
+///
+/// # Arguments
+///
+/// * `name` - Dictionary name to check (e.g. `ipadic`).
+///
+/// # Returns
+///
+/// `true` if the name is one of [`DOWNLOADABLE_DICTIONARIES`].
+pub(crate) fn is_downloadable_dictionary(name: &str) -> bool {
+    DOWNLOADABLE_DICTIONARIES.contains(&name)
+}
+
+/// Builds the GitHub release URL of a pre-built dictionary archive.
+///
+/// The release tag is `v`-prefixed while the asset file name is not
+/// (e.g. tag `v5.1.0`, asset `lindera-ipadic-5.1.0.zip`).
+///
+/// # Arguments
+///
+/// * `name` - Downloadable dictionary name (e.g. `ipadic`).
+/// * `version` - Crate version of the running CLI (e.g. `5.1.0`).
+///
+/// # Returns
+///
+/// The absolute download URL of the dictionary archive.
+pub(crate) fn download_url(name: &str, version: &str) -> String {
+    format!(
+        "https://github.com/lindera/lindera/releases/download/v{version}/lindera-{name}-{version}.zip"
+    )
+}
+
+/// Resolves the base application data directory for Lindera.
+///
+/// # Arguments
+///
+/// * `env_override` - Value of the `LINDERA_DATA_DIR` environment variable,
+///   if set. The caller reads the environment so that this function stays
+///   testable without touching process state.
+///
+/// # Returns
+///
+/// The override as-is when present; otherwise the OS-standard local
+/// application data directory joined with `lindera` (e.g.
+/// `~/.local/share/lindera` on Linux, `~/Library/Application Support/lindera`
+/// on macOS, `%LOCALAPPDATA%\lindera` on Windows). An `Io` error when neither
+/// is available.
+pub(crate) fn base_data_dir(env_override: Option<PathBuf>) -> LinderaResult<PathBuf> {
+    if let Some(dir) = env_override {
+        return Ok(dir);
+    }
+
+    dirs::data_local_dir()
+        .map(|dir| dir.join("lindera"))
+        .ok_or_else(|| {
+            LinderaErrorKind::Io.with_error(anyhow::anyhow!(
+                "could not determine the application data directory; set {DATA_DIR_ENV} to override it"
+            ))
+        })
+}
+
+/// Builds the installation directory of a downloaded dictionary.
+///
+/// # Arguments
+///
+/// * `base` - Base data directory (see [`base_data_dir`]).
+/// * `version` - Crate version of the running CLI.
+/// * `name` - Downloadable dictionary name.
+///
+/// # Returns
+///
+/// `<base>/dictionaries/<version>/lindera-<name>`. The `lindera-<name>`
+/// component matches the top-level directory inside the release archive.
+pub(crate) fn dictionary_dir(base: &Path, version: &str, name: &str) -> PathBuf {
+    base.join("dictionaries")
+        .join(version)
+        .join(format!("lindera-{name}"))
+}
+
+/// Lists the required dictionary files missing from a directory.
+///
+/// # Arguments
+///
+/// * `dir` - Directory expected to contain a complete pre-built dictionary.
+///
+/// # Returns
+///
+/// The names from [`REQUIRED_DICTIONARY_FILES`] that are absent (all of them
+/// when `dir` does not exist or is not a directory).
+pub(crate) fn missing_dictionary_files(dir: &Path) -> Vec<&'static str> {
+    REQUIRED_DICTIONARY_FILES
+        .iter()
+        .copied()
+        .filter(|file| !dir.join(file).is_file())
+        .collect()
+}
+
+/// Checks whether a directory contains a complete pre-built dictionary.
+///
+/// # Arguments
+///
+/// * `dir` - Directory to check.
+///
+/// # Returns
+///
+/// `true` when all files from [`REQUIRED_DICTIONARY_FILES`] are present.
+pub(crate) fn is_complete_dictionary_dir(dir: &Path) -> bool {
+    missing_dictionary_files(dir).is_empty()
+}
+
+/// Resolves the `--dict` argument of `lindera tokenize`.
+///
+/// Resolution order, preserving backward compatibility:
+///
+/// 1. A URI containing `://` is returned unchanged (e.g. `embedded://ipadic`).
+/// 2. An existing filesystem path is returned unchanged (paths always win
+///    over dictionary names).
+/// 3. A downloadable dictionary name resolves to its downloaded directory; a
+///    missing or incomplete directory produces an error suggesting
+///    `lindera download`.
+/// 4. Anything else is returned unchanged and handled by the dictionary
+///    loader downstream.
+///
+/// # Arguments
+///
+/// * `dict` - Raw `--dict` argument value.
+/// * `env_override` - Value of the `LINDERA_DATA_DIR` environment variable,
+///   if set.
+/// * `version` - Crate version of the running CLI.
+///
+/// # Returns
+///
+/// The dictionary URI or path to pass to the tokenizer builder.
+pub(crate) fn resolve_dictionary_arg(
+    dict: &str,
+    env_override: Option<PathBuf>,
+    version: &str,
+) -> LinderaResult<String> {
+    if dict.contains("://") || Path::new(dict).exists() || !is_downloadable_dictionary(dict) {
+        return Ok(dict.to_string());
+    }
+
+    let dir = dictionary_dir(&base_data_dir(env_override)?, version, dict);
+    let missing = missing_dictionary_files(&dir);
+    if missing.is_empty() {
+        return dir.into_os_string().into_string().map_err(|path| {
+            LinderaErrorKind::Io.with_error(anyhow::anyhow!(
+                "dictionary path is not valid UTF-8: {}",
+                PathBuf::from(path).display()
+            ))
+        });
+    }
+
+    if dir.is_dir() {
+        Err(LinderaErrorKind::Content.with_error(anyhow::anyhow!(
+            "dictionary '{dict}' at {} is incomplete (missing: {}). Run 'lindera download {dict} --force' to re-download it.",
+            dir.display(),
+            missing.join(", ")
+        )))
+    } else {
+        Err(LinderaErrorKind::NotFound.with_error(anyhow::anyhow!(
+            "dictionary '{dict}' is not downloaded (looked in {}). Run 'lindera download {dict}' to fetch it.",
+            dir.display()
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    /// Creates the given files (with dummy content) inside a directory.
+    fn create_files(dir: &Path, files: &[&str]) {
+        fs::create_dir_all(dir).unwrap();
+        for file in files {
+            fs::write(dir.join(file), b"test").unwrap();
+        }
+    }
+
+    #[test]
+    fn download_url_builds_expected_release_url() {
+        assert_eq!(
+            download_url("ipadic", "5.1.0"),
+            "https://github.com/lindera/lindera/releases/download/v5.1.0/lindera-ipadic-5.1.0.zip"
+        );
+    }
+
+    #[test]
+    fn downloadable_dictionary_names_are_accepted() {
+        for name in DOWNLOADABLE_DICTIONARIES {
+            assert!(
+                is_downloadable_dictionary(name),
+                "{name} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_dictionary_names_are_rejected() {
+        for name in ["IPADIC", "", "ipadic2", "embedded://ipadic"] {
+            assert!(
+                !is_downloadable_dictionary(name),
+                "{name} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn base_data_dir_prefers_env_override() {
+        let dir = base_data_dir(Some(PathBuf::from("/custom/data"))).unwrap();
+        assert_eq!(dir, PathBuf::from("/custom/data"));
+    }
+
+    #[test]
+    fn base_data_dir_defaults_to_local_data_dir() {
+        if let Some(expected) = dirs::data_local_dir() {
+            assert_eq!(base_data_dir(None).unwrap(), expected.join("lindera"));
+        }
+    }
+
+    #[test]
+    fn dictionary_dir_uses_versioned_layout() {
+        assert_eq!(
+            dictionary_dir(Path::new("/base"), "5.1.0", "ipadic"),
+            PathBuf::from("/base/dictionaries/5.1.0/lindera-ipadic")
+        );
+    }
+
+    #[test]
+    fn missing_dictionary_files_reports_all_when_dir_is_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = missing_dictionary_files(&tmp.path().join("nonexistent"));
+        assert_eq!(missing, REQUIRED_DICTIONARY_FILES.to_vec());
+    }
+
+    #[test]
+    fn missing_dictionary_files_reports_only_absent_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_files(tmp.path(), &["metadata.json", "char_def.bin"]);
+        let missing = missing_dictionary_files(tmp.path());
+        assert!(!missing.contains(&"metadata.json"));
+        assert!(!missing.contains(&"char_def.bin"));
+        assert!(missing.contains(&"matrix.mtx"));
+        assert!(missing.contains(&"unk.bin"));
+    }
+
+    #[test]
+    fn complete_dictionary_dir_is_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_files(tmp.path(), &REQUIRED_DICTIONARY_FILES);
+        assert!(is_complete_dictionary_dir(tmp.path()));
+        assert!(missing_dictionary_files(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn resolve_passes_uri_through_unchanged() {
+        let resolved = resolve_dictionary_arg("embedded://ipadic", None, "5.1.0").unwrap();
+        assert_eq!(resolved, "embedded://ipadic");
+    }
+
+    #[test]
+    fn resolve_prefers_existing_filesystem_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("ipadic");
+        fs::create_dir_all(&path).unwrap();
+        let arg = path.to_str().unwrap();
+        let resolved = resolve_dictionary_arg(arg, None, "5.1.0").unwrap();
+        assert_eq!(resolved, arg);
+    }
+
+    #[test]
+    fn resolve_returns_downloaded_dictionary_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = dictionary_dir(tmp.path(), "5.1.0", "ipadic");
+        create_files(&dir, &REQUIRED_DICTIONARY_FILES);
+        let resolved =
+            resolve_dictionary_arg("ipadic", Some(tmp.path().to_path_buf()), "5.1.0").unwrap();
+        assert_eq!(resolved, dir.to_str().unwrap());
+    }
+
+    #[test]
+    fn resolve_suggests_download_when_not_downloaded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err =
+            resolve_dictionary_arg("ipadic", Some(tmp.path().to_path_buf()), "5.1.0").unwrap_err();
+        let message = format!("{err}");
+        assert!(message.contains("lindera download ipadic"), "{message}");
+    }
+
+    #[test]
+    fn resolve_suggests_force_when_incomplete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = dictionary_dir(tmp.path(), "5.1.0", "ipadic");
+        create_files(&dir, &["metadata.json"]);
+        let err =
+            resolve_dictionary_arg("ipadic", Some(tmp.path().to_path_buf()), "5.1.0").unwrap_err();
+        let message = format!("{err}");
+        assert!(
+            message.contains("lindera download ipadic --force"),
+            "{message}"
+        );
+        assert!(message.contains("unk.bin"), "{message}");
+    }
+
+    #[test]
+    fn resolve_passes_unknown_name_through_unchanged() {
+        let resolved = resolve_dictionary_arg("no-such-dictionary", None, "5.1.0").unwrap();
+        assert_eq!(resolved, "no-such-dictionary");
+    }
+}

--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -4,8 +4,10 @@ use lindera::LinderaResult;
 use lindera_cli::get_version;
 
 mod commands;
+mod dictionary_registry;
 
 use commands::build::BuildArgs;
+use commands::download::DownloadArgs;
 #[cfg(feature = "train")]
 use commands::export::ExportArgs;
 use commands::list::ListArgs;
@@ -30,6 +32,7 @@ enum Commands {
     List(ListArgs),
     Tokenize(TokenizeArgs),
     Build(BuildArgs),
+    Download(DownloadArgs),
     #[cfg(feature = "train")]
     Train(TrainArgs),
     #[cfg(feature = "train")]
@@ -43,6 +46,7 @@ fn main() -> LinderaResult<()> {
         Commands::List(args) => commands::list::list(args),
         Commands::Tokenize(args) => commands::tokenize::tokenize(args),
         Commands::Build(args) => commands::build::build(args),
+        Commands::Download(args) => commands::download::download(args),
         #[cfg(feature = "train")]
         Commands::Train(args) => commands::train::train(args),
         #[cfg(feature = "train")]

--- a/lindera-cli/tests/cli.rs
+++ b/lindera-cli/tests/cli.rs
@@ -21,6 +21,7 @@ fn help_shows_subcommands() {
     assert!(stdout.contains("list"));
     assert!(stdout.contains("tokenize"));
     assert!(stdout.contains("build"));
+    assert!(stdout.contains("download"));
 }
 
 #[test]
@@ -55,6 +56,41 @@ fn tokenize_with_invalid_dictionary_fails() {
         .unwrap();
     assert!(!output.status.success());
     assert!(!output.stderr.is_empty());
+}
+
+#[test]
+fn download_help_lists_dictionary_names() {
+    let output = lindera().args(["download", "--help"]).output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("ipadic-neologd"), "got: {stdout}");
+    assert!(stdout.contains("cc-cedict"), "got: {stdout}");
+    assert!(stdout.contains("--force"), "got: {stdout}");
+}
+
+#[test]
+fn download_with_invalid_name_fails() {
+    let output = lindera()
+        .args(["download", "no-such-dictionary"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("ipadic"), "got: {stderr}");
+}
+
+#[test]
+fn tokenize_with_undownloaded_name_suggests_download() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let output = lindera()
+        .env("LINDERA_DATA_DIR", data_dir.path())
+        .args(["tokenize", "--dict", "ipadic"])
+        .write_stdin("テスト\n")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("lindera download ipadic"), "got: {stderr}");
 }
 
 #[cfg(feature = "embed-ipadic")]


### PR DESCRIPTION
## Summary

Adds `lindera download <name>` which fetches the pre-built dictionary archive matching the CLI version from GitHub releases and installs it under the OS-standard application data directory, and lets `tokenize` reference downloaded dictionaries by bare name (`--dict ipadic`).

Closes #893

## Changes

### New

- `lindera-cli/src/dictionary_registry.rs` — registry shared by `download` and `tokenize`: the six downloadable dictionary names, the eight required dictionary files, `LINDERA_DATA_DIR` handling, release URL construction, versioned directory layout (`<base>/dictionaries/<version>/lindera-<name>/`), completeness validation, and `--dict` argument resolution. Environment variables are read at command entry points and injected as parameters, keeping everything unit-testable.
- `lindera-cli/src/commands/download.rs` — the subcommand: a `Fetcher` trait with a thin ureq shim (30 s connect timeout, no overall timeout, non-2xx passed through as data, streaming body without ureq's 10 MB default limit), 64 KiB chunked streaming with a TTY-aware stderr progress line, pid-suffixed temporary files with stale-temp sweeping, `ZipArchive::extract` (built-in zip-slip sanitization and per-file CRC32 verification), tolerant dictionary-root detection (expects `lindera-<name>/`, accepts flat or single-top-dir archives), required-file validation, and an atomic rename into place. The installed path goes to stdout; progress and notices go to stderr. HTTP 404 produces a dedicated hint for unreleased development versions.

### Modified

- `tokenize --dict` resolution order: URI (`://`) → existing filesystem path → downloadable dictionary name → passthrough. Existing paths always win, so current usages are unaffected; a missing or incomplete download fails with a message suggesting `lindera download <name>` (or `--force`).
- `lindera-cli/Cargo.toml`: new CLI-only dependencies — `dirs 6.0.0`, `ureq 3.3.0` (rustls/ring, same configuration as lindera-dictionary's build-time dependency), `zip 8.6.0` with `deflate-flate2` + `flate2` `rust_backend` (explicit miniz_oxide backend, avoiding the Zlib-only zlib-rs that zip's default `deflate` feature pulls in), dev-dependency `tempfile`. All MIT and/or Apache-2.0 compatible.
- Docs (EN + JA): `commands.md` gains a `## download` section with per-OS storage locations and `LINDERA_DATA_DIR`; `installation.md` and `tutorial.md` now lead with `lindera download`, keeping curl/unzip as the manual alternative; README updates for lindera-cli and the workspace root.

## Testing

- 28 unit tests (registry + download core with a mock fetcher and in-memory fixture zips): URL construction, name accept/reject, data-dir override precedence, all resolution branches, happy path, already-downloaded short-circuit (0 fetches), `--force` replacement, 404/5xx messages, mid-stream failure leaving no temps or target, corrupt archive rejection, zip-slip containment (`../evil.txt` never lands outside), flat/differently-named archive tolerance, missing-file listing, progress callback totals, stale-temp sweeping.
- 7 integration tests (`tests/cli.rs`, assert_cmd, no network): help shows `download`, `download --help` lists names, invalid name rejection, undownloaded name suggests `lindera download ipadic`.
- CI-equivalent run with `--features train,embed-ipadic`: 15 integration tests green (no `embedded://` regression).
- `cargo fmt --all -- --check`, `cargo clippy -p lindera-cli --all-targets -- -D warnings`, markdownlint on all touched markdown: clean.
- Real-world verification: `lindera download cc-cedict` (10.5 MB actual download from the v5.1.0 release) installs all 8 files and prints the path to stdout; `echo "可以进行中文形态学分析。" | lindera tokenize -d cc-cedict` tokenizes correctly; re-running short-circuits with an "already downloaded" notice.

## Out of scope (follow-ups)

- Checksum files do not exist on releases today, so integrity is HTTPS + ZIP CRC32; can be strengthened once `.sha256` assets are published.
- Download resume is not supported (documented).
- Listing downloaded dictionaries in `lindera list` is a possible follow-up.
- Release asset version-naming unification is tracked separately in #894.
