### PR TITLE
feat(bindings): add tokenize_surfaces for Ruby, PHP, and WASM

### DIFF
--- a/docs/ja/src/lindera-php/tokenizer_api.md
+++ b/docs/ja/src/lindera-php/tokenizer_api.md
@@ -131,6 +131,25 @@ $tokens = $tokenizer->tokenize('形態素解析');
 
 **戻り値:** `array<Token>`
 
+#### `tokenizeSurfaces($text)`
+
+入力テキストをトークナイズし、トークンの surface のみを文字列の配列として返します。分かち書き用途の高速パスです。`Token` オブジェクトを生成せず、形態素の詳細情報もロードしないため、surface 文字列だけが必要な場合は `tokenize` より大幅に高速です。結果は `array_map(fn ($t) => $t->surface, $tokenizer->tokenize($text))` と一致します。
+
+```php
+<?php
+
+$surfaces = $tokenizer->tokenizeSurfaces('形態素解析');
+// ["形態素", "解析"]
+```
+
+**パラメータ:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| `$text` | `string` | トークナイズするテキスト |
+
+**戻り値:** `array<string>`
+
 #### `tokenizeNbest($text, $n)`
 
 N-best トークナイズ結果を返します。各結果は `NbestResult` オブジェクトで、トークン配列とトータルパスコストを含みます。

--- a/docs/ja/src/lindera-ruby/tokenizer_api.md
+++ b/docs/ja/src/lindera-ruby/tokenizer_api.md
@@ -135,6 +135,23 @@ tokens = tokenizer.tokenize('形態素解析')
 
 **戻り値:** `Array<Token>`
 
+#### `tokenize_surfaces(text)`
+
+入力テキストをトークナイズし、トークンの surface のみを文字列の配列として返します。分かち書き用途の高速パスです。`Token` オブジェクトを生成せず、形態素の詳細情報もロードしないため、surface 文字列だけが必要な場合は `tokenize` より大幅に高速です。結果は `tokenizer.tokenize(text).map(&:surface)` と一致します。
+
+```ruby
+surfaces = tokenizer.tokenize_surfaces('形態素解析')
+# ["形態素", "解析"]
+```
+
+**パラメータ:**
+
+| 名前 | 型 | 説明 |
+| --- | --- | --- |
+| `text` | `String` | トークナイズするテキスト |
+
+**戻り値:** `Array<String>`
+
 #### `tokenize_nbest(text, n, unique, cost_threshold)`
 
 N-best トークナイズ結果を返します。各結果はトータルパスコストとペアになっています。

