### PR TITLE
feat(core): add reusable SegmentWorker with automatic lattice shrink

### DIFF
--- a/docs/ja/src/concepts/tokenization.md
+++ b/docs/ja/src/concepts/tokenization.md
@@ -142,3 +142,5 @@ use lindera_dictionary::viterbi::Lattice;
 let mut lattice = Lattice::default();
 let results = tokenizer.tokenize_nbest_with_lattice(text, &mut lattice, 3, false, None)?;
 ```
+
+セグメンターのレベルでは、`SegmentWorker`（`Segmenter::new_worker` で作成）がこのパターンをラティスとスクラッチバッファを所有するセッションオブジェクトとしてまとめており、さらに自動縮小ポリシーで保持メモリも制限します。詳細は [Segmenter](../lindera/segmenter.md) のページを参照してください。

--- a/docs/ja/src/lindera/segmenter.md
+++ b/docs/ja/src/lindera/segmenter.md
@@ -157,3 +157,23 @@ for (tokens, cost) in results {
 ```
 
 `segment_nbest_with_lattice` は同じ処理を行いますが、呼び出しごとの `Lattice` バッファの再確保を避けるために、再利用可能な `Lattice` を自分で渡すことができます。
+
+## 再利用可能な Worker
+
+`SegmentWorker` は、Viterbi ラティスとバックトレース用スクラッチバッファを所有する再利用可能なセグメンテーションセッションです。呼び出しのたびに `segment` が支払うアロケーションを回避できます。`new_worker`（セグメンターを clone）または `into_worker`（セグメンターを消費し、ユーザー辞書のコピーを回避）で作成し、`segment`/`segment_nbest` を呼び出します：
+
+```rust
+let mut worker = segmenter.new_worker();
+for line in lines {
+    let tokens = worker.segment(line)?;
+    for token in &tokens {
+        println!("{}", token.surface.as_ref());
+    }
+}
+```
+
+返されるトークンは worker を借用するため、次の呼び出しの前に消費する必要があります（上記のような行単位のループはそのままコンパイルできます）。`set_mode` と `set_keep_whitespace` で呼び出しごとに設定を切り替えられます。
+
+Worker は保持メモリも制限します。区切り文字のない 32 KiB の文を 1 回処理するとラティスは約 20 MB まで成長し、素の `Lattice` はそれを保持し続けます。Worker は一定回数の呼び出し窓で容量が過大と判明した場合に自動でラティスを縮小し、`shrink_to(text_len_hint)` で即時に縮小することもできます。
+
+Worker は作成元セグメンターの辞書に恒久的に紐付けられ、稼働中の worker の辞書を差し替える手段はありません。これにより、ラティス再利用に起因するバグの一群を構造的に排除しています。マルチスレッドで使う場合は、共有の `Segmenter` からスレッドごとに worker を 1 つ作成してください。

--- a/docs/src/concepts/tokenization.md
+++ b/docs/src/concepts/tokenization.md
@@ -142,3 +142,5 @@ use lindera_dictionary::viterbi::Lattice;
 let mut lattice = Lattice::default();
 let results = tokenizer.tokenize_nbest_with_lattice(text, &mut lattice, 3, false, None)?;
 ```
+
+At the segmenter level, `SegmentWorker` (created via `Segmenter::new_worker`) packages this pattern into a session object that owns the lattice and scratch buffers, and additionally bounds retained memory with an automatic shrink policy. See the [Segmenter](../lindera/segmenter.md) page for details.

--- a/docs/src/lindera/segmenter.md
+++ b/docs/src/lindera/segmenter.md
@@ -157,3 +157,23 @@ for (tokens, cost) in results {
 ```
 
 `segment_nbest_with_lattice` is the same operation but lets you pass in a reusable `Lattice` buffer to avoid reallocating one per call.
+
+## Reusable Worker
+
+`SegmentWorker` is a reusable segmentation session that owns the Viterbi lattice and the backtrace scratch buffer, so repeated calls avoid the per-call allocations `segment` pays. Create one with `new_worker` (clones the segmenter) or `into_worker` (consumes it, avoiding a user-dictionary copy), then call `segment`/`segment_nbest` on it:
+
+```rust
+let mut worker = segmenter.new_worker();
+for line in lines {
+    let tokens = worker.segment(line)?;
+    for token in &tokens {
+        println!("{}", token.surface.as_ref());
+    }
+}
+```
+
+The returned tokens borrow the worker, so they must be consumed before the next call (the usual per-line loop above compiles as-is). `set_mode` and `set_keep_whitespace` switch the configuration between calls.
+
+A worker also bounds retained memory: one delimiter-free 32 KiB sentence grows the lattice to roughly 20 MB, and a plain `Lattice` keeps that forever. The worker automatically shrinks its lattice once a window of calls shows the capacity is oversized, and `shrink_to(text_len_hint)` forces a shrink immediately.
+
+The worker is permanently bound to the dictionary of the segmenter that created it; there is no way to swap dictionaries under a live worker, which rules out a class of lattice-reuse bugs by construction. For multi-threaded use, create one worker per thread from a shared `Segmenter`.

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -433,6 +433,71 @@ impl Lattice {
         }
     }
 
