### PR TITLE
chore(release): unify asset version naming across release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,20 +435,31 @@ jobs:
       - name: Compile
         run: cargo build -p lindera-cli --release --target=${{ matrix.platform.target }}
 
+      # Asset file names use the bare crate version (e.g. 5.1.0) to match the
+      # dictionary archives and the ecosystem-fixed gem/wheel names, while the
+      # release tag itself stays v-prefixed. `shell: bash` keeps this step
+      # working on the Windows matrix entries.
+      - name: Get version
+        id: get_version
+        shell: bash
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera-cli") | .version')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Create artifact for Unix
         if: "!startsWith(matrix.platform.runner, 'windows')"
-        run: zip --junk-paths lindera-${{ matrix.platform.target }}-${{ github.ref_name }}${{ matrix.platform.archive }} target/${{ matrix.platform.target }}/release/lindera${{ matrix.platform.extension }}
+        run: zip --junk-paths lindera-${{ matrix.platform.target }}-${{ steps.get_version.outputs.version }}${{ matrix.platform.archive }} target/${{ matrix.platform.target }}/release/lindera${{ matrix.platform.extension }}
 
       - name: Create artifact for Windows
         if: startsWith(matrix.platform.runner, 'windows')
-        run: powershell Compress-Archive -DestinationPath lindera-${{ matrix.platform.target }}-${{ github.ref_name }}${{ matrix.platform.archive }} -Path target/${{ matrix.platform.target }}/release/lindera${{ matrix.platform.extension }}
+        run: powershell Compress-Archive -DestinationPath lindera-${{ matrix.platform.target }}-${{ steps.get_version.outputs.version }}${{ matrix.platform.archive }} -Path target/${{ matrix.platform.target }}/release/lindera${{ matrix.platform.extension }}
 
       - name: Upload artifact
         uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: lindera-${{ matrix.platform.target }}-${{ github.ref_name }}${{ matrix.platform.archive }}
+          files: lindera-${{ matrix.platform.target }}-${{ steps.get_version.outputs.version }}${{ matrix.platform.archive }}
           tag_name: ${{ github.ref_name }}
 
   build-python-wheels:


### PR DESCRIPTION
## Summary

Unifies release asset file names on the bare crate version (e.g. `5.1.0`): CLI binary archives drop the `v` prefix so all assets on a release share one naming style.

Closes #894

## Background

On [v5.1.0](https://github.com/lindera/lindera/releases/tag/v5.1.0), CLI binary archives were named from the git tag (`lindera-x86_64-unknown-linux-gnu-v5.1.0.zip`) while dictionary archives, PHP archives, gems, and wheels all use the bare version (`lindera-ipadic-5.1.0.zip`, `lindera-5.1.0.gem`, …). Gem and wheel file names are dictated by RubyGems and PEP 427 and always use the bare version, so the bare version is the only naming all assets can share.

## Changes

`.github/workflows/release.yml`, `build` job only:

- Add a "Get version" step after Compile, mirroring the `build-dictionary` job: extracts the `lindera-cli` crate version via `cargo metadata` + jq. `shell: bash` is set explicitly so the step runs identically on the Windows matrix entries (GitHub-hosted Windows runners provide bash and jq).
- Replace `${{ github.ref_name }}` with `${{ steps.get_version.outputs.version }}` in the three asset-naming spots: "Create artifact for Unix", "Create artifact for Windows", and the `files:` input of "Upload artifact".
- The release `tag_name` stays `${{ github.ref_name }}` (tags remain `v`-prefixed). Workflow-internal `actions/upload-artifact` names in other jobs are unrelated to release asset file names and are untouched.

## Impact

- Next release's CLI binary assets: `lindera-<target>-5.2.0.zip` style (no `v`). Existing releases keep their historical asset names.
- No in-repo docs or scripts reference the old pattern (verified by grep), so no documentation changes are needed.
- External download scripts referencing the old `-v<version>.zip` pattern will break on the next release — the next release notes should mention the renaming (kept as a release-time task on #894's acceptance criteria).

## Verification

- `release.yml` is not triggered by pull requests (tag push / `workflow_dispatch` only), so runtime verification happens at the next release.
- Statically verified: YAML parses cleanly; grep confirms the `build` job's asset names no longer reference `github.ref_name` while `tag_name` inputs still do.
