### PR TITLE
feat(analysis): add AnalysisWorker and route CoreTokenizer through an internal Mutex-held worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ name = "lindera-analysis"
 version = "5.1.0"
 dependencies = [
  "anyhow",
+ "criterion",
  "daachorse",
  "kanaria",
  "lindera",

--- a/docs/ja/src/lindera-analysis/architecture.md
+++ b/docs/ja/src/lindera-analysis/architecture.md
@@ -53,6 +53,10 @@ Segmenterが生成したトークンを後処理するフィルタのtraitです
 
 `TokenizerBuilder`は`TokenizerConfig`（`serde_json::Value`）から`Tokenizer`を組み立てます。この設定はプログラムから直接構築することも、YAMLファイルから読み込むこと（`TokenizerBuilder::from_file`、または環境変数`LINDERA_CONFIG_PATH`経由で自動的に読み込む`TokenizerBuilder::new`）も、`set_segmenter_mode`・`set_segmenter_dictionary`・`append_character_filter`・`append_token_filter`で段階的に組み立てることもできます。YAMLファイルの形式は[設定](./configuration.md)を、フィルタの完全なリファレンスは[フィルタ](./filters.md)を参照してください。
 
+### AnalysisWorker
+
+`AnalysisWorker`（`Tokenizer::new_worker`または`Tokenizer::into_worker`で作成）は、解析チェーン全体に対する再利用可能なセッションです。呼び出しごとのバッファ — Viterbiラティスとバックトレース用スクラッチ（`SegmentWorker`経由）、文字フィルタが操作する正規化テキストバッファ、オフセットマッピング用スクラッチ — をすべて所有するため、`tokenize`を繰り返し呼び出しても`Tokenizer::tokenize`が支払う呼び出しごとのアロケーションを回避できます。文字フィルタが設定されている場合、トークンのsurfaceはトークンごとの`String`にコピーされる代わりにワーカーのバッファを借用します。返されるトークンはワーカーを借用するため、次の呼び出しの前に消費する必要があります。マルチスレッドで使う場合はスレッドごとにワーカーを作成してください（あるいは`lindera-binding-core`のように`Mutex`で保護します）。基盤となる`SegmentWorker`と自動メモリ縮小ポリシーについては[Segmenter](../lindera/segmenter.md)のページを参照してください。
+
 ## Feature フラグ
 
 | Feature | 説明 | デフォルト |

--- a/docs/src/lindera-analysis/architecture.md
+++ b/docs/src/lindera-analysis/architecture.md
@@ -53,6 +53,10 @@ A trait for filters that post-process the tokens produced by the segmenter. Each
 
 `TokenizerBuilder` assembles a `Tokenizer` from a `TokenizerConfig` (a `serde_json::Value`), which can be constructed programmatically, loaded from a YAML file (via `TokenizerBuilder::from_file`, or automatically from the `LINDERA_CONFIG_PATH` environment variable via `TokenizerBuilder::new`), or built up incrementally with `set_segmenter_mode`, `set_segmenter_dictionary`, `append_character_filter`, and `append_token_filter`. See [Configuration](./configuration.md) for the YAML file format and [Filters](./filters.md) for the full filter reference.
 
+### AnalysisWorker
+
+`AnalysisWorker` (created with `Tokenizer::new_worker` or `Tokenizer::into_worker`) is a reusable session over the full analysis chain. It owns every per-call buffer — the Viterbi lattice and backtrace scratch (via `SegmentWorker`), the normalized-text buffer the character filters operate on, and the offset-mapping scratch — so repeated `tokenize` calls avoid the per-call allocations `Tokenizer::tokenize` pays. When character filters are configured, token surfaces borrow the worker's buffer instead of being copied into per-token `String`s. Returned tokens borrow the worker and must be consumed before the next call; for multi-threaded use, create one worker per thread (or guard one with a `Mutex`, as `lindera-binding-core` does). See the [Segmenter](../lindera/segmenter.md) page for the underlying `SegmentWorker` and its automatic memory-shrink policy.
+
 ## Feature Flags
 
 | Feature | Description | Default |

--- a/lindera-analysis/Cargo.toml
+++ b/lindera-analysis/Cargo.toml
@@ -38,6 +38,14 @@ unicode-normalization = "0.1.25"
 unicode-segmentation = "1.13.3"
 
 [dev-dependencies]
+criterion = { version = "0.8.2", default-features = false, features = [
+    "html_reports",
+] }
 lindera-dictionary = { workspace = true }
 once_cell = { workspace = true }
 serde_json = { workspace = true }
+
+[[bench]]
+name = "bench_analysis_ipadic"
+harness = false
+required-features = ["embed-ipadic"]

--- a/lindera-analysis/benches/bench_analysis_ipadic.rs
+++ b/lindera-analysis/benches/bench_analysis_ipadic.rs
@@ -1,0 +1,101 @@
+//! Analysis-chain benchmarks: fresh `Tokenizer::tokenize` (a new lattice
+//! per call) vs the reusable `AnalysisWorker`, with and without filters.
+//! All benches return the token count so the worker variants (whose tokens
+//! borrow the worker and cannot leave the closure) stay comparable with
+//! the fresh variants.
+
+#[cfg(feature = "embed-ipadic")]
+use std::collections::HashMap;
+
+#[cfg(feature = "embed-ipadic")]
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[cfg(feature = "embed-ipadic")]
+use lindera::dictionary::load_dictionary;
+#[cfg(feature = "embed-ipadic")]
+use lindera::mode::Mode;
+#[cfg(feature = "embed-ipadic")]
+use lindera::segmenter::Segmenter;
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::character_filter::BoxCharacterFilter;
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::character_filter::mapping::MappingCharacterFilter;
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::token_filter::BoxTokenFilter;
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::token_filter::lowercase::LowercaseTokenFilter;
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::tokenizer::Tokenizer;
+
+#[cfg(feature = "embed-ipadic")]
+const SHORT_TEXT: &str = "すもももももももものうち";
+
+#[cfg(feature = "embed-ipadic")]
+fn build_tokenizer(with_filters: bool) -> Tokenizer {
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+    let mut tokenizer = Tokenizer::new(segmenter);
+    if with_filters {
+        let mut mapping = HashMap::new();
+        mapping.insert("リンデラ".to_string(), "Lindera".to_string());
+        let filter = MappingCharacterFilter::new(mapping).unwrap();
+        tokenizer
+            .character_filters
+            .push(BoxCharacterFilter::from(filter));
+        tokenizer
+            .token_filters
+            .push(BoxTokenFilter::from(LowercaseTokenFilter::new()));
+    }
+    tokenizer
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_analysis_tokenize_ipadic(c: &mut Criterion) {
+    let tokenizer = build_tokenizer(false);
+    c.bench_function("bench-analysis-tokenize-ipadic", |b| {
+        b.iter(|| tokenizer.tokenize(SHORT_TEXT).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_analysis_worker_ipadic(c: &mut Criterion) {
+    let tokenizer = build_tokenizer(false);
+    c.bench_function("bench-analysis-worker-ipadic", |b| {
+        let mut worker = tokenizer.new_worker();
+        b.iter(|| worker.tokenize(SHORT_TEXT).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_analysis_tokenize_filters_ipadic(c: &mut Criterion) {
+    let tokenizer = build_tokenizer(true);
+    c.bench_function("bench-analysis-tokenize-filters-ipadic", |b| {
+        b.iter(|| tokenizer.tokenize(SHORT_TEXT).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_analysis_worker_filters_ipadic(c: &mut Criterion) {
+    let tokenizer = build_tokenizer(true);
+    c.bench_function("bench-analysis-worker-filters-ipadic", |b| {
+        let mut worker = tokenizer.new_worker();
+        b.iter(|| worker.tokenize(SHORT_TEXT).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+criterion_group!(
+    benches,
+    bench_analysis_tokenize_ipadic,
+    bench_analysis_worker_ipadic,
+    bench_analysis_tokenize_filters_ipadic,
+    bench_analysis_worker_filters_ipadic,
+);
+
+#[cfg(feature = "embed-ipadic")]
+criterion_main!(benches);
+
+#[cfg(not(feature = "embed-ipadic"))]
+fn main() {
+    eprintln!("bench_analysis_ipadic requires --features embed-ipadic");
+}

--- a/lindera-analysis/src/lib.rs
+++ b/lindera-analysis/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod character_filter;
 pub mod token_filter;
 pub mod tokenizer;
+pub mod worker;
 
 use serde_json::Value;
 

--- a/lindera-analysis/src/tokenizer.rs
+++ b/lindera-analysis/src/tokenizer.rs
@@ -413,18 +413,7 @@ impl Tokenizer {
         }
 
         // Correct token offsets if character filters are applied.
-        // Apply corrections in reverse order (last filter first)
-        if !offset_mappings.is_empty() {
-            for token in tokens.iter_mut() {
-                // Apply corrections in reverse order to undo the transformations
-                for mapping in offset_mappings.iter().rev() {
-                    // Override start.
-                    token.byte_start = mapping.correct_offset(token.byte_start, final_text_len);
-                    // Override end.
-                    token.byte_end = mapping.correct_offset(token.byte_end, final_text_len);
-                }
-            }
-        }
+        correct_offsets(&mut tokens, &offset_mappings, final_text_len);
 
         Ok(tokens)
     }
@@ -488,17 +477,41 @@ impl Tokenizer {
                 token_filter.apply(tokens)?;
             }
 
-            if !offset_mappings.is_empty() {
-                for token in tokens.iter_mut() {
-                    for mapping in offset_mappings.iter().rev() {
-                        token.byte_start = mapping.correct_offset(token.byte_start, final_text_len);
-                        token.byte_end = mapping.correct_offset(token.byte_end, final_text_len);
-                    }
-                }
-            }
+            correct_offsets(tokens, &offset_mappings, final_text_len);
         }
 
         Ok(all_results)
+    }
+}
+
+/// Corrects token byte offsets back to the original (pre-filter) text by
+/// applying the character filters' offset mappings in reverse order (last
+/// filter first). A no-op when `offset_mappings` is empty.
+///
+/// Shared by `tokenize_with_lattice`, `tokenize_nbest_with_lattice`, and
+/// `AnalysisWorker`.
+///
+/// # 引数
+///
+/// * `tokens` - The tokens whose `byte_start`/`byte_end` are corrected in
+///   place.
+/// * `offset_mappings` - Non-empty mappings recorded by the character
+///   filters, in application order.
+/// * `final_text_len` - Length in bytes of the fully filtered text.
+pub(crate) fn correct_offsets(
+    tokens: &mut [Token<'_>],
+    offset_mappings: &[OffsetMapping],
+    final_text_len: usize,
+) {
+    if offset_mappings.is_empty() {
+        return;
+    }
+    for token in tokens.iter_mut() {
+        // Apply corrections in reverse order to undo the transformations.
+        for mapping in offset_mappings.iter().rev() {
+            token.byte_start = mapping.correct_offset(token.byte_start, final_text_len);
+            token.byte_end = mapping.correct_offset(token.byte_end, final_text_len);
+        }
     }
 }
 

--- a/lindera-analysis/src/worker.rs
+++ b/lindera-analysis/src/worker.rs
@@ -1,0 +1,425 @@
+use lindera::LinderaResult;
+use lindera::mode::Mode;
+use lindera::token::Token;
+use lindera::worker::SegmentWorker;
+
+use crate::character_filter::{BoxCharacterFilter, OffsetMapping};
+use crate::token_filter::BoxTokenFilter;
+use crate::tokenizer::{Tokenizer, correct_offsets};
+
+/// A reusable tokenization session over a [`Tokenizer`]'s full analysis
+/// chain (character filters → segmentation → token filters), owning every
+/// per-call buffer: the Viterbi lattice and backtrace scratch (via
+/// [`SegmentWorker`]), the normalized-text buffer the character filters
+/// operate on, and the offset-mapping scratch.
+///
+/// Compared to [`Tokenizer::tokenize`], repeated calls avoid the fresh
+/// lattice allocation, and — when character filters are configured — both
+/// the per-call `String` promotion of the input and the per-token surface
+/// `String` allocations (surfaces borrow the worker's buffer instead).
+///
+/// Create a worker with [`Tokenizer::new_worker`] or
+/// [`Tokenizer::into_worker`]; it stays permanently bound to that
+/// tokenizer's dictionary and filter chain. Returned tokens borrow the
+/// worker, so they must be consumed before the next call — the usual
+/// per-line loop compiles as-is:
+///
+/// ```ignore
+/// let mut worker = tokenizer.new_worker();
+/// for line in lines {
+///     let tokens = worker.tokenize(line)?;
+///     for token in &tokens {
+///         // use token.surface, ...
+///     }
+/// }
+/// ```
+///
+/// The worker is `Send + Sync`; the `&mut self` API means cross-thread
+/// sharing requires external synchronization (one worker per thread, or a
+/// `Mutex` as `lindera-binding-core` does).
+pub struct AnalysisWorker {
+    /// Character filters applied to the text before segmentation.
+    character_filters: Vec<BoxCharacterFilter>,
+    /// Token filters applied to the tokens after segmentation.
+    token_filters: Vec<BoxTokenFilter>,
+    /// The reusable segmentation session (lattice + backtrace scratch).
+    segment_worker: SegmentWorker,
+    /// Persistent buffer holding the character-filtered (normalized) text;
+    /// token surfaces borrow from it when character filters are configured.
+    text_buf: String,
+    /// Scratch for the per-call offset mappings produced by the character
+    /// filters (the `Vec` is reused; mappings themselves are per-call).
+    offset_mappings: Vec<OffsetMapping>,
+}
+
+impl Tokenizer {
+    /// Creates a reusable [`AnalysisWorker`] bound to a deep clone of this
+    /// tokenizer (filters are cloned via `box_clone`; the dictionary clone
+    /// is `Arc`-cheap, but a configured user dictionary is deep-copied —
+    /// prefer [`Tokenizer::into_worker`] when the tokenizer itself is no
+    /// longer needed).
+    ///
+    /// # 戻り値
+    ///
+    /// A fresh worker with empty internal buffers.
+    pub fn new_worker(&self) -> AnalysisWorker {
+        self.clone().into_worker()
+    }
+
+    /// Consumes this tokenizer and creates a reusable [`AnalysisWorker`]
+    /// from it without cloning any of its parts.
+    ///
+    /// # 戻り値
+    ///
+    /// A fresh worker with empty internal buffers.
+    pub fn into_worker(self) -> AnalysisWorker {
+        AnalysisWorker {
+            character_filters: self.character_filters,
+            token_filters: self.token_filters,
+            segment_worker: self.segmenter.into_worker(),
+            text_buf: String::new(),
+            offset_mappings: Vec::new(),
+        }
+    }
+}
+
+impl AnalysisWorker {
+    /// Tokenizes `text` through the full analysis chain, reusing this
+    /// worker's internal buffers.
+    ///
+    /// Produces exactly the same tokens as [`Tokenizer::tokenize`] for the
+    /// same input and configuration. The returned tokens borrow both
+    /// `text` and this worker, so they must be consumed before the next
+    /// call.
+    ///
+    /// # 引数
+    ///
+    /// * `text` - The input text to tokenize.
+    ///
+    /// # 戻り値
+    ///
+    /// The filtered tokens, in reading order, with byte offsets corrected
+    /// back to the original (pre-filter) text.
+    pub fn tokenize<'w>(&'w mut self, text: &'w str) -> LinderaResult<Vec<Token<'w>>> {
+        let Self {
+            character_filters,
+            token_filters,
+            segment_worker,
+            text_buf,
+            offset_mappings,
+        } = self;
+        offset_mappings.clear();
+
+        let (mut tokens, final_text_len) = if character_filters.is_empty() {
+            (segment_worker.segment(text)?, text.len())
+        } else {
+            text_buf.clear();
+            text_buf.push_str(text);
+            for character_filter in character_filters.iter() {
+                let mapping = character_filter.apply(text_buf)?;
+                if !mapping.is_empty() {
+                    offset_mappings.push(mapping);
+                }
+            }
+            // Read the length before segmenting: the tokens returned below
+            // hold a shared borrow of `text_buf` for the rest of the call.
+            let final_text_len = text_buf.len();
+            (segment_worker.segment(text_buf.as_str())?, final_text_len)
+        };
+
+        for token_filter in token_filters.iter() {
+            token_filter.apply(&mut tokens)?;
+        }
+
+        correct_offsets(&mut tokens, offset_mappings, final_text_len);
+
+        Ok(tokens)
+    }
+
+    /// Tokenizes `text` and returns the top-N results with costs, through
+    /// the full analysis chain, reusing this worker's internal buffers.
+    ///
+    /// Produces exactly the same results as [`Tokenizer::tokenize_nbest`]
+    /// for the same input and configuration.
+    ///
+    /// # 引数
+    ///
+    /// * `text` - The input text to tokenize.
+    /// * `n` - Maximum number of tokenizations to return.
+    /// * `unique` - Deduplicate results with identical word boundaries.
+    /// * `cost_threshold` - Discard paths costing more than best + threshold.
+    ///
+    /// # 戻り値
+    ///
+    /// Up to `n` `(tokens, cost)` pairs ordered by cost (best first).
+    pub fn tokenize_nbest<'w>(
+        &'w mut self,
+        text: &'w str,
+        n: usize,
+        unique: bool,
+        cost_threshold: Option<i64>,
+    ) -> LinderaResult<Vec<(Vec<Token<'w>>, i64)>> {
+        let Self {
+            character_filters,
+            token_filters,
+            segment_worker,
+            text_buf,
+            offset_mappings,
+        } = self;
+        offset_mappings.clear();
+
+        let (mut all_results, final_text_len) = if character_filters.is_empty() {
+            (
+                segment_worker.segment_nbest(text, n, unique, cost_threshold)?,
+                text.len(),
+            )
+        } else {
+            text_buf.clear();
+            text_buf.push_str(text);
+            for character_filter in character_filters.iter() {
+                let mapping = character_filter.apply(text_buf)?;
+                if !mapping.is_empty() {
+                    offset_mappings.push(mapping);
+                }
+            }
+            let final_text_len = text_buf.len();
+            (
+                segment_worker.segment_nbest(text_buf.as_str(), n, unique, cost_threshold)?,
+                final_text_len,
+            )
+        };
+
+        for (tokens, _cost) in &mut all_results {
+            for token_filter in token_filters.iter() {
+                token_filter.apply(tokens)?;
+            }
+            correct_offsets(tokens, offset_mappings, final_text_len);
+        }
+
+        Ok(all_results)
+    }
+
+    /// Sets the segmentation mode for subsequent calls.
+    ///
+    /// # 引数
+    ///
+    /// * `mode` - The mode to use from the next call on.
+    pub fn set_mode(&mut self, mode: Mode) {
+        self.segment_worker.set_mode(mode);
+    }
+
+    /// Sets whether whitespace tokens are kept in the output for
+    /// subsequent calls.
+    ///
+    /// # 引数
+    ///
+    /// * `keep` - `true` to keep whitespace tokens, `false` to drop them.
+    pub fn set_keep_whitespace(&mut self, keep: bool) {
+        self.segment_worker.set_keep_whitespace(keep);
+    }
+
+    /// Immediately shrinks the worker's internal buffers to what an input
+    /// of `text_len_hint` bytes needs.
+    ///
+    /// # 引数
+    ///
+    /// * `text_len_hint` - Expected typical input length in bytes.
+    pub fn shrink_to(&mut self, text_len_hint: usize) {
+        self.segment_worker.shrink_to(text_len_hint);
+        self.text_buf.shrink_to(text_len_hint);
+        self.offset_mappings.shrink_to_fit();
+    }
+
+    /// Discards all internal buffers, replacing them with fresh ones.
+    ///
+    /// Intended for recovery paths (e.g. after a panic poisoned a mutex
+    /// holding this worker) where the buffers may be in an inconsistent
+    /// intermediate state; configuration (dictionary, filters, mode) is
+    /// preserved.
+    pub fn reset(&mut self) {
+        self.segment_worker.reset();
+        self.text_buf = String::new();
+        self.offset_mappings = Vec::new();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "embed-ipadic")]
+    mod with_ipadic {
+        use std::collections::HashMap;
+
+        use lindera::dictionary::load_dictionary;
+        use lindera::mode::Mode;
+        use lindera::segmenter::Segmenter;
+
+        use crate::character_filter::BoxCharacterFilter;
+        use crate::character_filter::mapping::MappingCharacterFilter;
+        use crate::token_filter::BoxTokenFilter;
+        use crate::token_filter::lowercase::LowercaseTokenFilter;
+        use crate::tokenizer::Tokenizer;
+
+        fn ipadic_tokenizer(with_filters: bool) -> Tokenizer {
+            let dictionary = match load_dictionary("embedded://ipadic") {
+                Ok(dictionary) => dictionary,
+                Err(err) => panic!("failed to load embedded IPADIC: {err}"),
+            };
+            let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+            let mut tokenizer = Tokenizer::new(segmenter);
+            if with_filters {
+                let mut mapping = HashMap::new();
+                mapping.insert("リンデラ".to_string(), "Lindera".to_string());
+                let filter = match MappingCharacterFilter::new(mapping) {
+                    Ok(filter) => filter,
+                    Err(err) => panic!("failed to build mapping filter: {err}"),
+                };
+                tokenizer
+                    .character_filters
+                    .push(BoxCharacterFilter::from(filter));
+                tokenizer
+                    .token_filters
+                    .push(BoxTokenFilter::from(LowercaseTokenFilter::new()));
+            }
+            tokenizer
+        }
+
+        fn assert_same_tokens(
+            tokenizer: &Tokenizer,
+            worker_tokens: &[(String, usize, usize)],
+            text: &str,
+        ) {
+            let expected = match tokenizer.tokenize(text) {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("tokenize failed: {err}"),
+            };
+            let expected: Vec<(String, usize, usize)> = expected
+                .iter()
+                .map(|t| (t.surface.to_string(), t.byte_start, t.byte_end))
+                .collect();
+            assert_eq!(expected, worker_tokens, "mismatch for {text:?}");
+        }
+
+        #[test]
+        fn test_worker_matches_tokenize_without_filters() {
+            let tokenizer = ipadic_tokenizer(false);
+            let mut worker = tokenizer.new_worker();
+
+            let texts = [
+                "すもももももももものうち",
+                "関西国際空港限定トートバッグ",
+                "",
+            ];
+            for _ in 0..3 {
+                for text in texts {
+                    let actual: Vec<(String, usize, usize)> = {
+                        let tokens = match worker.tokenize(text) {
+                            Ok(tokens) => tokens,
+                            Err(err) => panic!("worker.tokenize failed: {err}"),
+                        };
+                        tokens
+                            .iter()
+                            .map(|t| (t.surface.to_string(), t.byte_start, t.byte_end))
+                            .collect()
+                    };
+                    assert_same_tokens(&tokenizer, &actual, text);
+                }
+            }
+        }
+
+        #[test]
+        fn test_worker_matches_tokenize_with_filters() {
+            let tokenizer = ipadic_tokenizer(true);
+            let mut worker = tokenizer.new_worker();
+
+            // The mapping filter rewrites リンデラ -> Lindera (changing byte
+            // lengths, so offset corrections are exercised), and the
+            // lowercase token filter forces owned surfaces.
+            let texts = [
+                "リンデラは形態素解析器です。",
+                "TOKYO と リンデラ",
+                "すもももももももものうち",
+            ];
+            for _ in 0..3 {
+                for text in texts {
+                    let actual: Vec<(String, usize, usize)> = {
+                        let tokens = match worker.tokenize(text) {
+                            Ok(tokens) => tokens,
+                            Err(err) => panic!("worker.tokenize failed: {err}"),
+                        };
+                        tokens
+                            .iter()
+                            .map(|t| (t.surface.to_string(), t.byte_start, t.byte_end))
+                            .collect()
+                    };
+                    assert_same_tokens(&tokenizer, &actual, text);
+                }
+            }
+        }
+
+        #[test]
+        fn test_worker_matches_tokenize_nbest() {
+            let tokenizer = ipadic_tokenizer(true);
+            let mut worker = tokenizer.new_worker();
+            let text = "リンデラとすもももももももものうち";
+
+            let expected = match tokenizer.tokenize_nbest(text, 3, false, None) {
+                Ok(results) => results,
+                Err(err) => panic!("tokenize_nbest failed: {err}"),
+            };
+            for _ in 0..2 {
+                let actual = match worker.tokenize_nbest(text, 3, false, None) {
+                    Ok(results) => results,
+                    Err(err) => panic!("worker.tokenize_nbest failed: {err}"),
+                };
+                assert_eq!(expected.len(), actual.len());
+                for ((e_tokens, e_cost), (a_tokens, a_cost)) in expected.iter().zip(actual.iter()) {
+                    assert_eq!(e_cost, a_cost);
+                    let e: Vec<(String, usize, usize)> = e_tokens
+                        .iter()
+                        .map(|t| (t.surface.to_string(), t.byte_start, t.byte_end))
+                        .collect();
+                    let a: Vec<(String, usize, usize)> = a_tokens
+                        .iter()
+                        .map(|t| (t.surface.to_string(), t.byte_start, t.byte_end))
+                        .collect();
+                    assert_eq!(e, a);
+                }
+            }
+        }
+
+        #[test]
+        fn test_worker_reset_and_shrink_keep_output() {
+            let tokenizer = ipadic_tokenizer(true);
+            let mut worker = tokenizer.new_worker();
+            let text = "リンデラは形態素解析器です。";
+
+            let before: Vec<String> = {
+                let tokens = match worker.tokenize(text) {
+                    Ok(tokens) => tokens,
+                    Err(err) => panic!("worker.tokenize failed: {err}"),
+                };
+                tokens.iter().map(|t| t.surface.to_string()).collect()
+            };
+
+            worker.reset();
+            let after_reset: Vec<String> = {
+                let tokens = match worker.tokenize(text) {
+                    Ok(tokens) => tokens,
+                    Err(err) => panic!("worker.tokenize failed: {err}"),
+                };
+                tokens.iter().map(|t| t.surface.to_string()).collect()
+            };
+            assert_eq!(before, after_reset, "output changed after reset()");
+
+            worker.shrink_to(0);
+            let after_shrink: Vec<String> = {
+                let tokens = match worker.tokenize(text) {
+                    Ok(tokens) => tokens,
+                    Err(err) => panic!("worker.tokenize failed: {err}"),
+                };
+                tokens.iter().map(|t| t.surface.to_string()).collect()
+            };
+            assert_eq!(before, after_shrink, "output changed after shrink_to()");
+        }
+    }
+}

--- a/lindera-binding-core/Cargo.toml
+++ b/lindera-binding-core/Cargo.toml
@@ -10,6 +10,11 @@ keywords = ["morphological", "analysis", "binding"]
 categories = { workspace = true }
 license = { workspace = true }
 
+[features]
+# Dictionary-embedding pass-throughs, used only by feature-gated tests and
+# benches in this crate; the bindings enable embedding via their own crates.
+embed-ipadic = ["lindera/embed-ipadic", "lindera-analysis/embed-ipadic"]
+
 [dependencies]
 lindera = { workspace = true }
 lindera-analysis = { workspace = true }

--- a/lindera-binding-core/src/tokenizer.rs
+++ b/lindera-binding-core/src/tokenizer.rs
@@ -9,6 +9,7 @@
 
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::{Mutex, MutexGuard};
 
 use serde_json::Value;
 
@@ -16,6 +17,7 @@ use lindera::dictionary::{Dictionary, UserDictionary};
 use lindera::mode::Mode;
 use lindera::segmenter::Segmenter;
 use lindera_analysis::tokenizer::{Tokenizer, TokenizerBuilder};
+use lindera_analysis::worker::AnalysisWorker;
 
 use crate::error::CoreResult;
 use crate::token::TokenView;
@@ -84,19 +86,52 @@ impl CoreTokenizerBuilder {
 
     /// Builds a [`CoreTokenizer`] from the current configuration.
     pub fn build(&self) -> CoreResult<CoreTokenizer> {
-        Ok(CoreTokenizer {
-            inner: self.inner.build()?,
-        })
+        Ok(CoreTokenizer::from_tokenizer(self.inner.build()?))
     }
 }
 
 /// Tokenizer that orchestrates tokenization on behalf of the bindings.
 ///
-/// Wraps [`lindera_analysis::tokenizer::Tokenizer`] and returns owned [`TokenView`]s so
-/// the bindings never handle borrowed `lindera` tokens directly.
+/// Internally holds a reusable [`AnalysisWorker`] behind a [`Mutex`], so
+/// every call reuses the Viterbi lattice and scratch buffers instead of
+/// reallocating them (bindings keep one long-lived `CoreTokenizer`
+/// instance, which makes this the natural reuse point). `Mutex` — rather
+/// than `RefCell` — keeps `CoreTokenizer: Send + Sync`, which the Python
+/// (pyo3) and Node.js (napi) class wrappers require. All binding runtimes
+/// call tokenize while effectively single-threaded (GIL / one JS thread /
+/// request scope), so the lock is uncontended in practice.
+///
+/// Returns owned [`TokenView`]s so the bindings never handle borrowed
+/// `lindera` tokens directly.
 pub struct CoreTokenizer {
-    /// The backing lindera tokenizer.
-    inner: Tokenizer,
+    /// The reusable analysis session (lattice + normalization buffer +
+    /// scratch), locked per call.
+    worker: Mutex<AnalysisWorker>,
+}
+
+/// Locks the worker mutex, recovering from poisoning.
+///
+/// A panic in a previous call may have left the worker's internal buffers
+/// in an inconsistent intermediate state, so recovery resets them (the
+/// dictionary and filter configuration are unaffected). Capacity built up
+/// so far is lost, which is acceptable on this exceptional path.
+///
+/// # 引数
+///
+/// * `mutex` - The worker mutex to lock.
+///
+/// # 戻り値
+///
+/// A guard for the (possibly reset) worker.
+fn lock_worker(mutex: &Mutex<AnalysisWorker>) -> MutexGuard<'_, AnalysisWorker> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            let mut guard = poisoned.into_inner();
+            guard.reset();
+            guard
+        }
+    }
 }
 
 impl CoreTokenizer {
@@ -108,23 +143,31 @@ impl CoreTokenizer {
     ) -> CoreResult<Self> {
         let mode = Mode::from_str(mode)?;
         let segmenter = Segmenter::new(mode, dictionary, user_dictionary);
-        Ok(Self {
-            inner: Tokenizer::new(segmenter),
-        })
+        Ok(Self::from_tokenizer(Tokenizer::new(segmenter)))
     }
 
-    /// Wraps an already-built lindera [`Tokenizer`].
+    /// Wraps an already-built lindera [`Tokenizer`], consuming it into the
+    /// internal reusable worker (no user-dictionary copy).
     pub fn from_tokenizer(tokenizer: Tokenizer) -> Self {
-        Self { inner: tokenizer }
+        Self {
+            worker: Mutex::new(tokenizer.into_worker()),
+        }
     }
 
     /// Tokenizes `text`, returning owned [`TokenView`]s.
+    ///
+    /// Reuses the internal worker's buffers across calls; output is
+    /// identical to tokenizing with a fresh lattice.
     pub fn tokenize(&self, text: &str) -> CoreResult<Vec<TokenView>> {
-        let tokens = self.inner.tokenize(text)?;
+        let mut worker = lock_worker(&self.worker);
+        let tokens = worker.tokenize(text)?;
         Ok(tokens.into_iter().map(TokenView::from_token).collect())
     }
 
     /// Tokenizes `text` and returns the N-best results as `(tokens, cost)` pairs.
+    ///
+    /// Reuses the internal worker's buffers across calls, like
+    /// [`CoreTokenizer::tokenize`].
     pub fn tokenize_nbest(
         &self,
         text: &str,
@@ -132,7 +175,8 @@ impl CoreTokenizer {
         unique: bool,
         cost_threshold: Option<i64>,
     ) -> CoreResult<Vec<(Vec<TokenView>, i64)>> {
-        let results = self.inner.tokenize_nbest(text, n, unique, cost_threshold)?;
+        let mut worker = lock_worker(&self.worker);
+        let results = worker.tokenize_nbest(text, n, unique, cost_threshold)?;
         Ok(results
             .into_iter()
             .map(|(tokens, cost)| {
@@ -175,5 +219,117 @@ mod tests {
             .set_keep_whitespace(true)
             .append_token_filter("japanese_compound_word", &Value::Object(Default::default()));
         // Reaching here means the borrow-returning setters compose.
+    }
+
+    /// The pyo3 (Python) and napi (Node.js) class wrappers require the
+    /// wrapped type to be `Send + Sync`; losing either auto-trait would be
+    /// a de-facto breaking change for every binding. The `Mutex` (rather
+    /// than `RefCell`) around the internal worker exists exactly to
+    /// preserve this.
+    #[test]
+    fn core_tokenizer_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CoreTokenizer>();
+        assert_send_sync::<CoreTokenizerBuilder>();
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    mod with_ipadic {
+        use super::super::*;
+
+        fn ipadic_tokenizer() -> CoreTokenizer {
+            let dictionary = match lindera::dictionary::load_dictionary("embedded://ipadic") {
+                Ok(dictionary) => dictionary,
+                Err(err) => panic!("failed to load embedded IPADIC: {err}"),
+            };
+            match CoreTokenizer::from_segmenter("normal", dictionary, None) {
+                Ok(tokenizer) => tokenizer,
+                Err(err) => panic!("failed to build CoreTokenizer: {err}"),
+            }
+        }
+
+        /// Repeated calls through the internal reused worker must keep
+        /// producing identical output (lattice-reuse regression gate).
+        #[test]
+        fn tokenize_repeated_calls_are_stable() {
+            let tokenizer = ipadic_tokenizer();
+            let first = match tokenizer.tokenize("すもももももももものうち") {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("tokenize failed: {err}"),
+            };
+            assert!(!first.is_empty());
+            for _ in 0..100 {
+                let again = match tokenizer.tokenize("すもももももももものうち") {
+                    Ok(tokens) => tokens,
+                    Err(err) => panic!("tokenize failed: {err}"),
+                };
+                assert_eq!(first.len(), again.len());
+                for (a, b) in first.iter().zip(again.iter()) {
+                    assert_eq!(a.surface, b.surface);
+                    assert_eq!(a.byte_start, b.byte_start);
+                    assert_eq!(a.byte_end, b.byte_end);
+                    assert_eq!(a.details, b.details);
+                }
+            }
+        }
+
+        /// N-best calls reuse the same worker and must stay stable too.
+        #[test]
+        fn tokenize_nbest_repeated_calls_are_stable() {
+            let tokenizer = ipadic_tokenizer();
+            let first = match tokenizer.tokenize_nbest("すもももももももものうち", 3, false, None)
+            {
+                Ok(results) => results,
+                Err(err) => panic!("tokenize_nbest failed: {err}"),
+            };
+            assert!(!first.is_empty());
+            for _ in 0..10 {
+                let again =
+                    match tokenizer.tokenize_nbest("すもももももももものうち", 3, false, None)
+                    {
+                        Ok(results) => results,
+                        Err(err) => panic!("tokenize_nbest failed: {err}"),
+                    };
+                assert_eq!(first.len(), again.len());
+                for ((a_tokens, a_cost), (b_tokens, b_cost)) in first.iter().zip(again.iter()) {
+                    assert_eq!(a_cost, b_cost);
+                    assert_eq!(a_tokens.len(), b_tokens.len());
+                }
+            }
+        }
+
+        /// A panic while the worker lock is held must not wedge the
+        /// tokenizer: the next call recovers from the poisoned mutex with a
+        /// reset worker and produces correct output.
+        #[test]
+        fn tokenize_recovers_from_poisoned_lock() {
+            use std::sync::Arc;
+
+            let tokenizer = Arc::new(ipadic_tokenizer());
+            let expected = match tokenizer.tokenize("すもももももももものうち") {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("tokenize failed: {err}"),
+            };
+
+            // Poison the mutex by panicking while holding the guard.
+            let poisoner = Arc::clone(&tokenizer);
+            let result = std::thread::spawn(move || {
+                let _guard = lock_worker(&poisoner.worker);
+                panic!("intentional panic to poison the worker lock");
+            })
+            .join();
+            assert!(result.is_err(), "poisoning thread must have panicked");
+            assert!(tokenizer.worker.is_poisoned(), "lock must be poisoned");
+
+            // The next call must recover and produce identical output.
+            let after = match tokenizer.tokenize("すもももももももものうち") {
+                Ok(tokens) => tokens,
+                Err(err) => panic!("tokenize after poison failed: {err}"),
+            };
+            assert_eq!(expected.len(), after.len());
+            for (a, b) in expected.iter().zip(after.iter()) {
+                assert_eq!(a.surface, b.surface);
+            }
+        }
     }
 }

--- a/lindera/src/worker.rs
+++ b/lindera/src/worker.rs
@@ -234,6 +234,18 @@ impl SegmentWorker {
         self.calls_in_window = 0;
     }
 
+    /// Discards the internal buffers, replacing them with fresh ones.
+    ///
+    /// Intended for recovery paths (e.g. after a panic poisoned a mutex
+    /// holding this worker) where the buffers may hold an inconsistent
+    /// intermediate state; the segmenter configuration is preserved.
+    pub fn reset(&mut self) {
+        self.lattice = Lattice::default();
+        self.offsets = Vec::new();
+        self.window_max_needed = 0;
+        self.calls_in_window = 0;
+    }
+
     /// Records one call of `text_len` bytes and, once per shrink window,
     /// shrinks the lattice if its capacity exceeds the window's observed
     /// need by more than the hysteresis factor.


### PR DESCRIPTION
## What

Closes #908. Part of #881 (child B — see the design note comment there). Builds on #913.

Adds `AnalysisWorker`, the reusable session over the full analysis chain (character filters → segmentation → token filters), and routes `CoreTokenizer` through an internal `Mutex<AnalysisWorker>` — **all five language bindings get lattice + buffer reuse with zero binding-code changes**. All changes are additive; no existing public signature changes.

## Changes

- **`lindera-analysis`**:
  - New `worker.rs`: `AnalysisWorker` = filters (`box_clone`) + `SegmentWorker` + persistent normalized-text buffer (C12) + offset-mapping scratch, created via `Tokenizer::new_worker()` / `into_worker()`. With character filters configured, the per-call `String` promotion and the per-token `Cow::Owned` surface allocations disappear (surfaces borrow the worker's buffer; the borrow checker forces consuming tokens before the next call, keeping this sound without unsafe).
  - Offset-correction loop extracted into `pub(crate) correct_offsets`, shared by `tokenize_with_lattice`, `tokenize_nbest_with_lattice`, and the worker.
  - Criterion bench `bench_analysis_ipadic.rs` (fresh vs worker, with/without filters) + criterion dev-dep + `[[bench]]`.
- **`lindera`**: `SegmentWorker::reset()` — replaces internal buffers with fresh ones for recovery paths; configuration preserved.
- **`lindera-binding-core`**:
  - `CoreTokenizer` now holds `Mutex<AnalysisWorker>`; `tokenize`/`tokenize_nbest` lock, run the worker, and convert to owned `TokenView`s. `from_tokenizer` consumes the tokenizer via `into_worker` (no user-dictionary copy). `Mutex` (not `RefCell`) preserves `Send + Sync`, which the pyo3/napi class wrappers require; the binding runtimes are effectively single-threaded at call time, so the lock is uncontended (~tens of ns vs µs-scale calls — the null measurement below confirms no regression).
  - Poisoned-lock recovery: `into_inner()` + `worker.reset()` (no `unwrap`, per project convention).
  - Static `Send + Sync` assertion test; `embed-ipadic` feature pass-through for feature-gated tests.
- **Docs**: `AnalysisWorker` section in `docs/{src,ja/src}/lindera-analysis/architecture.md`.

## Measurements (criterion, embed-ipadic, short text, i7-1185G7)

| Workload | fresh `tokenize` | `AnalysisWorker` |
|---|---|---|
| no filters | 3.19 µs | **1.42 µs (−55.6%)** |
| mapping + lowercase filter chain | 3.30 µs | **1.53 µs (−53.7%)** |

The filtered worker path (1.53 µs) is nearly as fast as the unfiltered one (1.42 µs) — the C12 normalization buffer removes what used to make filters expensive per call. Binding-visible effect lands automatically via `CoreTokenizer`; per-binding before/after numbers follow with the harness in #911.

## Verification

- `cargo test -p lindera-analysis --features embed-ipadic,embed-ko-dic`: 114 + 6 green (new: worker equivalence with/without filters incl. offset-mapping rewrites, nbest equivalence, reset/shrink stability).
- `cargo test -p lindera-binding-core --features embed-ipadic`: 26 green (new: 100-call stability, nbest stability, poison recovery — a thread panics while holding the guard, the next call recovers with identical output; `is_poisoned` asserted in between).
- `cargo test -p lindera-binding-core` (no features, CI parity): green.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -D warnings` (lindera-analysis + lindera-binding-core, embed-ipadic): clean.
- markdownlint: 0 errors.
- Binding test jobs (python/nodejs/ruby/php/wasm) trigger on this PR via the `lindera-binding-core/**` paths-filter added in #912 and must stay green — that is the zero-binding-change compatibility gate.
