### PR TITLE
feat(cli): show downloaded dictionaries in list subcommand

### DIFF
--- a/docs/ja/src/lindera-cli/commands.md
+++ b/docs/ja/src/lindera-cli/commands.md
@@ -2,7 +2,7 @@
 
 Lindera CLI は6つのメインコマンドを提供します：
 
-- **list** - バイナリに埋め込まれた形態素解析辞書の一覧を表示
+- **list** - 形態素解析辞書の一覧と状態を表示
 - **tokenize** - テキストに対して形態素解析を実行
 - **build** - ソースCSVファイルから辞書をビルド
 - **download** - GitHub リリースページから学習済み辞書をダウンロード
@@ -11,11 +11,11 @@ Lindera CLI は6つのメインコマンドを提供します：
 
 ## list
 
-ビルド時に（`embed-*` feature フラグ経由で）バイナリに埋め込まれた形態素解析辞書の一覧を表示します。
+既知の形態素解析辞書の一覧を表示し、各辞書について（`embed-*` feature フラグ経由で）バイナリに埋め込まれているか、および `lindera download` で学習済み辞書がローカルにダウンロード済みかを表示します。
 
 ### list パラメータ
 
-このコマンドは引数を取りません。
+このコマンドは引数を取りません。環境変数 `LINDERA_DATA_DIR` を設定すると、ダウンロード済み辞書を探すアプリケーションデータディレクトリを上書きできます（`lindera download` と同じ挙動です）。
 
 ### list の使用方法
 
@@ -24,10 +24,20 @@ Lindera CLI は6つのメインコマンドを提供します：
 ```
 
 ```text
-ipadic
+NAME            EMBEDDED  DOWNLOADED  PATH
+ipadic          yes       yes         /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-ipadic
+ipadic-neologd  no        no          -
+unidic          no        incomplete  /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-unidic
+ko-dic          no        no          -
+cc-cedict       no        no          -
+jieba           no        no          -
 ```
 
-出力にはビルド時に有効化されていた `embed-*` feature（例: `--features=embed-ipadic`）に対応する辞書名のみが1行ずつ表示されます。`embed-*` feature が1つも有効化されていない場合、出力はありません。
+出力は1行につき1辞書です：
+
+- `EMBEDDED` は、ビルド時に辞書が埋め込まれている場合（例: `--features=embed-ipadic`）に `yes` になります。
+- `DOWNLOADED` は、実行中の CLI バージョンに対応する `lindera download` でインストールされた完全な辞書が存在する場合に `yes`、インストールディレクトリは存在するが必要なファイルが欠けている場合に `incomplete` になります（`lindera download <name> --force` で再ダウンロードしてください）。
+- `PATH` は、インストールディレクトリが存在する場合はそのパス、存在しない場合は `-` を表示します。
 
 ## tokenize
 

--- a/docs/src/lindera-cli/commands.md
+++ b/docs/src/lindera-cli/commands.md
@@ -2,7 +2,7 @@
 
 The Lindera CLI provides six main commands:
 
-- **list** - List the morphological analysis dictionaries embedded in the binary
+- **list** - List the morphological analysis dictionaries and their status
 - **tokenize** - Perform morphological analysis on text
 - **build** - Build a dictionary from source CSV files
 - **download** - Download a pre-built dictionary from the GitHub releases page
@@ -11,11 +11,11 @@ The Lindera CLI provides six main commands:
 
 ## list
 
-List the morphological analysis dictionaries that were embedded in the binary at build time (via the `embed-*` feature flags).
+List all known morphological analysis dictionaries and show, for each one, whether it is embedded in the binary (via the `embed-*` feature flags) and whether a pre-built copy has been downloaded locally with `lindera download`.
 
 ### List parameters
 
-This command takes no arguments.
+This command takes no arguments. The `LINDERA_DATA_DIR` environment variable overrides the application data directory searched for downloaded dictionaries, exactly as it does for `lindera download`.
 
 ### List usage
 
@@ -24,10 +24,20 @@ This command takes no arguments.
 ```
 
 ```text
-ipadic
+NAME            EMBEDDED  DOWNLOADED  PATH
+ipadic          yes       yes         /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-ipadic
+ipadic-neologd  no        no          -
+unidic          no        incomplete  /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-unidic
+ko-dic          no        no          -
+cc-cedict       no        no          -
+jieba           no        no          -
 ```
 