--- a/docs/ja/src/lindera-wasm/tokenizer_api.md
+++ b/docs/ja/src/lindera-wasm/tokenizer_api.md
@@ -154,6 +154,18 @@ const tokenizer = new Tokenizer(dictionary, mode, userDictionary);
 const tokens = tokenizer.tokenize("関西国際空港");
 ```
 
+#### `tokenizeSurfaces(text)`
+
+入力テキストをトークナイズし、トークンの surface のみを返します。分かち書き用途の高速パスです。トークンオブジェクトを生成せず、形態素の詳細情報もロードしないため、surface 文字列だけが必要な場合は `tokenize` より大幅に高速です。結果は `tokenizer.tokenize(text).map((t) => t.surface)` と一致します。（Web Worker とは無関係です。）
+
+- **パラメータ**: `text` (string) -- トークナイズするテキスト
+- **戻り値**: `string[]` -- surface 文字列の配列
+
+```javascript
+const surfaces = tokenizer.tokenizeSurfaces("関西国際空港");
+// ["関西国際空港"]
+```
+
 #### `tokenizeNbest(text, n, unique?, costThreshold?)`
 
 トータルパスコスト順に N-best トークナイズ結果を返します。
@@ -337,6 +349,7 @@ Python API との一貫性のため、すべてのメソッドは snake\_case �
 | `setKeepWhitespace()` | `set_keep_whitespace()` |
 | `appendCharacterFilter()` | `append_character_filter()` |
 | `appendTokenFilter()` | `append_token_filter()` |
+| `tokenizeSurfaces()` | `tokenize_surfaces()` |
 | `tokenizeNbest()` | `tokenize_nbest()` |
 | `loadDictionary()` | `load_dictionary()` |
 | `loadDictionaryFromBytes()` | `load_dictionary_from_bytes()` |

--- a/docs/src/lindera-php/tokenizer_api.md
+++ b/docs/src/lindera-php/tokenizer_api.md
@@ -156,6 +156,25 @@ $tokens = $tokenizer->tokenize('形態素解析');
 
 **Returns:** `array<Token>`
 
+#### `tokenizeSurfaces($text)`
+
+Tokenizes the input text and returns only the token surfaces, as an array of strings. This is the fast path for wakati-style use: no `Token` objects are created and no morphological details are loaded, so it is significantly faster than `tokenize` when only the surface strings are needed. The result equals `array_map(fn ($t) => $t->surface, $tokenizer->tokenize($text))`.
+
+```php
+<?php
+
+$surfaces = $tokenizer->tokenizeSurfaces('形態素解析');
+// ["形態素", "解析"]
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `$text` | `string` | Text to tokenize |
+
+**Returns:** `array<string>`
+
 #### `tokenizeNbest($text, $n, $unique, $costThreshold)`
 
 Returns the N-best tokenization results as an array of `NbestResult` objects.

--- a/docs/src/lindera-ruby/tokenizer_api.md
+++ b/docs/src/lindera-ruby/tokenizer_api.md
@@ -136,6 +136,23 @@ tokens = tokenizer.tokenize('形態素解析')
 
 **Returns:** `Array<Token>`
 
+#### `tokenize_surfaces(text)`
+
+Tokenizes the input text and returns only the token surfaces, as an array of strings. This is the fast path for wakati-style use: no `Token` objects are created and no morphological details are loaded, so it is significantly faster than `tokenize` when only the surface strings are needed. The result equals `tokenizer.tokenize(text).map(&:surface)`.
+
+```ruby
+surfaces = tokenizer.tokenize_surfaces('形態素解析')
+# ["形態素", "解析"]
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `text` | `String` | Text to tokenize |
+
+**Returns:** `Array<String>`
+
 #### `tokenize_nbest(text, n, unique, cost_threshold)`
 
 Returns the N-best tokenization results, each paired with its total path cost.

--- a/docs/src/lindera-wasm/tokenizer_api.md
+++ b/docs/src/lindera-wasm/tokenizer_api.md
@@ -154,6 +154,18 @@ Tokenizes the input text.
 const tokens = tokenizer.tokenize("関西国際空港");
 ```
 
+#### `tokenizeSurfaces(text)`
+
+Tokenizes the input text and returns only the token surfaces. This is the fast path for wakati-style use: no token objects are created and no morphological details are loaded, so it is significantly faster than `tokenize` when only the surface strings are needed. The result equals `tokenizer.tokenize(text).map((t) => t.surface)`. (Unrelated to Web Workers.)
+
+- **Parameters**: `text` (string) -- Text to tokenize
+- **Returns**: `string[]` -- Array of surface strings
+
+```javascript
+const surfaces = tokenizer.tokenizeSurfaces("関西国際空港");
+// ["関西国際空港"]
+```
+
 #### `tokenizeNbest(text, n, unique?, costThreshold?)`
 
 Returns N-best tokenization results ordered by total path cost.
@@ -337,6 +349,7 @@ For consistency with the Python API, all methods are also available in snake\_ca
 | `setKeepWhitespace()` | `set_keep_whitespace()` |
 | `appendCharacterFilter()` | `append_character_filter()` |
 | `appendTokenFilter()` | `append_token_filter()` |
