### PR TITLE
feat(bindings): add surface-only tokenize_surfaces fast path for binding-core, Python, and Node.js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,7 @@ dependencies = [
 name = "lindera-binding-core"
 version = "5.1.0"
 dependencies = [
+ "criterion",
  "lindera",
  "lindera-analysis",
  "serde_json",

--- a/docs/ja/src/lindera-nodejs/tokenizer_api.md
+++ b/docs/ja/src/lindera-nodejs/tokenizer_api.md
@@ -132,6 +132,23 @@ const tokens = tokenizer.tokenize("形態素解析");
 
 **戻り値:** `Token[]`
 
+#### `tokenizeSurfaces(text)`
+
+入力テキストをトークナイズし、トークンの surface のみを文字列の配列として返します。分かち書き用途の高速パスです。`Token` オブジェクトを生成せず、形態素の詳細情報もロードしないため、surface 文字列だけが必要な場合は `tokenize` より大幅に高速です。結果は `tokenizer.tokenize(text).map((t) => t.surface)` と一致します。
+
+```javascript
+const surfaces = tokenizer.tokenizeSurfaces("形態素解析");
+// ["形態素", "解析"]
+```
+
+**パラメータ:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| `text` | `string` | トークナイズするテキスト |
+
+**戻り値:** `string[]`
+
 #### `tokenizeNbest(text, n, unique?, costThreshold?)`
 
 N-best トークナイズ結果を返します。各結果はトークン配列とトータルパスコストを含みます。

--- a/docs/ja/src/lindera-python/tokenizer_api.md
+++ b/docs/ja/src/lindera-python/tokenizer_api.md
@@ -131,6 +131,23 @@ tokens = tokenizer.tokenize("形態素解析")
 
 **戻り値:** `list[Token]`
 
+#### `tokenize_surfaces(text)`
+
+入力テキストをトークナイズし、トークンの surface のみを文字列のリストとして返します。分かち書き用途の高速パスです。`Token` オブジェクトを生成せず、形態素の詳細情報もロードしないため、surface 文字列だけが必要な場合は `tokenize` より大幅に高速です。結果は `[t.surface for t in tokenizer.tokenize(text)]` と一致します。
+
+```python
+surfaces = tokenizer.tokenize_surfaces("形態素解析")
+# ["形態素", "解析"]
+```
+
+**パラメータ:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| `text` | `str` | トークナイズするテキスト |
+
+**戻り値:** `list[str]`
+
 #### `tokenize_nbest(text, n, unique=False, cost_threshold=None)`
 
 N-best トークナイズ結果を返します。各結果はトータルパスコストとペアになっています。

--- a/docs/src/lindera-nodejs/tokenizer_api.md
+++ b/docs/src/lindera-nodejs/tokenizer_api.md
@@ -130,6 +130,23 @@ const tokens = tokenizer.tokenize("形態素解析");
 
 **Returns:** `Token[]`
 
+#### `tokenizeSurfaces(text)`
+
+Tokenizes the input text and returns only the token surfaces, as an array of strings. This is the fast path for wakati-style use: no `Token` objects are created and no morphological details are loaded, so it is significantly faster than `tokenize` when only the surface strings are needed. The result equals `tokenizer.tokenize(text).map((t) => t.surface)`.
+
+```javascript
+const surfaces = tokenizer.tokenizeSurfaces("形態素解析");
+// ["形態素", "解析"]
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `text` | `string` | Text to tokenize |
+
+**Returns:** `string[]`
+
 #### `tokenizeNbest(text, n, unique?, costThreshold?)`
 
 Returns the N-best tokenization results, each containing tokens and total path cost.

--- a/docs/src/lindera-python/tokenizer_api.md
+++ b/docs/src/lindera-python/tokenizer_api.md
@@ -130,6 +130,23 @@ tokens = tokenizer.tokenize("形態素解析")
 
 **Returns:** `list[Token]`
 
+#### `tokenize_surfaces(text)`
+
+Tokenizes the input text and returns only the token surfaces, as a list of strings. This is the fast path for wakati-style use: no `Token` objects are created and no morphological details are loaded, so it is significantly faster than `tokenize` when only the surface strings are needed. The result equals `[t.surface for t in tokenizer.tokenize(text)]`.
+
+```python
+surfaces = tokenizer.tokenize_surfaces("形態素解析")
+# ["形態素", "解析"]
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `text` | `str` | Text to tokenize |
+
+**Returns:** `list[str]`
+
 #### `tokenize_nbest(text, n, unique=False, cost_threshold=None)`
 
 Returns the N-best tokenization results, each paired with its total path cost.

--- a/lindera-binding-core/Cargo.toml
+++ b/lindera-binding-core/Cargo.toml
@@ -19,3 +19,13 @@ embed-ipadic = ["lindera/embed-ipadic", "lindera-analysis/embed-ipadic"]
 lindera = { workspace = true }
 lindera-analysis = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+criterion = { version = "0.8.2", default-features = false, features = [
+    "html_reports",
+] }
+
+[[bench]]
+name = "bench_binding_core_ipadic"
+harness = false
+required-features = ["embed-ipadic"]

--- a/lindera-binding-core/benches/bench_binding_core_ipadic.rs
+++ b/lindera-binding-core/benches/bench_binding_core_ipadic.rs
@@ -1,0 +1,49 @@
+//! Binding-layer benchmarks: full `TokenView` materialization (details
+//! loaded and copied per token) vs the surface-only `tokenize_surfaces`
+//! fast path. This is the primary evidence for the C3 claim of #881.
+
+#[cfg(feature = "embed-ipadic")]
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[cfg(feature = "embed-ipadic")]
+use lindera_binding_core::tokenizer::CoreTokenizer;
+
+#[cfg(feature = "embed-ipadic")]
+const SHORT_TEXT: &str = "すもももももももものうち";
+
+#[cfg(feature = "embed-ipadic")]
+fn build_tokenizer() -> CoreTokenizer {
+    let dictionary = lindera::dictionary::load_dictionary("embedded://ipadic").unwrap();
+    CoreTokenizer::from_segmenter("normal", dictionary, None).unwrap()
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_binding_tokenize_ipadic(c: &mut Criterion) {
+    let tokenizer = build_tokenizer();
+    c.bench_function("bench-binding-tokenize-ipadic", |b| {
+        b.iter(|| tokenizer.tokenize(SHORT_TEXT).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_binding_tokenize_surfaces_ipadic(c: &mut Criterion) {
+    let tokenizer = build_tokenizer();
+    c.bench_function("bench-binding-tokenize-surfaces-ipadic", |b| {
+        b.iter(|| tokenizer.tokenize_surfaces(SHORT_TEXT).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+criterion_group!(
+    benches,
+    bench_binding_tokenize_ipadic,
+    bench_binding_tokenize_surfaces_ipadic,
+);
+
+#[cfg(feature = "embed-ipadic")]
+criterion_main!(benches);
+
+#[cfg(not(feature = "embed-ipadic"))]
+fn main() {
+    eprintln!("bench_binding_core_ipadic requires --features embed-ipadic");
+}

--- a/lindera-binding-core/src/token.rs
+++ b/lindera-binding-core/src/token.rs
@@ -19,7 +19,9 @@ pub struct TokenView {
 impl TokenView {
     /// Extracts the binding-facing data from a `lindera` token.
     pub fn from_token(mut token: Token) -> Self {
-        let details = token.details().iter().map(|s| s.to_string()).collect();
+        // details_iter avoids the intermediate Vec<&str> that details()
+        // collects on every call.
+        let details = token.details_iter().map(|s| s.to_string()).collect();
 
         Self {
             surface: token.surface.to_string(),
@@ -29,6 +31,45 @@ impl TokenView {
             word_id: token.word_id.id(),
             is_unknown: token.word_id.is_unknown(),
             details,
+        }
+    }
+}
+
+/// Surface-only view of a [`lindera::token::Token`], for callers that do
+/// not need morphological details (wakati-style use).
+///
+/// Unlike [`TokenView::from_token`], constructing this never touches the
+/// dictionary's word details, skipping their materialization entirely
+/// (roughly one allocation per token instead of ~14 for IPADIC). Byte
+/// offsets are carried here so bindings can expose them later without a
+/// breaking change; the current language APIs return only the surfaces.
+#[derive(Debug, Clone)]
+pub struct SurfaceView {
+    /// The token's surface form.
+    pub surface: String,
+    /// Starting byte position in the original (pre-filter) text.
+    pub byte_start: usize,
+    /// Ending byte position (exclusive) in the original (pre-filter) text.
+    pub byte_end: usize,
+}
+
+impl SurfaceView {
+    /// Extracts the surface data from a `lindera` token without loading
+    /// details.
+    ///
+    /// # 引数
+    ///
+    /// * `token` - The token to consume; a borrowed surface is copied
+    ///   once, an owned surface is moved.
+    ///
+    /// # 戻り値
+    ///
+    /// The surface-only view.
+    pub fn from_token(token: Token) -> Self {
+        Self {
+            surface: token.surface.into_owned(),
+            byte_start: token.byte_start,
+            byte_end: token.byte_end,
         }
     }
 }

--- a/lindera-binding-core/src/tokenizer.rs
+++ b/lindera-binding-core/src/tokenizer.rs
@@ -20,7 +20,7 @@ use lindera_analysis::tokenizer::{Tokenizer, TokenizerBuilder};
 use lindera_analysis::worker::AnalysisWorker;
 
 use crate::error::CoreResult;
-use crate::token::TokenView;
+use crate::token::{SurfaceView, TokenView};
 
 /// Builder that orchestrates tokenizer configuration on behalf of the bindings.
 ///
@@ -164,6 +164,22 @@ impl CoreTokenizer {
         Ok(tokens.into_iter().map(TokenView::from_token).collect())
     }
 
+    /// Tokenizes `text`, returning surface-only views ([`SurfaceView`])
+    /// without materializing any morphological details.
+    ///
+    /// This is the fast path for wakati-style callers: it skips the
+    /// per-token details loading and string materialization that
+    /// [`CoreTokenizer::tokenize`] pays (~14 allocations per IPADIC token
+    /// down to ~1), while reusing the internal worker's buffers like the
+    /// other methods. Token filters configured on the tokenizer still run
+    /// (some may load details internally); the saving on this path is the
+    /// FFI-side materialization.
+    pub fn tokenize_surfaces(&self, text: &str) -> CoreResult<Vec<SurfaceView>> {
+        let mut worker = lock_worker(&self.worker);
+        let tokens = worker.tokenize(text)?;
+        Ok(tokens.into_iter().map(SurfaceView::from_token).collect())
+    }
+
     /// Tokenizes `text` and returns the N-best results as `(tokens, cost)` pairs.
     ///
     /// Reuses the internal worker's buffers across calls, like
@@ -294,6 +310,36 @@ mod tests {
                 for ((a_tokens, a_cost), (b_tokens, b_cost)) in first.iter().zip(again.iter()) {
                     assert_eq!(a_cost, b_cost);
                     assert_eq!(a_tokens.len(), b_tokens.len());
+                }
+            }
+        }
+
+        /// The surface-only fast path must yield exactly the surfaces and
+        /// byte offsets of the full tokenize path, for repeated calls.
+        #[test]
+        fn tokenize_surfaces_matches_tokenize() {
+            let tokenizer = ipadic_tokenizer();
+            let texts = [
+                "すもももももももものうち",
+                "関西国際空港限定トートバッグ",
+                "",
+            ];
+            for _ in 0..3 {
+                for text in texts {
+                    let full = match tokenizer.tokenize(text) {
+                        Ok(tokens) => tokens,
+                        Err(err) => panic!("tokenize failed: {err}"),
+                    };
+                    let surfaces = match tokenizer.tokenize_surfaces(text) {
+                        Ok(views) => views,
+                        Err(err) => panic!("tokenize_surfaces failed: {err}"),
+                    };
+                    assert_eq!(full.len(), surfaces.len(), "count for {text:?}");
+                    for (a, b) in full.iter().zip(surfaces.iter()) {
+                        assert_eq!(a.surface, b.surface);
+                        assert_eq!(a.byte_start, b.byte_start);
+                        assert_eq!(a.byte_end, b.byte_end);
+                    }
                 }
             }
         }

--- a/lindera-nodejs/index.d.ts
+++ b/lindera-nodejs/index.d.ts
@@ -265,6 +265,23 @@ export declare class Tokenizer {
    */
   tokenize(text: string): Array<Token>
   /**
+   * Tokenizes the given text and returns only the token surfaces.
+   *
+   * This is the fast path for wakati-style use: no Token objects are
+   * created and no morphological details are loaded, so it is
+   * significantly faster than `tokenize` when only the surface strings
+   * are needed. The surfaces equal `tokenize(text).map((t) => t.surface)`.
+   *
+   * # Arguments
+   *
+   * * `text` - Text to tokenize.
+   *
+   * # Returns
+   *
+   * An array of surface strings, in reading order.
+   */
+  tokenizeSurfaces(text: string): Array<string>
+  /**
    * Tokenizes the given text and returns N-best results.
    *
    * # Arguments

--- a/lindera-nodejs/src/tokenizer.rs
+++ b/lindera-nodejs/src/tokenizer.rs
@@ -183,6 +183,26 @@ impl JsTokenizer {
         Ok(views.into_iter().map(JsToken::from_view).collect())
     }
 
+    /// Tokenizes the given text and returns only the token surfaces.
+    ///
+    /// This is the fast path for wakati-style use: no Token objects are
+    /// created and no morphological details are loaded, so it is
+    /// significantly faster than `tokenize` when only the surface strings
+    /// are needed. The surfaces equal `tokenize(text).map((t) => t.surface)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - Text to tokenize.
+    ///
+    /// # Returns
+    ///
+    /// An array of surface strings, in reading order.
+    #[napi]
+    pub fn tokenize_surfaces(&self, text: String) -> napi::Result<Vec<String>> {
+        let views = self.inner.tokenize_surfaces(&text).map_err(to_napi_error)?;
+        Ok(views.into_iter().map(|view| view.surface).collect())
+    }
+
     /// Tokenizes the given text and returns N-best results.
     ///
     /// # Arguments

--- a/lindera-nodejs/tests/test_tokenize_ipadic.js
+++ b/lindera-nodejs/tests/test_tokenize_ipadic.js
@@ -45,6 +45,30 @@ describe(
       assert.strictEqual(tokens[0].surface, "東京");
     });
 
+    it("should return the same surfaces from tokenizeSurfaces as tokenize", () => {
+      const dictionary = lindera.loadDictionary("embedded://ipadic");
+      const tokenizer = new lindera.Tokenizer(dictionary, "normal");
+
+      for (const text of ["すもももももももものうち", "関西国際空港限定トートバッグ", ""]) {
+        const expected = tokenizer.tokenize(text).map((t) => t.surface);
+        const surfaces = tokenizer.tokenizeSurfaces(text);
+        assert.deepStrictEqual(surfaces, expected);
+      }
+    });
+
+    it("should produce stable output across repeated calls on one instance", () => {
+      // The tokenizer reuses an internal lattice across calls; repeated
+      // calls on one instance must keep producing identical output.
+      const dictionary = lindera.loadDictionary("embedded://ipadic");
+      const tokenizer = new lindera.Tokenizer(dictionary, "normal");
+
+      const text = "すもももももももものうち";
+      const first = tokenizer.tokenizeSurfaces(text);
+      for (let i = 0; i < 100; i++) {
+        assert.deepStrictEqual(tokenizer.tokenizeSurfaces(text), first);
+      }
+    });
+
     it("should support N-best tokenization", () => {
       const dictionary = lindera.loadDictionary("embedded://ipadic");
       const tokenizer = new lindera.Tokenizer(dictionary, "normal");

--- a/lindera-python/src/tokenizer.rs
+++ b/lindera-python/src/tokenizer.rs
@@ -279,6 +279,30 @@ impl PyTokenizer {
         Ok(views.into_iter().map(PyToken::from_view).collect())
     }
 
+    /// Tokenizes the given text and returns only the token surfaces.
+    ///
+    /// This is the fast path for wakati-style use: no Token objects are
+    /// created and no morphological details are loaded, so it is
+    /// significantly faster than `tokenize` when only the surface strings
+    /// are needed. The surfaces equal `[t.surface for t in tokenize(text)]`.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - Text to tokenize.
+    ///
+    /// # Returns
+    ///
+    /// A list of surface strings, in reading order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if tokenization fails.
+    #[pyo3(signature = (text))]
+    fn tokenize_surfaces(&self, text: &str) -> PyResult<Vec<String>> {
+        let views = self.inner.tokenize_surfaces(text).map_err(to_py_error)?;
+        Ok(views.into_iter().map(|view| view.surface).collect())
+    }
+
     /// Tokenizes the given text and returns N-best results.
     ///
     /// # Arguments

--- a/lindera-python/tests/test_tokenize_ipadic.py
+++ b/lindera-python/tests/test_tokenize_ipadic.py
@@ -20,3 +20,28 @@ def test_tokenize_with_ipadic():
     assert tokens[6].surface == "うち"
 
     assert len(tokens) == 7
+
+
+def test_tokenize_surfaces_matches_tokenize():
+    dictionary = load_dictionary("embedded://ipadic")
+    tokenizer = Tokenizer(dictionary, mode="normal")
+
+    for text in ["すもももももももものうち", "関西国際空港限定トートバッグ", ""]:
+        expected = [token.surface for token in tokenizer.tokenize(text)]
+        surfaces = tokenizer.tokenize_surfaces(text)
+        assert surfaces == expected
+        assert all(isinstance(surface, str) for surface in surfaces)
+
+
+def test_tokenize_repeated_calls_are_stable():
+    # The tokenizer reuses an internal lattice across calls; repeated calls
+    # on one instance must keep producing identical output.
+    dictionary = load_dictionary("embedded://ipadic")
+    tokenizer = Tokenizer(dictionary, mode="normal")
+
+    text = "すもももももももものうち"
+    first_tokens = [(t.surface, t.byte_start, t.byte_end) for t in tokenizer.tokenize(text)]
+    first_surfaces = tokenizer.tokenize_surfaces(text)
+    for _ in range(100):
+        assert [(t.surface, t.byte_start, t.byte_end) for t in tokenizer.tokenize(text)] == first_tokens
+        assert tokenizer.tokenize_surfaces(text) == first_surfaces


### PR DESCRIPTION
## What

Closes #909. Part of #881 (child C — see the design note comment there). Builds on #914.

Adds the surface-only fast path (C3): a new `SurfaceView` type and `CoreTokenizer::tokenize_surfaces` that never materialize morphological details, exposed to Python as `tokenize_surfaces` and to Node.js as `tokenizeSurfaces`, both returning plain string arrays. All changes are additive.

## Changes

- **`lindera-binding-core`**:
  - `SurfaceView { surface, byte_start, byte_end }` — new type (adding fields to `TokenView` would be a breaking change). Byte offsets stay at core level so bindings can expose them later without breakage; the language APIs return only strings (byte indices are unidiomatic in Python/JS).
  - `CoreTokenizer::tokenize_surfaces(&self, text)` — routes through the same internal `Mutex<AnalysisWorker>`, never touches details: **~14 → ~1 allocation per IPADIC token**. `Cow` surface is moved (zero-copy) on the character-filter path and copied once otherwise.
  - `TokenView::from_token` now uses `Token::details_iter()` (from #913), removing one intermediate `Vec<&str>` per token on the existing full path.
  - Criterion bench `bench_binding_core_ipadic.rs` (full TokenView vs surface-only) + equivalence test (surfaces + offsets == `tokenize`).
- **Python**: `Tokenizer.tokenize_surfaces(text) -> list[str]` — no `PyToken` objects, one `PyList[PyString]`. pytest: equivalence + 100-call stability. Docs en/ja.
- **Node.js**: `tokenizer.tokenizeSurfaces(text): string[]` — no JS class instances, one string array. node:test: equivalence + stability. **`index.d.ts` regenerated via `napi build`** (`index.js` unchanged — module-level exports identical). Docs en/ja.

## Measurements (criterion, embed-ipadic, short text, i7-1185G7)

| Path | time |
|---|---|
| full `tokenize` (TokenView, details materialized) | 4.39 µs |
| `tokenize_surfaces` | **1.40 µs (−68.2%)** |

Per-language interleaved A/B numbers land with the harness in #911.

## Verification

- `cargo test -p lindera-binding-core --features embed-ipadic`: 27 green (incl. the new equivalence test); no-features run also green.
- Python: `make test-lindera-python` — 10 pytest green.
- Node.js: `make test-lindera-nodejs` flow with `--features embed-ipadic,train` — 25 node:test green.
- `cargo fmt --all -- --check`; `cargo clippy --all-targets -D warnings` across binding-core/python/nodejs; markdownlint 0 errors.