-The output contains one dictionary name per line, limited to whichever `embed-*` features were enabled when the binary was built (e.g. `--features=embed-ipadic`). If no `embed-*` feature was enabled, the command produces no output.
+The output contains one dictionary per line:
+
+- `EMBEDDED` is `yes` when the dictionary was embedded at build time (e.g. `--features=embed-ipadic`).
+- `DOWNLOADED` is `yes` when a complete dictionary installed by `lindera download` exists for the running CLI version, and `incomplete` when the installation directory exists but required files are missing (re-download it with `lindera download <name> --force`).
+- `PATH` shows the installation directory when it exists, and `-` otherwise.
 
 ## tokenize
 

--- a/lindera-cli/src/commands/list.rs
+++ b/lindera-cli/src/commands/list.rs
@@ -1,18 +1,302 @@
+use std::path::{Path, PathBuf};
+
 use lindera::LinderaResult;
 use lindera::dictionary::DictionaryKind;
 use lindera_cli::get_version;
 
+use crate::dictionary_registry::{
+    DATA_DIR_ENV, DOWNLOADABLE_DICTIONARIES, base_data_dir, dictionary_dir,
+    is_complete_dictionary_dir,
+};
+
+/// Column headers of the dictionary listing table.
+const HEADERS: [&str; 4] = ["NAME", "EMBEDDED", "DOWNLOADED", "PATH"];
+
+/// Placeholder shown in the `PATH` column when no installation directory
+/// exists.
+const NO_PATH: &str = "-";
+
 #[derive(Debug, clap::Args)]
 #[clap(
     author,
-    about = "List embedded morphological analysis dictionaries",
+    about = "List morphological analysis dictionaries and their status",
     version = get_version(),
 )]
+/// Arguments for the `list` subcommand.
 pub struct ListArgs {}
 