+| `tokenizeSurfaces()` | `tokenize_surfaces()` |
 | `tokenizeNbest()` | `tokenize_nbest()` |
 | `loadDictionary()` | `load_dictionary()` |
 | `loadDictionaryFromBytes()` | `load_dictionary_from_bytes()` |

--- a/lindera-php/src/tokenizer.rs
+++ b/lindera-php/src/tokenizer.rs
@@ -198,6 +198,29 @@ impl PhpTokenizer {
         Ok(views.into_iter().map(PhpToken::from_view).collect())
     }
 
+    /// Tokenizes the given text and returns only the token surfaces.
+    ///
+    /// This is the fast path for wakati-style use: no Token objects are
+    /// created and no morphological details are loaded, so it is
+    /// significantly faster than `tokenize` when only the surface strings
+    /// are needed. Exposed to PHP as `tokenizeSurfaces` (ext-php-rs
+    /// converts snake_case method names to camelCase).
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - Text to tokenize.
+    ///
+    /// # Returns
+    ///
+    /// An array of surface strings, in reading order.
+    pub fn tokenize_surfaces(&self, text: String) -> PhpResult<Vec<String>> {
+        let views = self
+            .inner
+            .tokenize_surfaces(&text)
+            .map_err(lindera_value_err)?;
+        Ok(views.into_iter().map(|view| view.surface).collect())
+    }
+
     /// Tokenizes the given text and returns N-best results.
     ///
     /// Returns an array of associative arrays, each containing:

--- a/lindera-php/tests/LinderaTest.php
+++ b/lindera-php/tests/LinderaTest.php
@@ -154,6 +154,39 @@ class LinderaTest extends TestCase
         $this->assertIsArray($token->details);
     }
 
