### PR TITLE
ci: cover lindera-binding-core in regression and periodic workflows

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -260,6 +260,25 @@ jobs:
       - name: Run test
         run: cargo test -p lindera-analysis --features embed-ipadic,embed-ko-dic
 
+  test-lindera-binding-core:
+    name: Test lindera-binding-core (${{ matrix.toolchain }})
+    needs: [test-lindera-analysis]
+    strategy:
+      matrix:
+        toolchain: [stable, beta, nightly]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v7
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Run test
+        run: cargo test -p lindera-binding-core
+
   test-lindera-cli:
     name: Test lindera-cli (${{ matrix.toolchain }})
     needs: [test-lindera]

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -39,6 +39,7 @@ jobs:
       lindera-jieba: ${{ steps.filter.outputs.lindera-jieba }}
       lindera: ${{ steps.filter.outputs.lindera }}
       lindera-analysis: ${{ steps.filter.outputs.lindera-analysis }}
+      lindera-binding-core: ${{ steps.filter.outputs.lindera-binding-core }}
       lindera-cli: ${{ steps.filter.outputs.lindera-cli }}
       lindera-python: ${{ steps.filter.outputs.lindera-python }}
       lindera-nodejs: ${{ steps.filter.outputs.lindera-nodejs }}
@@ -99,6 +100,12 @@ jobs:
               - 'lindera-dictionary/**'
               - 'lindera-ipadic/**'
               - 'lindera-ko-dic/**'
+            lindera-binding-core:
+              - 'lindera-binding-core/**'
+              - 'lindera-analysis/**'
+              - 'lindera/**'
+              - 'lindera-crf/**'
+              - 'lindera-dictionary/**'
             lindera-cli:
               - 'lindera-cli/**'
               - 'lindera/**'
@@ -114,6 +121,7 @@ jobs:
               - 'lindera-jieba/**'
             lindera-python:
               - 'lindera-python/**'
+              - 'lindera-binding-core/**'
               - 'lindera/**'
               - 'lindera-analysis/**'
               - 'lindera-crf/**'
@@ -127,6 +135,7 @@ jobs:
               - 'lindera-jieba/**'
             lindera-nodejs:
               - 'lindera-nodejs/**'
+              - 'lindera-binding-core/**'
               - 'lindera/**'
               - 'lindera-analysis/**'
               - 'lindera-crf/**'
@@ -140,6 +149,7 @@ jobs:
               - 'lindera-jieba/**'
             lindera-ruby:
               - 'lindera-ruby/**'
+              - 'lindera-binding-core/**'
               - 'lindera/**'
               - 'lindera-analysis/**'
               - 'lindera-crf/**'
@@ -153,6 +163,7 @@ jobs:
               - 'lindera-jieba/**'
             lindera-php:
               - 'lindera-php/**'
+              - 'lindera-binding-core/**'
               - 'lindera/**'
               - 'lindera-analysis/**'
               - 'lindera-crf/**'
@@ -166,6 +177,7 @@ jobs:
               - 'lindera-jieba/**'
             lindera-wasm:
               - 'lindera-wasm/**'
+              - 'lindera-binding-core/**'
               - 'lindera/**'
               - 'lindera-analysis/**'
               - 'lindera-crf/**'
@@ -335,6 +347,16 @@ jobs:
       crate: lindera-analysis
       features: "--features embed-ipadic,embed-ko-dic"
 
+  test-lindera-binding-core:
+    name: Test lindera-binding-core
+    needs: [test-lindera-analysis, detect-changes]
+    if: >-
+      !cancelled() && !failure() &&
+      (github.event_name != 'pull_request' || needs.detect-changes.outputs.lindera-binding-core == 'true')
+    uses: ./.github/workflows/test-crate.yml
+    with:
+      crate: lindera-binding-core
+
   test-lindera-cli:
     name: Test lindera-cli
     needs: [test-lindera, test-lindera-analysis, detect-changes]