+    /// Returns the lattice's current slot capacity: the largest sentence
+    /// length (in bytes) whose `ends_at` slots are already allocated.
+    ///
+    /// # 戻り値
+    ///
+    /// The capacity in bytes. `0` for a fresh lattice.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Shrinks the internal buffers down to what a sentence of `text_len`
+    /// bytes needs, releasing memory retained after processing a long
+    /// sentence.
+    ///
+    /// The lattice grows monotonically (`set_capacity` never shrinks), so a
+    /// single long sentence pins its worst-case allocation for the lifetime
+    /// of the lattice. Long-lived holders (e.g. a reusable worker) can call
+    /// this to bound retention. This is never called on the hot path:
+    /// `clear()`/`set_text` stay shrink-free (#877/#884).
+    ///
+    /// Invariants preserved:
+    /// - Every remaining `ends_at` slot keeps a capacity of at least 16, the
+    ///   pre-size that avoids first-growth reallocations (#827/#841).
+    /// - `clear()` runs first, so all slots are empty and the
+    ///   `last_text_len` bound (#877) stays valid after truncation.
+    ///
+    /// # 引数
+    ///
+    /// * `text_len` - Target sentence length in bytes; buffers are reduced
+    ///   to what a sentence of this length requires. Buffers already at or
+    ///   below the target are left untouched.
+    pub fn shrink_to(&mut self, text_len: usize) {
+        self.clear();
+        let slots = text_len + 1;
+        if self.capacity > text_len {
+            self.ends_at.truncate(slots);
+            self.ends_at.shrink_to(slots);
+            for slot in &mut self.ends_at {
+                // Keep the per-slot pre-size intact (#841); only release
+                // growth beyond it.
+                slot.shrink_to(16);
+            }
+            self.capacity = text_len;
+        }
+        if self.nbest_capacity > text_len {
+            self.all_paths.truncate(slots);
+            self.all_paths.shrink_to(slots);
+            for paths in &mut self.all_paths {
+                paths.shrink_to(0);
+            }
+            self.nbest_capacity = text_len;
+        }
+        // All slots are empty after clear() + truncate, so lowering the
+        // clear()/backtrace bound is safe (its debug_asserts hold trivially).
+        self.last_text_len = self.last_text_len.min(text_len);
+        // Scratch buffers are sized per sentence content, not per slot; the
+        // bounds below are heuristics (roughly: categories per char, matches
+        // per start position), not correctness requirements — set_text
+        // regrows them on demand.
+        self.char_info_buffer.shrink_to(text_len);
+        self.categories_buffer.shrink_to(4 * text_len);
+        self.matches_head.shrink_to(slots);
+        self.matches_store.shrink_to(8 * slots);
+    }
+
     #[inline(never)]
     // Forward Viterbi implementation:
     // Constructs the lattice and calculates the path costs simultaneously.
@@ -1380,6 +1445,114 @@ mod tests {
         assert_eq!(offsets.len(), 1);
         assert_eq!(offsets[0].0, 0);
         assert_eq!(offsets[0].1, WordId::new(LexType::System, 42));
+    }
+
+    /// `shrink_to` must release slots beyond the target while preserving
+    /// the #841 per-slot pre-size on the remaining slots, and the lattice
+    /// must regrow correctly (pre-sized) afterwards.
+    #[test]
+    fn test_shrink_to_truncates_and_keeps_presize() {
+        let mut lattice = Lattice::default();
+
+        lattice.set_capacity(100);
+        lattice.ends_at[0].push(test_edge(1, 0, 0, u16::MAX));
+        lattice.ends_at[100].push(test_edge(2, 0, 100, 0));
+
+        lattice.shrink_to(10);
+        assert_eq!(lattice.capacity(), 10);
+        assert_eq!(lattice.ends_at.len(), 11);
+        assert!(
+            lattice.ends_at.iter().all(|v| v.is_empty()),
+            "shrink_to must clear all slots"
+        );
+        for (i, slot) in lattice.ends_at.iter().enumerate() {
+            assert!(
+                slot.capacity() >= 16,
+                "slot {} lost its pre-size after shrink_to (capacity {})",
+                i,
+                slot.capacity()
+            );
+        }
+
+        // Regrowth after a shrink must pre-size the appended slots again.
+        lattice.set_capacity(50);
+        assert_eq!(lattice.ends_at.len(), 51);
+        for (i, slot) in lattice.ends_at.iter().enumerate() {
+            assert!(
+                slot.capacity() >= 16,
+                "slot {} not pre-sized after regrowth (capacity {})",
+                i,
+                slot.capacity()
+            );
+        }
+    }
+
+    /// `shrink_to` with a target at or above the current capacity must be a
+    /// no-op for the slot vectors (no truncation, no capacity change).
+    #[test]
+    fn test_shrink_to_noop_when_target_not_smaller() {
+        let mut lattice = Lattice::default();
+        lattice.set_capacity(5);
+
+        lattice.shrink_to(100);
+        assert_eq!(lattice.capacity(), 5);
+        assert_eq!(lattice.ends_at.len(), 6);
+
+        lattice.shrink_to(5);
+        assert_eq!(lattice.capacity(), 5);
+        assert_eq!(lattice.ends_at.len(), 6);
+
+        // A fresh lattice tolerates shrink_to without panicking.
+        let mut fresh = Lattice::default();
+        fresh.shrink_to(0);
+        assert_eq!(fresh.capacity(), 0);
+        assert!(fresh.ends_at.is_empty());
+    }
+
+    /// A lattice must produce a correct backtrace when used again after
+    /// `shrink_to`: the `last_text_len` bound and the EOS scan start must
+    /// stay consistent (same guarantee as the #877 regression tests, with a
+    /// shrink in between).
+    #[test]
+    fn test_backtrace_works_after_shrink_to() {
+        let mut lattice = Lattice::default();
+        lattice.set_capacity(100);
+        lattice.ends_at[0].push(test_edge(1, 0, 0, u16::MAX));
+        lattice.ends_at[100].push(test_edge(2, 0, 100, 0));
+
+        lattice.shrink_to(10);
+
+        // Hand-assemble a 3-byte sentence path, as in the #877 tests.
+        lattice.set_capacity(3);
+        lattice.ends_at[0].push(test_edge(0, 0, 0, u16::MAX)); // BOS
+        lattice.ends_at[3].push(test_edge(42, 0, 3, 0)); // token A
+        lattice.ends_at[3].push(test_edge(0, 3, 3, 0)); // EOS -> token A
+
+        let offsets = lattice.tokens_offset();
+        assert_eq!(offsets.len(), 1);
+        assert_eq!(offsets[0].0, 0);
+        assert_eq!(offsets[0].1, WordId::new(LexType::System, 42));
+
+        // clear() after the shrink must leave nothing behind.
+        lattice.clear();
+        assert!(lattice.ends_at.iter().all(|v| v.is_empty()));
+    }
+
+    /// `shrink_to` must also release the N-Best `all_paths` slots.
+    #[test]
+    fn test_shrink_to_releases_nbest_paths() {
+        let mut lattice = Lattice::default();
+        lattice.set_capacity_nbest(100);
+        assert_eq!(lattice.all_paths.len(), 101);
+
+        lattice.shrink_to(10);
+        assert_eq!(lattice.all_paths.len(), 11);
+        assert_eq!(lattice.nbest_capacity, 10);
+        assert!(lattice.all_paths.iter().all(|v| v.is_empty()));
+
+        // Regrowth of the nbest side after a shrink.
+        lattice.set_capacity_nbest(20);
+        assert_eq!(lattice.all_paths.len(), 21);
     }
 
     /// `tokens_offset_into` must clear the caller's buffer and produce the