+/// Local download state of a dictionary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DownloadState {
+    /// No installation directory exists.
+    NotDownloaded,
+    /// A complete installation exists at the contained path.
+    Downloaded(PathBuf),
+    /// An installation directory exists but required files are missing.
+    Incomplete(PathBuf),
+}
+
+/// One row of the dictionary listing.
+#[derive(Debug)]
+struct DictionaryRow {
+    /// Dictionary name (e.g. `ipadic`).
+    name: String,
+    /// Whether the dictionary is embedded in the binary.
+    embedded: bool,
+    /// Local download state of the dictionary.
+    download: DownloadState,
+}
+
+/// Runs the `list` subcommand.
+///
+/// Prints a table of all known dictionaries showing whether each one is
+/// embedded in the binary (via `embed-*` cargo features) and whether a
+/// pre-built copy is downloaded locally (see `lindera download`).
+///
+/// # Arguments
+///
+/// * `_args` - Parsed command line arguments (none).
+///
+/// # Returns
+///
+/// `Ok(())` when the listing is printed. An `Io` error when the application
+/// data directory cannot be determined.
 pub fn list(_args: ListArgs) -> LinderaResult<()> {
-    for dic in DictionaryKind::contained_variants() {
-        println!("{}", dic.as_str());
-    }
+    let embedded: Vec<String> = DictionaryKind::contained_variants()
+        .iter()
+        .map(|kind| kind.as_str().to_string())
+        .collect();
+    let base = base_data_dir(std::env::var_os(DATA_DIR_ENV).map(PathBuf::from))?;
+    let rows = dictionary_rows(&embedded, &base, get_version());
+    print!("{}", render_rows(&rows));
     Ok(())
+}
+
+/// Collects the listing rows for all known dictionaries.
+///
+/// The listed set is the union of [`DOWNLOADABLE_DICTIONARIES`] and the
+/// embedded dictionary names. Download detection only considers the given
+/// CLI version's installation directory, matching how `tokenize --dict`
+/// resolves dictionary names.
+///
+/// # Arguments
+///
+/// * `embedded` - Names of the dictionaries embedded in the binary.
+/// * `base` - Base application data directory (see `base_data_dir`).
+/// * `version` - Crate version of the running CLI.
+///
+/// # Returns
+///
+/// One row per known dictionary, in [`DOWNLOADABLE_DICTIONARIES`] order with
+/// any extra embedded names appended.
+fn dictionary_rows(embedded: &[String], base: &Path, version: &str) -> Vec<DictionaryRow> {
+    let mut names: Vec<String> = DOWNLOADABLE_DICTIONARIES
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect();
+    for name in embedded {
+        if !names.contains(name) {
+            names.push(name.clone());
+        }
+    }
+
+    names
+        .into_iter()
+        .map(|name| {
+            let dir = dictionary_dir(base, version, &name);
+            let download = if is_complete_dictionary_dir(&dir) {
+                DownloadState::Downloaded(dir)
+            } else if dir.is_dir() {
+                DownloadState::Incomplete(dir)
+            } else {
+                DownloadState::NotDownloaded
+            };
+            DictionaryRow {
+                embedded: embedded.contains(&name),
+                name,
+                download,
+            }
+        })
+        .collect()
+}
+
+/// Renders listing rows as a column-aligned table.
+///
+/// # Arguments
+///
+/// * `rows` - Listing rows to render.
+///
+/// # Returns
+///
+/// The table as a string with a header line and one line per row, each
+/// terminated by a newline. Columns are separated by two spaces; the `PATH`
+/// column shows [`NO_PATH`] when no installation directory exists.
+fn render_rows(rows: &[DictionaryRow]) -> String {
+    let cells: Vec<[String; 4]> = rows
+        .iter()
+        .map(|row| {
+            let (downloaded, path) = match &row.download {
+                DownloadState::NotDownloaded => ("no".to_string(), NO_PATH.to_string()),
+                DownloadState::Downloaded(dir) => ("yes".to_string(), dir.display().to_string()),
+                DownloadState::Incomplete(dir) => {
+                    ("incomplete".to_string(), dir.display().to_string())
+                }
+            };
+            let embedded = if row.embedded { "yes" } else { "no" };
+            [row.name.clone(), embedded.to_string(), downloaded, path]
+        })
+        .collect();
+
+    // Width of each column except the last, which is left unpadded.
+    let mut widths = [HEADERS[0].len(), HEADERS[1].len(), HEADERS[2].len()];
+    for row in &cells {
+        for (width, cell) in widths.iter_mut().zip(row.iter()) {
+            *width = (*width).max(cell.len());
+        }
+    }
+
+    let mut output = String::new();
+    render_line(&mut output, &HEADERS.map(str::to_string), &widths);
+    for row in &cells {
+        render_line(&mut output, row, &widths);
+    }
+    output
+}
+
+/// Appends one table line to the output buffer.
+///
+/// # Arguments
+///
+/// * `output` - Buffer receiving the rendered line.
+/// * `cells` - Cell values of the line.
+/// * `widths` - Padded widths of all columns except the last.
+fn render_line(output: &mut String, cells: &[String; 4], widths: &[usize; 3]) {
+    for (cell, width) in cells.iter().zip(widths.iter()) {
+        output.push_str(&format!("{cell:<width$}  "));
+    }
+    output.push_str(&cells[3]);
+    output.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use crate::dictionary_registry::REQUIRED_DICTIONARY_FILES;
+
+    use super::*;
+
+    /// Creates the given files (with dummy content) inside a directory.
+    fn create_files(dir: &Path, files: &[&str]) {
+        fs::create_dir_all(dir).unwrap();
+        for file in files {
+            fs::write(dir.join(file), b"test").unwrap();
+        }
+    }
+
+    /// Returns the row with the given name, panicking when absent.
+    fn row_by_name<'a>(rows: &'a [DictionaryRow], name: &str) -> &'a DictionaryRow {
+        rows.iter()
+            .find(|row| row.name == name)
+            .unwrap_or_else(|| panic!("row {name} not found"))
+    }
+
+    #[test]
+    fn rows_cover_all_downloadable_dictionaries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rows = dictionary_rows(&[], tmp.path(), "5.1.0");
+        let names: Vec<&str> = rows.iter().map(|row| row.name.as_str()).collect();
+        assert_eq!(names, DOWNLOADABLE_DICTIONARIES.to_vec());
+        assert!(
+            rows.iter()
+                .all(|row| !row.embedded && row.download == DownloadState::NotDownloaded)
+        );
+    }
+
+    #[test]
+    fn complete_installation_is_reported_with_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = dictionary_dir(tmp.path(), "5.1.0", "ipadic");
+        create_files(&dir, &REQUIRED_DICTIONARY_FILES);
+
+        let rows = dictionary_rows(&[], tmp.path(), "5.1.0");
+        assert_eq!(
+            row_by_name(&rows, "ipadic").download,
+            DownloadState::Downloaded(dir)
+        );
+    }
+
+    #[test]
+    fn incomplete_installation_is_reported() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = dictionary_dir(tmp.path(), "5.1.0", "unidic");
+        create_files(&dir, &["metadata.json"]);
+
+        let rows = dictionary_rows(&[], tmp.path(), "5.1.0");
+        assert_eq!(
+            row_by_name(&rows, "unidic").download,
+            DownloadState::Incomplete(dir)
+        );
+    }
+
+    #[test]
+    fn other_version_installation_is_not_reported() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = dictionary_dir(tmp.path(), "5.0.0", "ipadic");
+        create_files(&dir, &REQUIRED_DICTIONARY_FILES);
+
+        let rows = dictionary_rows(&[], tmp.path(), "5.1.0");
+        assert_eq!(
+            row_by_name(&rows, "ipadic").download,
+            DownloadState::NotDownloaded
+        );
+    }
+
+    #[test]
+    fn embedded_flag_follows_embedded_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let embedded = vec!["ipadic".to_string()];
+        let rows = dictionary_rows(&embedded, tmp.path(), "5.1.0");
+        assert!(row_by_name(&rows, "ipadic").embedded);
+        assert!(!row_by_name(&rows, "unidic").embedded);
+    }
+
+    #[test]
+    fn embedded_name_outside_downloadable_set_is_appended() {
+        let tmp = tempfile::tempdir().unwrap();
+        let embedded = vec!["custom-dic".to_string()];
+        let rows = dictionary_rows(&embedded, tmp.path(), "5.1.0");
+        let row = row_by_name(&rows, "custom-dic");
+        assert!(row.embedded);
+        assert_eq!(rows.len(), DOWNLOADABLE_DICTIONARIES.len() + 1);
+    }
+
+    #[test]
+    fn render_aligns_columns_and_marks_states() {
+        let rows = vec![
+            DictionaryRow {
+                name: "ipadic".to_string(),
+                embedded: true,
+                download: DownloadState::Downloaded(PathBuf::from("/data/lindera-ipadic")),
+            },
+            DictionaryRow {
+                name: "ipadic-neologd".to_string(),
+                embedded: false,
+                download: DownloadState::NotDownloaded,
+            },
+            DictionaryRow {
+                name: "unidic".to_string(),
+                embedded: false,
+                download: DownloadState::Incomplete(PathBuf::from("/data/lindera-unidic")),
+            },
+        ];
+
+        let expected = "\
+NAME            EMBEDDED  DOWNLOADED  PATH
+ipadic          yes       yes         /data/lindera-ipadic
+ipadic-neologd  no        no          -
+unidic          no        incomplete  /data/lindera-unidic
+";
+        assert_eq!(render_rows(&rows), expected);
+    }
 }