@@ -348,7 +370,7 @@ jobs:
 
   test-lindera-python:
     name: Test lindera-python
-    needs: [test-lindera, test-lindera-analysis, detect-changes]
+    needs: [test-lindera, test-lindera-analysis, test-lindera-binding-core, detect-changes]
     if: >-
       !cancelled() && !failure() &&
       (github.event_name != 'pull_request' || needs.detect-changes.outputs.lindera-python == 'true')
@@ -372,7 +394,7 @@ jobs:
 
   test-lindera-nodejs:
     name: Test lindera-nodejs
-    needs: [test-lindera, test-lindera-analysis, detect-changes]
+    needs: [test-lindera, test-lindera-analysis, test-lindera-binding-core, detect-changes]
     if: >-
       !cancelled() && !failure() &&
       (github.event_name != 'pull_request' || needs.detect-changes.outputs.lindera-nodejs == 'true')
@@ -406,7 +428,7 @@ jobs:
 
   test-lindera-ruby:
     name: Test lindera-ruby
-    needs: [test-lindera, test-lindera-analysis, detect-changes]
+    needs: [test-lindera, test-lindera-analysis, test-lindera-binding-core, detect-changes]
     if: >-
       !cancelled() && !failure() &&
       (github.event_name != 'pull_request' || needs.detect-changes.outputs.lindera-ruby == 'true')
@@ -432,7 +454,7 @@ jobs:
 
   test-lindera-php:
     name: Test lindera-php
-    needs: [test-lindera, test-lindera-analysis, detect-changes]
+    needs: [test-lindera, test-lindera-analysis, test-lindera-binding-core, detect-changes]
     if: >-
       !cancelled() && !failure() &&
       (github.event_name != 'pull_request' || needs.detect-changes.outputs.lindera-php == 'true')
@@ -456,7 +478,7 @@ jobs:
 
   test-lindera-wasm:
     name: Test lindera-wasm
-    needs: [test-lindera, test-lindera-analysis, detect-changes]
+    needs: [test-lindera, test-lindera-analysis, test-lindera-binding-core, detect-changes]
     if: >-
       !cancelled() && !failure() &&
       (github.event_name != 'pull_request' || needs.detect-changes.outputs.lindera-wasm == 'true')


### PR DESCRIPTION
## What

Closes #906.

The `dorny/paths-filter` config in `regression.yml` did not reference `lindera-binding-core` anywhere, and neither `regression.yml` nor `periodic.yml` had a test job for the crate. Consequences:

- A PR touching only `lindera-binding-core/**` ran **none** of the five binding test jobs, even though every binding routes all tokenize calls through `CoreTokenizer` in that crate.
- The crate's own unit tests (22 tests) never ran in CI at all.

## Changes

- `regression.yml`
  - New `lindera-binding-core` filter (crate + dependency crates `lindera-analysis`, `lindera`, `lindera-crf`, `lindera-dictionary`; no dictionary crates since the crate has no embed features) and matching job output.
  - New `test-lindera-binding-core` job via the reusable `test-crate.yml` (no feature flags), following the sibling jobs' `!cancelled() && !failure()` conditional pattern.
  - `- 'lindera-binding-core/**'` added to the paths-filters of all five binding jobs (python, nodejs, ruby, php, wasm), and `test-lindera-binding-core` added to their `needs` chains. A skipped binding-core job does not block binding jobs (same semantics as `test-lindera-analysis` today).
- `periodic.yml`
  - New `test-lindera-binding-core` job (stable/beta/nightly matrix) mirroring the other crate jobs.

## Verification

- YAML validity checked for both workflow files.
- `cargo test -p lindera-binding-core` locally: 22 passed — identical to the new job's command.
- This PR itself touches only `.github/**`, so job-trigger behavior for `lindera-binding-core/**` changes will be exercised by the first #881 child PR (#908).

## Related

- Prerequisite for the #881 PR series (found during its investigation).