--- a/lindera/benches/bench_ipadic.rs
+++ b/lindera/benches/bench_ipadic.rs
@@ -139,6 +139,79 @@ fn bench_tokenize_with_simple_userdic_ipadic(c: &mut Criterion) {
     });
 }
 
+/// Short text matching the per-call binding workload #881 targets. All
+/// three variants below return the token count so the worker variant
+/// (whose tokens borrow the worker and cannot leave the closure) stays
+/// comparable with the fresh/lattice variants.
+#[cfg(feature = "embed-ipadic")]
+const SHORT_TEXT: &str = "すもももももももものうち";
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_segment_short_ipadic(c: &mut Criterion) {
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+
+    c.bench_function("bench-segment-short-ipadic", |b| {
+        b.iter(|| segmenter.segment(Cow::Borrowed(SHORT_TEXT)).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_segment_short_with_lattice_ipadic(c: &mut Criterion) {
+    use lindera::dictionary::Lattice;
+
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+
+    c.bench_function("bench-segment-short-with-lattice-ipadic", |b| {
+        let mut lattice = Lattice::default();
+        b.iter(|| {
+            segmenter
+                .segment_with_lattice(Cow::Borrowed(SHORT_TEXT), &mut lattice)
+                .unwrap()
+                .len()
+        })
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_segment_short_worker_ipadic(c: &mut Criterion) {
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+
+    c.bench_function("bench-segment-short-worker-ipadic", |b| {
+        let mut worker = segmenter.new_worker();
+        b.iter(|| worker.segment(SHORT_TEXT).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_tokenize_with_worker_ipadic(c: &mut Criterion) {
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+
+    c.bench_function("bench-tokenize-with-worker-ipadic", |b| {
+        let mut worker = segmenter.new_worker();
+        b.iter(|| worker.segment("検索エンジン（けんさくエンジン、英語: search engine）は、狭義にはインターネットに存在する情報（ウェブページ、ウェブサイト、画像ファイル、ネットニュースなど）を検索する機能およびそのプログラム。").unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_segment_nbest_worker_ipadic(c: &mut Criterion) {
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+
+    c.bench_function("bench-segment-nbest-worker-ipadic", |b| {
+        let mut worker = segmenter.new_worker();
+        b.iter(|| {
+            worker
+                .segment_nbest(SHORT_TEXT, 5, false, None)
+                .unwrap()
+                .len()
+        })
+    });
+}
+
 #[cfg(feature = "embed-ipadic")]
 fn bench_tokenize_long_text_ipadic(c: &mut Criterion) {
     let mut long_text_file = BufReader::new(
@@ -196,10 +269,15 @@ criterion_group!(
     bench_clone_ipadic,
     bench_tokenize_ipadic,
     bench_tokenize_with_lattice_ipadic,
+    bench_tokenize_with_worker_ipadic,
     bench_tokenize_with_simple_userdic_ipadic,
     bench_tokenize_long_text_ipadic,
     bench_tokenize_details_long_text_ipadic,
     bench_segment_nbest_ipadic,
+    bench_segment_nbest_worker_ipadic,
+    bench_segment_short_ipadic,
+    bench_segment_short_with_lattice_ipadic,
+    bench_segment_short_worker_ipadic,
 );
 
 #[cfg(feature = "embed-ipadic")]

--- a/lindera/src/lib.rs
+++ b/lindera/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod mode;
 pub mod segmenter;
 pub mod token;
+pub mod worker;
 
 pub type LinderaResult<T> = lindera_dictionary::LinderaResult<T>;
 

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -27,7 +27,7 @@ pub type SegmenterConfig = Value;
 /// error or warning (see <https://github.com/lindera/lindera/issues/871>).
 /// 32 KiB stays well under both that saturation point and downstream
 /// consumers' own token-length limits (e.g. tantivy's `MAX_TOKEN_LEN`).
-const MAX_SENTENCE_BYTES: usize = 32 * 1024;
+pub(crate) const MAX_SENTENCE_BYTES: usize = 32 * 1024;
 
 /// Finds the end of the next sentence starting at `sentence_start`, scanning
 /// for a real sentence delimiter (`\n`, `\t`, `。`, `、`) or, failing that,
@@ -386,6 +386,36 @@ impl Segmenter {
         text: Cow<'a, str>,
         lattice: &mut Lattice,
     ) -> LinderaResult<Vec<Token<'a>>> {
+        // The backtrace buffer is allocated once per call; SegmentWorker
+        // routes through segment_with_buffers to reuse it across calls too.
+        let mut offsets: Vec<(usize, WordId)> = Vec::new();
+        self.segment_with_buffers(text, lattice, &mut offsets)
+    }
+
+    /// Segments the input text reusing both the caller's lattice and the
+    /// caller's backtrace scratch buffer.
+    ///
+    /// This is the shared body behind [`Segmenter::segment_with_lattice`]
+    /// (which passes a fresh buffer) and `SegmentWorker::segment` (which
+    /// keeps one buffer alive across calls). Output is identical to
+    /// `segment_with_lattice` for the same input.
+    ///
+    /// # 引数
+    ///
+    /// * `text` - The input text, borrowed or owned.
+    /// * `lattice` - The Viterbi lattice to reuse across sentences/calls.
+    /// * `offsets` - Backtrace scratch buffer; overwritten per sentence
+    ///   (`tokens_offset_into` clears it), so no pre-clearing is required.
+    ///
+    /// # 戻り値
+    ///
+    /// The tokens segmented from `text`, in reading order.
+    pub(crate) fn segment_with_buffers<'a>(
+        &'a self,
+        text: Cow<'a, str>,
+        lattice: &mut Lattice,
+        offsets: &mut Vec<(usize, WordId)>,
+    ) -> LinderaResult<Vec<Token<'a>>> {
         let mut tokens: Vec<Token> = Vec::new();
 
         let mut position = 0_usize;
@@ -394,10 +424,6 @@ impl Segmenter {
         // Process whole text without splitting first for better performance with borrowed text
         let text_len = text.len();
         let mut sentence_start = 0;
-
-        // Reused across sentences so the backtrace buffer is allocated once
-        // per call instead of once per sentence.
-        let mut offsets: Vec<(usize, WordId)> = Vec::new();
 
         while sentence_start < text_len {
             // Find the end of the current sentence
@@ -426,7 +452,7 @@ impl Segmenter {
             );
             // Forward Viterbi implementation handles cost calculation within `set_text`.
 
-            lattice.tokens_offset_into(&mut offsets);
+            lattice.tokens_offset_into(offsets);
             tokens.reserve(offsets.len());
 
             for i in 0..offsets.len() {

--- a/lindera/src/token.rs
+++ b/lindera/src/token.rs
@@ -134,6 +134,27 @@ impl<'a> Token<'a> {
         }
     }
 
+    /// Returns an iterator over the token's details without allocating the
+    /// intermediate `Vec<&str>` that [`Token::details`] collects on every
+    /// call.
+    ///
+    /// Details are loaded (and cached) on first access, exactly as with
+    /// [`Token::details`]; only the per-call collection is avoided. Prefer
+    /// this accessor when the details are consumed once in order (joining,
+    /// serializing, copying into an FFI buffer).
+    ///
+    /// # 戻り値
+    ///
+    /// An iterator yielding each detail field as `&str`, in schema order.
+    pub fn details_iter(&mut self) -> impl Iterator<Item = &str> {
+        self.ensure_details();
+        self.details
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|c| c.as_ref())
+    }
+
     /// Helper method to ensure details are loaded without returning them
     fn ensure_details(&mut self) {
         if self.details.is_none() {
@@ -316,5 +337,44 @@ impl<'a> Token<'a> {
         }
 
         Value::Object(obj)
+    }
+}
+
+#[cfg(all(test, feature = "embed-ipadic"))]
+mod tests {
+    use std::borrow::Cow;
+
+    use lindera_dictionary::mode::Mode;
+
+    use crate::dictionary::load_dictionary;
+    use crate::segmenter::Segmenter;
+
+    /// `details_iter` must yield exactly the same fields, in the same
+    /// order, as the `Vec`-collecting `details()` accessor, for both known
+    /// and unknown words.
+    #[test]
+    fn test_details_iter_matches_details() {
+        let dictionary = match load_dictionary("embedded://ipadic") {
+            Ok(dictionary) => dictionary,
+            Err(err) => panic!("failed to load embedded IPADIC: {err}"),
+        };
+        let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+
+        // Mixed input: dictionary words plus an unknown (Latin) token.
+        let tokens = match segmenter.segment(Cow::Borrowed("すもももsupercalifragilisticも")) {
+            Ok(tokens) => tokens,
+            Err(err) => panic!("segment failed: {err}"),
+        };
+        assert!(!tokens.is_empty());
+
+        for mut token in tokens {
+            let expected: Vec<String> = {
+                let mut probe = token.clone();
+                probe.details().iter().map(|s| s.to_string()).collect()
+            };
+            let actual: Vec<String> = token.details_iter().map(|s| s.to_string()).collect();
+            assert_eq!(expected, actual, "surface {:?}", token.surface);
+            assert!(!actual.is_empty());
+        }
     }
 }

--- a/lindera/src/worker.rs
+++ b/lindera/src/worker.rs
@@ -1,0 +1,459 @@
+use std::borrow::Cow;
+
+use lindera_dictionary::mode::Mode;
+use lindera_dictionary::viterbi::{Lattice, WordId};
+
+use crate::LinderaResult;
+use crate::segmenter::{MAX_SENTENCE_BYTES, Segmenter};
+use crate::token::Token;
+
+/// Number of `segment`/`segment_nbest` calls between two automatic shrink
+/// checks. A window (rather than a per-call check) amortizes the check and
+/// avoids shrink/regrow thrashing on alternating long/short inputs.
+const SHRINK_WINDOW_CALLS: u32 = 64;
+
+/// Hysteresis factor for the automatic shrink: the lattice is only shrunk
+/// when its capacity exceeds the window's observed need by more than this
+/// factor, so a workload hovering around one size never thrashes.
+const SHRINK_HYSTERESIS: usize = 4;
+
+/// Floor (in bytes) below which the lattice is never shrunk. Typical
+/// line-oriented input stays under this, so the automatic policy never
+/// fires for it; worst-case retention above the floor is bounded to a few
+/// MB instead of the ~20 MB a 32 KiB sentence can pin.
+const SHRINK_FLOOR_BYTES: usize = 4 * 1024;
+
+/// A reusable segmentation session that owns the Viterbi [`Lattice`] and
+/// the backtrace scratch buffer, so repeated calls avoid the per-call
+/// allocations that `Segmenter::segment` pays.
+///
+/// A worker is created from a [`Segmenter`] via [`Segmenter::new_worker`]
+/// or [`Segmenter::into_worker`] — never constructed directly — so the
+/// lattice is permanently tied to one dictionary. Reusing a lattice across
+/// dictionaries was the source of a past correctness bug (see
+/// `lindera/tests/lattice_reuse_across_dictionaries.rs`); this type makes
+/// that misuse unrepresentable.
+///
+/// Tokens returned by [`SegmentWorker::segment`] borrow the worker, so the
+/// borrow checker requires consuming (or cloning from) them before the next
+/// call — the usual per-line loop works without annotations:
+///
+/// ```ignore
+/// let mut worker = segmenter.new_worker();
+/// for line in lines {
+///     let tokens = worker.segment(line)?;
+///     for token in &tokens {
+///         // use token.surface, ...
+///     }
+/// } // tokens dropped here; the next iteration may call segment again
+/// ```
+///
+/// The worker automatically bounds retained memory: one 32 KiB sentence
+/// grows the lattice to ~20 MB, and without intervention that stays pinned
+/// for the worker's lifetime. Every [`SHRINK_WINDOW_CALLS`] calls the
+/// worker compares the lattice capacity against the window's largest input
+/// (with a [`SHRINK_HYSTERESIS`]x margin and a [`SHRINK_FLOOR_BYTES`]
+/// floor) and shrinks it when oversized. [`SegmentWorker::shrink_to`]
+/// forces a shrink immediately.
+///
+/// The worker is `Send + Sync` (all fields are); the `&mut self` API means
+/// sharing one worker across threads requires external synchronization —
+/// the intended pattern is one worker per thread over a shared `Segmenter`.
+pub struct SegmentWorker {
+    /// The owned segmenter this worker is permanently bound to.
+    segmenter: Segmenter,
+    /// The reused Viterbi lattice (grows monotonically between shrinks).
+    lattice: Lattice,
+    /// Backtrace scratch reused across calls (cleared per sentence by
+    /// `tokens_offset_into`).
+    offsets: Vec<(usize, WordId)>,
+    /// Largest per-call input need (bytes, capped at one sentence) observed
+    /// in the current shrink window.
+    window_max_needed: usize,
+    /// Calls seen in the current shrink window.
+    calls_in_window: u32,
+}
+
+impl Segmenter {
+    /// Creates a reusable [`SegmentWorker`] bound to a clone of this
+    /// segmenter.
+    ///
+    /// The clone is cheap for the dictionary (`Arc`-backed) but deep-copies
+    /// the user dictionary if one is configured; when the segmenter itself
+    /// is no longer needed, prefer [`Segmenter::into_worker`] to avoid that
+    /// copy.
+    ///
+    /// # 戻り値
+    ///
+    /// A fresh worker with empty internal buffers.
+    pub fn new_worker(&self) -> SegmentWorker {
+        SegmentWorker::new(self.clone())
+    }
+
+    /// Consumes this segmenter and creates a reusable [`SegmentWorker`]
+    /// from it, without cloning the user dictionary.
+    ///
+    /// # 戻り値
+    ///
+    /// A fresh worker with empty internal buffers.
+    pub fn into_worker(self) -> SegmentWorker {
+        SegmentWorker::new(self)
+    }
+}
+
+impl SegmentWorker {
+    /// Creates a worker around an owned segmenter. Private: the only public
+    /// entry points are `Segmenter::new_worker`/`into_worker`, which keep
+    /// the dictionary↔lattice pairing fixed.
+    ///
+    /// # 引数
+    ///
+    /// * `segmenter` - The segmenter this worker is bound to.
+    ///
+    /// # 戻り値
+    ///
+    /// A worker with empty internal buffers.
+    fn new(segmenter: Segmenter) -> Self {
+        Self {
+            segmenter,
+            lattice: Lattice::default(),
+            offsets: Vec::new(),
+            window_max_needed: 0,
+            calls_in_window: 0,
+        }
+    }
+
+    /// Segments `text` reusing this worker's internal buffers.
+    ///
+    /// Produces exactly the same tokens as [`Segmenter::segment`] for the
+    /// same input and configuration. The returned tokens borrow both `text`
+    /// and this worker, so they must be consumed before the next call.
+    ///
+    /// # 引数
+    ///
+    /// * `text` - The input text to segment.
+    ///
+    /// # 戻り値
+    ///
+    /// The tokens segmented from `text`, in reading order.
+    pub fn segment<'w>(&'w mut self, text: &'w str) -> LinderaResult<Vec<Token<'w>>> {
+        self.maybe_auto_shrink(text.len());
+        let Self {
+            segmenter,
+            lattice,
+            offsets,
+            ..
+        } = self;
+        segmenter.segment_with_buffers(Cow::Borrowed(text), lattice, offsets)
+    }
+
+    /// Segments `text` and returns the top-N results with costs, reusing
+    /// this worker's lattice.
+    ///
+    /// Produces exactly the same results as [`Segmenter::segment_nbest`]
+    /// for the same input and configuration.
+    ///
+    /// # 引数
+    ///
+    /// * `text` - The input text to segment.
+    /// * `n` - Maximum number of segmentations to return.
+    /// * `unique` - Deduplicate results with identical word boundaries.
+    /// * `cost_threshold` - Discard paths costing more than best + threshold.
+    ///
+    /// # 戻り値
+    ///
+    /// Up to `n` `(tokens, cost)` pairs ordered by cost (best first).
+    pub fn segment_nbest<'w>(
+        &'w mut self,
+        text: &'w str,
+        n: usize,
+        unique: bool,
+        cost_threshold: Option<i64>,
+    ) -> LinderaResult<Vec<(Vec<Token<'w>>, i64)>> {
+        self.maybe_auto_shrink(text.len());
+        let Self {
+            segmenter, lattice, ..
+        } = self;
+        segmenter.segment_nbest_with_lattice(
+            Cow::Borrowed(text),
+            lattice,
+            n,
+            unique,
+            cost_threshold,
+        )
+    }
+
+    /// Sets the segmentation mode for subsequent calls.
+    ///
+    /// The mode carries no lattice state (it is passed anew to every
+    /// sentence), so switching per call is safe.
+    ///
+    /// # 引数
+    ///
+    /// * `mode` - The mode to use from the next call on.
+    pub fn set_mode(&mut self, mode: Mode) {
+        self.segmenter.mode = mode;
+    }
+
+    /// Sets whether whitespace tokens are kept in the output for
+    /// subsequent calls.
+    ///
+    /// # 引数
+    ///
+    /// * `keep` - `true` to keep whitespace tokens, `false` (MeCab-compatible
+    ///   default) to drop them.
+    pub fn set_keep_whitespace(&mut self, keep: bool) {
+        self.segmenter.keep_whitespace = keep;
+    }
+
+    /// Returns a shared reference to the underlying segmenter.
+    ///
+    /// No `&mut` accessor is provided on purpose: swapping the dictionary
+    /// out from under the reused lattice would break the dictionary↔lattice
+    /// pairing this type exists to guarantee.
+    ///
+    /// # 戻り値
+    ///
+    /// The segmenter this worker is bound to.
+    pub fn segmenter(&self) -> &Segmenter {
+        &self.segmenter
+    }
+
+    /// Immediately shrinks the worker's internal buffers to what an input
+    /// of `text_len_hint` bytes needs, and resets the automatic-shrink
+    /// window.
+    ///
+    /// # 引数
+    ///
+    /// * `text_len_hint` - Expected typical input length in bytes.
+    pub fn shrink_to(&mut self, text_len_hint: usize) {
+        self.lattice
+            .shrink_to(text_len_hint.min(MAX_SENTENCE_BYTES));
+        self.offsets.shrink_to_fit();
+        self.window_max_needed = 0;
+        self.calls_in_window = 0;
+    }
+
+    /// Records one call of `text_len` bytes and, once per shrink window,
+    /// shrinks the lattice if its capacity exceeds the window's observed
+    /// need by more than the hysteresis factor.
+    ///
+    /// The per-call need is capped at [`MAX_SENTENCE_BYTES`] because the
+    /// segmenter never feeds the lattice a longer sentence; using the full
+    /// text length would only over-estimate (which is the safe direction —
+    /// it can at most delay a shrink, never cause one too early).
+    ///
+    /// # 引数
+    ///
+    /// * `text_len` - Length in bytes of the current call's input.
+    fn maybe_auto_shrink(&mut self, text_len: usize) {
+        self.window_max_needed = self.window_max_needed.max(text_len.min(MAX_SENTENCE_BYTES));
+        self.calls_in_window += 1;
+        if self.calls_in_window >= SHRINK_WINDOW_CALLS {
+            let target = self.window_max_needed.max(SHRINK_FLOOR_BYTES);
+            if self.lattice.capacity() > target.saturating_mul(SHRINK_HYSTERESIS) {
+                self.lattice.shrink_to(target);
+            }
+            self.window_max_needed = 0;
+            self.calls_in_window = 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "embed-ipadic")]
+    mod with_ipadic {
+        use std::borrow::Cow;
+
+        use lindera_dictionary::mode::{Mode, Penalty};
+
+        use crate::dictionary::load_dictionary;
+        use crate::segmenter::Segmenter;
+
+        fn ipadic_segmenter() -> Segmenter {
+            let dictionary = match load_dictionary("embedded://ipadic") {
+                Ok(dictionary) => dictionary,
+                Err(err) => panic!("failed to load embedded IPADIC: {err}"),
+            };
+            Segmenter::new(Mode::Normal, dictionary, None)
+        }
+
+        #[test]
+        fn test_worker_matches_segment_output() {
+            let segmenter = ipadic_segmenter();
+            let mut worker = segmenter.new_worker();
+
+            let texts = [
+                "すもももももももものうち",
+                "関西国際空港限定トートバッグ",
+                "Lindera is a morphological analysis library.",
+                "",
+                "検索エンジン（けんさくエンジン、英語: search engine）は、狭義にはインターネットに存在する情報を検索する機能およびそのプログラム。",
+            ];
+
+            // Repeat the whole corpus to exercise buffer reuse across calls.
+            for _ in 0..3 {
+                for text in texts {
+                    let expected = match segmenter.segment(Cow::Borrowed(text)) {
+                        Ok(tokens) => tokens,
+                        Err(err) => panic!("segment failed: {err}"),
+                    };
+                    let actual = match worker.segment(text) {
+                        Ok(tokens) => tokens,
+                        Err(err) => panic!("worker.segment failed: {err}"),
+                    };
+                    assert_eq!(expected.len(), actual.len(), "token count for {text:?}");
+                    for (e, a) in expected.iter().zip(actual.iter()) {
+                        assert_eq!(e.surface, a.surface);
+                        assert_eq!(e.byte_start, a.byte_start);
+                        assert_eq!(e.byte_end, a.byte_end);
+                        assert_eq!(e.position, a.position);
+                        assert_eq!(e.word_id, a.word_id);
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn test_worker_matches_segment_nbest_output() {
+            let segmenter = ipadic_segmenter();
+            let mut worker = segmenter.new_worker();
+            let text = "すもももももももものうち";
+
+            let expected = match segmenter.segment_nbest(Cow::Borrowed(text), 5, false, None) {
+                Ok(results) => results,
+                Err(err) => panic!("segment_nbest failed: {err}"),
+            };
+            // Second call exercises nbest lattice reuse.
+            for _ in 0..2 {
+                let actual = match worker.segment_nbest(text, 5, false, None) {
+                    Ok(results) => results,
+                    Err(err) => panic!("worker.segment_nbest failed: {err}"),
+                };
+                assert_eq!(expected.len(), actual.len());
+                for ((e_tokens, e_cost), (a_tokens, a_cost)) in expected.iter().zip(actual.iter()) {
+                    assert_eq!(e_cost, a_cost);
+                    let e_surfaces: Vec<_> = e_tokens.iter().map(|t| t.surface.clone()).collect();
+                    let a_surfaces: Vec<_> = a_tokens.iter().map(|t| t.surface.clone()).collect();
+                    assert_eq!(e_surfaces, a_surfaces);
+                }
+            }
+        }
+
+        #[test]
+        fn test_worker_mode_and_whitespace_switching() {
+            let segmenter = ipadic_segmenter();
+            let mut worker = segmenter.new_worker();
+            let text = "関西国際空港へ 行く";
+
+            // Decompose mode must match a segmenter configured the same way.
+            worker.set_mode(Mode::Decompose(Penalty::default()));
+            let decompose_segmenter = Segmenter::new(
+                Mode::Decompose(Penalty::default()),
+                segmenter.dictionary.clone(),
+                None,
+            );
+            let expected = match decompose_segmenter.segment(Cow::Borrowed(text)) {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("segment failed: {err}"),
+            };
+            let actual = match worker.segment(text) {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            let expected_surfaces: Vec<_> = expected.iter().map(|t| t.surface.clone()).collect();
+            let actual_surfaces: Vec<_> = actual.iter().map(|t| t.surface.clone()).collect();
+            assert_eq!(expected_surfaces, actual_surfaces);
+
+            // Switching back restores Normal-mode output.
+            worker.set_mode(Mode::Normal);
+            let normal = match worker.segment(text) {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            let fresh = match segmenter.segment(Cow::Borrowed(text)) {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("segment failed: {err}"),
+            };
+            assert_eq!(normal.len(), fresh.len());
+
+            // keep_whitespace=true must surface the space token.
+            worker.set_keep_whitespace(true);
+            let kept = match worker.segment(text) {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            assert!(
+                kept.iter().any(|t| t.surface == " "),
+                "whitespace token missing with keep_whitespace=true"
+            );
+            worker.set_keep_whitespace(false);
+        }
+
+        /// The automatic policy must release a lattice grown by one long
+        /// delimiter-free sentence once a full window of short inputs shows
+        /// the capacity is oversized (target = max(window need, floor);
+        /// shrink when capacity > hysteresis * target).
+        #[test]
+        fn test_auto_shrink_fires_after_window_of_short_inputs() {
+            use super::super::{SHRINK_FLOOR_BYTES, SHRINK_HYSTERESIS, SHRINK_WINDOW_CALLS};
+
+            let segmenter = ipadic_segmenter();
+            let mut worker = segmenter.new_worker();
+
+            // One delimiter-free sentence well above the shrink threshold
+            // (but under the 32 KiB forced-cut bound): 7000 * 3 bytes.
+            let long_text = "あ".repeat(7000);
+            assert!(long_text.len() > SHRINK_FLOOR_BYTES * SHRINK_HYSTERESIS);
+            if let Err(err) = worker.segment(&long_text) {
+                panic!("worker.segment failed: {err}");
+            }
+            assert!(
+                worker.lattice.capacity() >= long_text.len(),
+                "long sentence did not grow the lattice"
+            );
+
+            // Two full windows of short inputs: the first window still
+            // contains the long call in its max, the second one triggers
+            // the shrink down to the floor.
+            let short_text = "すもももももももものうち";
+            for _ in 0..(2 * SHRINK_WINDOW_CALLS + 1) {
+                if let Err(err) = worker.segment(short_text) {
+                    panic!("worker.segment failed: {err}");
+                }
+            }
+            assert!(
+                worker.lattice.capacity() <= SHRINK_FLOOR_BYTES,
+                "auto shrink did not fire: capacity {} > floor {}",
+                worker.lattice.capacity(),
+                SHRINK_FLOOR_BYTES
+            );
+
+            // Output stays correct after the shrink.
+            let tokens = match worker.segment(short_text) {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            assert!(!tokens.is_empty());
+        }
+
+        #[test]
+        fn test_worker_shrink_to_keeps_output_identical() {
+            let segmenter = ipadic_segmenter();
+            let mut worker = segmenter.new_worker();
+            let text = "すもももももももものうち";
+
+            let before = match worker.segment(text) {
+                Ok(tokens) => tokens.len(),
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            worker.shrink_to(0);
+            let after = match worker.segment(text) {
+                Ok(tokens) => tokens.len(),
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            assert_eq!(before, after, "output changed after shrink_to");
+        }
+    }
+}


### PR DESCRIPTION
## What

Closes #907. Part of #881 (child A — see the design note comment there).

Adds the core reusable-session API: `SegmentWorker` owns the Viterbi `Lattice` and the backtrace scratch buffer so repeated calls avoid the per-call allocations `Segmenter::segment` pays, plus the supporting `Lattice::shrink_to` and `Token::details_iter` additions. All changes are additive; no existing public signature changes.

## Changes

- **`lindera-dictionary`**: `Lattice::capacity()` and `Lattice::shrink_to(text_len)`. `shrink_to` calls `clear()` first, truncates `ends_at`/`all_paths` to the target, preserves the per-slot pre-size of 16 (#827/#841) and the `last_text_len` bound (#877/#884). `clear()`/`set_text` stay shrink-free. 4 new regression tests (truncate+presize, no-op targets, backtrace-after-shrink, nbest release).
- **`lindera`**:
  - `segment_with_lattice` body moved to `pub(crate) segment_with_buffers(text, lattice, offsets)`; the public wrapper passes a fresh buffer. Output byte-identical.
  - New `lindera/src/worker.rs`: `SegmentWorker`, created only via `Segmenter::new_worker()` (clone; doc notes the user-dictionary deep copy) or `into_worker()` (consume). `segment<'w>` returns tokens that borrow the worker — the borrow checker forces consuming them before the next call, which keeps the worker-owned-buffer design sound without unsafe. `segment_nbest`, `set_mode`, `set_keep_whitespace`, `segmenter()` (shared ref only: no dictionary swap under a live lattice, guarding the `lattice_reuse_across_dictionaries` invariant), `shrink_to`.
  - Automatic shrink: every 64 calls, if lattice capacity exceeds 4x the window's largest input (floor 4 KiB), shrink to that need. A delimiter-free 32 KiB sentence pins ~20 MB otherwise; the floor bounds steady-state retention to ~1.7 MB worst case.
  - `Token::details_iter()`: iterator accessor that skips the `Vec<&str>` the existing `details()` collects on every call.
- **Benches** (`bench_ipadic.rs`): short-text (36 B) per-call trio — fresh / `segment_with_lattice` / worker — all returning token count (worker tokens cannot leave the closure); worker variant of the existing medium-text bench; nbest worker bench.
- **Docs**: new "Reusable Worker" section in `docs/{src,ja/src}/lindera/segmenter.md`; pointers from `docs/{src,ja/src}/concepts/tokenization.md`. markdownlint clean.

## Measurements (criterion, embed-ipadic, i7-1185G7, two runs)

| Workload | fresh | with_lattice | worker |
|---|---|---|---|
| short 36 B per call (run 1) | 2.77 µs | 1.45 µs | **1.36 µs** |
| short 36 B per call (run 2) | 3.17 µs | 1.53 µs | **1.26 µs** |
| medium ~250 B per call | 13.37 µs | 8.47 µs | **8.20 µs** |
| nbest short (n=5) | 7.78 µs | — | **5.41 µs** |

Signs are consistent across both runs: the worker is ~50-60% faster than fresh `segment()` on the short per-call workload and at or slightly below `segment_with_lattice` in every run (the extra win is the reused backtrace buffer). The definitive interleaved min-of-8 A/B against the pre-series baseline lands with the harness in #911.

## Verification

- `cargo test -p lindera --features embed-ipadic,embed-ko-dic,train` (golden tests included), `cargo test -p lindera-dictionary`: green.
- New tests: worker-vs-`segment()` equivalence over a repeated mixed corpus (incl. empty input), nbest equivalence, mode/keep_whitespace switching, auto-shrink firing (21 KB growth → two windows of short calls → capacity back at the floor), shrink-then-reuse output stability, `details_iter` == `details()` (known + unknown words).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -D warnings` (lindera + lindera-dictionary, embed-ipadic): clean.