### PR DESCRIPTION
## Summary

`lindera list` previously enumerated only the dictionaries embedded via `embed-*` cargo features, so a default build printed nothing and dictionaries installed by `lindera download` (#893, #895) were invisible. This PR extends the subcommand to list all known dictionaries with their embedded/downloaded status.

```text
NAME            EMBEDDED  DOWNLOADED  PATH
ipadic          no        yes         /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-ipadic
ipadic-neologd  no        no          -
unidic          no        incomplete  /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-unidic
ko-dic          no        no          -
cc-cedict       no        no          -
jieba           no        no          -
```

## Changes

- `lindera-cli/src/commands/list.rs`:
  - The listed set is the union of `DOWNLOADABLE_DICTIONARIES` and the embedded dictionary names (the union logic absorbs any future divergence between the two sets).
  - Download detection reuses `dictionary_dir` / `is_complete_dictionary_dir` and only considers the running CLI's version directory, matching `tokenize --dict <name>` resolution; `LINDERA_DATA_DIR` is respected. An existing but incomplete installation is shown as `incomplete`.
  - Row collection (`dictionary_rows`) and table rendering (`render_rows`) are pure functions so they can be unit-tested with a temp directory.
- Docs: updated the `## list` section of `docs/src/lindera-cli/commands.md` and `docs/ja/src/lindera-cli/commands.md`.

Note: this changes the output format from the previous one-name-per-line listing. `list` is a human-facing command and the `download` subcommand has just been introduced, so this is the right time for the change.

## Verification

- `cargo test -p lindera-cli`: 42 tests pass (35 existing + 7 new covering not-downloaded / complete / incomplete / other-version-ignored / embedded-flag / union / rendering).
- `cargo fmt --all -- --check`, `cargo clippy -p lindera-cli --all-targets`: clean.
- `markdownlint-cli2` on `docs/src` and `docs/ja/src`: 0 errors (204 files).
- Manual run: default build with no downloads shows all six dictionaries as `no` / `-`; with a `LINDERA_DATA_DIR` fixture containing a complete ipadic and an incomplete unidic, the states above are reported.
- Embedded-flag behavior is covered by unit tests; `embed-*` builds are left to CI (heavy dictionary build locally).

Closes #897