+    public function testTokenizeSurfacesMatchesTokenize(): void
+    {
+        $builder = new Lindera\TokenizerBuilder();
+        $builder->setDictionary('embedded://ipadic');
+        $tokenizer = $builder->build();
+
+        foreach (['すもももももももものうち', '関西国際空港限定トートバッグ', ''] as $text) {
+            $expected = array_map(
+                static fn ($token) => $token->surface,
+                $tokenizer->tokenize($text)
+            );
+            $surfaces = $tokenizer->tokenizeSurfaces($text);
+
+            $this->assertIsArray($surfaces);
+            $this->assertSame($expected, $surfaces);
+        }
+    }
+
+    public function testTokenizeSurfacesRepeatedCallsAreStable(): void
+    {
+        // The tokenizer reuses an internal lattice across calls; repeated
+        // calls on one instance must keep producing identical output.
+        $builder = new Lindera\TokenizerBuilder();
+        $builder->setDictionary('embedded://ipadic');
+        $tokenizer = $builder->build();
+
+        $text = 'すもももももももものうち';
+        $first = $tokenizer->tokenizeSurfaces($text);
+        for ($i = 0; $i < 100; $i++) {
+            $this->assertSame($first, $tokenizer->tokenizeSurfaces($text));
+        }
+    }
+
     public function testTokenGetDetail(): void
     {
         $builder = new Lindera\TokenizerBuilder();

--- a/lindera-ruby/src/tokenizer.rs
+++ b/lindera-ruby/src/tokenizer.rs
@@ -217,6 +217,34 @@ impl RbTokenizer {
         Ok(arr)
     }
 
+    /// Tokenizes the given text and returns only the token surfaces.
+    ///
+    /// This is the fast path for wakati-style use: no Token objects are
+    /// created and no morphological details are loaded, so it is
+    /// significantly faster than `tokenize` when only the surface strings
+    /// are needed. The surfaces equal `tokenize(text).map(&:surface)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - Text to tokenize.
+    ///
+    /// # Returns
+    ///
+    /// An array of surface strings, in reading order.
+    fn tokenize_surfaces(&self, text: String) -> Result<RArray, Error> {
+        let ruby = Ruby::get().expect("Ruby runtime not initialized");
+        let views = self
+            .inner
+            .tokenize_surfaces(&text)
+            .map_err(|err| to_magnus_error(&ruby, err.to_string()))?;
+
+        let arr = ruby.ary_new_capa(views.len());
+        for view in views {
+            arr.push(view.surface)?;
+        }
+        Ok(arr)
+    }
+
     /// Tokenizes the given text and returns N-best results.
     ///
     /// # Arguments
@@ -299,6 +327,10 @@ pub fn define(ruby: &Ruby, module: &magnus::RModule) -> Result<(), Error> {
     let tokenizer_class = module.define_class("Tokenizer", ruby.class_object())?;
     tokenizer_class.define_singleton_method("new", function!(tokenizer_new, 3))?;
     tokenizer_class.define_method("tokenize", method!(RbTokenizer::tokenize, 1))?;
+    tokenizer_class.define_method(
+        "tokenize_surfaces",
+        method!(RbTokenizer::tokenize_surfaces, 1),
+    )?;
     tokenizer_class.define_method("tokenize_nbest", method!(RbTokenizer::tokenize_nbest, 4))?;
 
     Ok(())

--- a/lindera-ruby/test/test_tokenize_ipadic.rb
+++ b/lindera-ruby/test/test_tokenize_ipadic.rb
@@ -44,4 +44,28 @@ class TestTokenizeIpadic < Minitest::Test
       assert_kind_of Integer, cost
     end
   end
+
+  def test_tokenize_surfaces_matches_tokenize
+    tokenizer = Lindera::Tokenizer.new(@dictionary, 'normal', nil)
+
+    ['すもももももももものうち', '関西国際空港限定トートバッグ', ''].each do |text|
+      expected = tokenizer.tokenize(text).map(&:surface)
+      surfaces = tokenizer.tokenize_surfaces(text)
+
+      assert_kind_of Array, surfaces
+      assert_equal expected, surfaces
+    end
+  end
+
+  def test_tokenize_repeated_calls_are_stable
+    # The tokenizer reuses an internal lattice across calls; repeated calls
+    # on one instance must keep producing identical output.
+    tokenizer = Lindera::Tokenizer.new(@dictionary, 'normal', nil)
+    text = 'すもももももももものうち'
+    first = tokenizer.tokenize_surfaces(text)
+
+    100.times do
+      assert_equal first, tokenizer.tokenize_surfaces(text)
+    end
+  end
 end

--- a/lindera-wasm/src/tokenizer.rs
+++ b/lindera-wasm/src/tokenizer.rs
@@ -225,6 +225,22 @@ impl Tokenizer {
         Ok(views.into_iter().map(JsToken::from_view).collect())
     }
 
+    /// Tokenizes the input text and returns only the token surfaces.
+    ///
+    /// This is the fast path for wakati-style use: no Token objects are
+    /// created and no morphological details are loaded, so it is
+    /// significantly faster than `tokenize` when only the surface strings
+    /// are needed. The surfaces equal `tokenize(text).map((t) => t.surface)`.
+    /// Unrelated to Web Workers.
+    #[wasm_bindgen(js_name = "tokenizeSurfaces")]
+    pub fn tokenize_surfaces(&self, input_text: &str) -> Result<Vec<String>, JsValue> {
+        let views = self
+            .inner
+            .tokenize_surfaces(input_text)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        Ok(views.into_iter().map(|view| view.surface).collect())
+    }
+
     /// Tokenizes the input text and returns N-best results.
     ///
     /// Returns an array of arrays, where each inner array contains Token JSON objects.
@@ -268,6 +284,12 @@ impl Tokenizer {
     ) -> Result<JsValue, JsValue> {
         self.tokenize_nbest(input_text, n, unique, cost_threshold)
     }
+
+    /// Tokenizes the input text and returns only the token surfaces (snake_case alias).
+    #[wasm_bindgen(js_name = "tokenize_surfaces")]
+    pub fn py_tokenize_surfaces(&self, input_text: &str) -> Result<Vec<String>, JsValue> {
+        self.tokenize_surfaces(input_text)
+    }
 }
 
 #[cfg(test)]
@@ -293,6 +315,36 @@ mod tests {
         assert_eq!(tokens[1].surface, "限定");
         assert_eq!(tokens[2].surface, "トートバッグ");
         assert_eq!(tokens[0].get_detail(0), Some("名詞".to_string()));
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_tokenize_surfaces_matches_tokenize() {
+        use crate::TokenizerBuilder;
+
+        let mut builder = TokenizerBuilder::new().unwrap();
+        builder.set_mode("normal").unwrap();
+        builder.set_dictionary("embedded://ipadic").unwrap();
+
+        let tokenizer = builder.build().unwrap();
+
+        let text = "関西国際空港限定トートバッグ";
+        let expected: Vec<String> = tokenizer
+            .tokenize(text)
+            .unwrap()
+            .into_iter()
+            .map(|t| t.surface)
+            .collect();
+        let surfaces = tokenizer.tokenize_surfaces(text).unwrap();
+        assert_eq!(expected, surfaces);
+        assert_eq!(surfaces, vec!["関西国際空港", "限定", "トートバッグ"]);
+
+        // Repeated calls on one instance reuse the internal lattice and
+        // must stay stable; the snake_case alias must match too.
+        for _ in 0..10 {
+            assert_eq!(surfaces, tokenizer.tokenize_surfaces(text).unwrap());
+        }
+        assert_eq!(surfaces, tokenizer.py_tokenize_surfaces(text).unwrap());
     }
 
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
## What

Closes #910. Part of #881 (child D — see the design note comment there). Builds on #915, completing the surface-only fast path across all five bindings.

## Changes

All three routes are thin wrappers over `CoreTokenizer::tokenize_surfaces` (#915), so no morphological details are materialized (~14 → ~1 allocation per token at the binding-core level) and no per-token host-language objects are created.

- **Ruby**: `Lindera::Tokenizer#tokenize_surfaces(text) -> Array<String>` — returns an `RArray` of plain strings instead of per-token `RbToken` TypedData objects (whose accessors clone on every read). Registered via `define_method` alongside `tokenize`.
- **PHP**: `Lindera\Tokenizer::tokenizeSurfaces(string $text): array` — ext-php-rs converts snake_case to camelCase, consistent with the existing `tokenizeNbest`. Returns an array of strings, no per-token Zend objects.
- **WASM**: `tokenizeSurfaces(text): string[]` plus the conventional snake_case alias `tokenize_surfaces` — direct `Vec<String>` → JS string array conversion (no `js_sys::Reflect` detour, minimal size impact under `opt-level = "s"`). Docs note it is unrelated to Web Workers.
- **Docs**: `tokenizer_api.md` for all three bindings, en/ja, including the wasm snake-case alias table row.

## Verification

- `make test-lindera-php`: 27 tests, 175 assertions OK (new: equivalence with `tokenize` surfaces incl. empty input, 100-call stability).
- `make test-lindera-ruby`: 20 runs, 180 assertions, 0 failures (same two new tests).
- `make test-lindera-wasm` (wasm-pack, wasm32, embed-ipadic): 29 passed (new equivalence/stability test asserts the snake_case alias too).
- `cargo clippy -D warnings` for lindera-php and lindera-ruby, and for lindera-wasm with `--target wasm32-unknown-unknown`; `cargo fmt --all -- --check`; markdownlint 0 errors.
- Pre-existing and untouched by this PR: rubocop reports 3 offenses in `lindera-ruby/examples/train_and_export.rb`; the wasm lint target's `prettier` step needs prettier installed locally (its `js/` files are unchanged here).

Per-binding before/after numbers land with the harness in #911.
