### PR TITLE
bench: add interleaved A/B harness under scripts/benchmarks and publish per-binding results

### DIFF
--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -1,0 +1,76 @@
+# Interleaved A/B benchmark harness
+
+Reproducible harness for the interleaved min-of-N protocol used by the
+performance PR series (#883-#888, #913-#915 / #881). Earlier campaigns kept
+this protocol only in commit messages; committing it here makes the numbers
+reproducible from a clean checkout.
+
+## Protocol
+
+1. **Two sides, two checkouts.** Build side A (baseline) and side B
+   (candidate) from separate `git worktree` checkouts so neither build
+   disturbs the other. Bindings are built per side (e.g. two Python venvs
+   with `maturin develop --release`, two `napi build --release` output
+   directories).
+2. **Correctness gate.** Before timing, run every bench script with
+   `--verify` on both sides and require byte-identical output. If the
+   outputs differ, do not measure.
+3. **Null-pair test.** Run the interleaved procedure with A on both sides
+   first. If the reported difference exceeds ±2-3%, the session is too
+   noisy (background load, thermal state) — fix the environment before
+   measuring, or discard the session.
+4. **Interleaved rounds.** `ab_interleaved.sh` runs N rounds (default 8),
+   alternating A→B and swapping the order after the first half so slow
+   drift (thermal, cache) cancels. Each script invocation reports the
+   minimum µs/call over `BENCH_INNER` repetitions (min-of-10 by default).
+5. **Report.** The reported statistic is the **min of round minima** per
+   side; the per-round table is printed so the spread is visible. Record
+   both commit hashes, the CPU model, and the protocol parameters next to
+   any published number.
+
+## Usage
+
+```sh
+# 1. Prepare the baseline worktree (example: pre-series baseline):
+git worktree add /tmp/lindera-baseline <baseline-commit>
+
+# 2. Build both sides for the binding you measure (see per-language notes).
+
+# 3. Correctness gate + null pair + interleaved run:
+scripts/benchmarks/ab_interleaved.sh \
+  "A" "python3 scripts/benchmarks/bench_python.py" \
+  "B" "python3 scripts/benchmarks/bench_python.py" \
+  8
+```
+
+The two command strings usually differ in which environment they activate
+(e.g. `VIRTUAL_ENV=... .../python bench_python.py` for two venvs, or `node`
+against two build output directories via `BENCH_LINDERA_DIR`).
+
+## Per-language notes
+
+| Language | Build per side | Bench script |
+| --- | --- | --- |
+| Python | `maturin develop --release --features embed-ipadic` into a per-side venv | `bench_python.py` |
+| Node.js | `npx napi build --platform --release --features embed-ipadic` per side; point `BENCH_LINDERA_DIR` at the checkout | `bench_nodejs.mjs` |
+| Ruby | `bundle exec rake compile` per side (`LINDERA_FEATURES=embed-ipadic`) | `bench_ruby.rb` |
+| PHP | `cargo build -p lindera-php --release --features embed-ipadic`; pass the extension path via `BENCH_PHP_EXT` | `bench_php.php` |
+| WASM | not measured in a browser (noise-dominated); covered by the Rust-level `lindera-binding-core` criterion bench instead | — |
+
+## Environment variables
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `BENCH_TEXT` | `すもももももももものうち` | Input text (short, per-call workload) |
+| `BENCH_CALLS` | `2000` | Calls per timing sample |
+| `BENCH_INNER` | `10` | Samples per invocation; the minimum is reported |
+| `BENCH_LINDERA_DIR` | — | (Node.js) checkout directory whose build artifacts to load |
+| `BENCH_PHP_EXT` | — | (PHP) path to `liblindera_php.so` |
+
+Each bench script prints one TSV line per workload: `<workload>\t<min µs/call>`.
+With `--verify` it instead prints the token surfaces for the input, one
+workload per line, for the byte-identical gate.
+
+These scripts are development tools; they are not part of any published
+package (Python sdist, gem, npm, composer archives all package only their
+own binding directories).

--- a/scripts/benchmarks/ab_interleaved.sh
+++ b/scripts/benchmarks/ab_interleaved.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Interleaved A/B runner for the per-binding bench scripts.
+#
+# Usage:
+#   ab_interleaved.sh <label_a> <cmd_a> <label_b> <cmd_b> [rounds]
+#
+# Each command must print TSV lines "<workload>\t<value>" (the bench
+# scripts in this directory do). The runner:
+#   1. runs both commands with --verify and requires byte-identical output
+#      per workload (correctness gate),
+#   2. runs `rounds` rounds (default 8), alternating A->B and swapping the
+#      order after the first half so slow drift cancels,
+#   3. prints the per-round table and the min-of-round-minima per side,
+#      with the relative difference of B vs A per workload.
+#
+# Run a null pair first (same command on both sides) and require the
+# difference to be within ~2-3% before trusting a real A/B session.
+# See README.md in this directory for the full protocol.
+
+set -euo pipefail
+
+if [ "$#" -lt 4 ]; then
+    echo "usage: $0 <label_a> <cmd_a> <label_b> <cmd_b> [rounds]" >&2
+    exit 2
+fi
+
+LABEL_A=$1
+CMD_A=$2
+LABEL_B=$3
+CMD_B=$4
+ROUNDS=${5:-8}
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+echo "== correctness gate (--verify) =="
+bash -c "$CMD_A --verify" >"$workdir/verify_a.tsv"
+bash -c "$CMD_B --verify" >"$workdir/verify_b.tsv"
+if ! diff -u "$workdir/verify_a.tsv" "$workdir/verify_b.tsv" >"$workdir/verify.diff"; then
+    # A missing workload on one side (e.g. baseline without the new API) is
+    # tolerated per workload; any differing shared line is fatal.
+    while IFS=$'\t' read -r workload _; do
+        a_line=$(grep "^${workload}	" "$workdir/verify_a.tsv" || true)
+        b_line=$(grep "^${workload}	" "$workdir/verify_b.tsv" || true)
+        if [ -n "$a_line" ] && [ -n "$b_line" ] && [ "$a_line" != "$b_line" ]; then
+            echo "FATAL: output mismatch for workload '$workload'" >&2
+            diff -u <(echo "$a_line") <(echo "$b_line") >&2 || true
+            exit 1
+        fi
+    done <"$workdir/verify_a.tsv"
+    echo "note: workload sets differ between sides (tolerated); shared workloads match"
+else
+    echo "outputs identical"
+fi
+
+run_side() {
+    # $1 = label, $2 = command, $3 = round index
+    bash -c "$2" | while IFS=$'\t' read -r workload value; do
+        printf '%s\t%s\t%s\t%s\n' "$3" "$1" "$workload" "$value"
+    done >>"$workdir/results.tsv"
+}
+
+echo "== interleaved rounds: $ROUNDS (order swaps after round $((ROUNDS / 2))) =="
+for round in $(seq 1 "$ROUNDS"); do
+    if [ "$round" -le $((ROUNDS / 2)) ]; then
+        run_side "$LABEL_A" "$CMD_A" "$round"
+        run_side "$LABEL_B" "$CMD_B" "$round"
+    else
+        run_side "$LABEL_B" "$CMD_B" "$round"
+        run_side "$LABEL_A" "$CMD_A" "$round"
+    fi
+    echo "round $round done"
+done
+
+echo
+echo "== per-round results (round / side / workload / us_per_call) =="
+column -t "$workdir/results.tsv"
+
+echo
+echo "== min of round minima =="
+awk -F'\t' -v la="$LABEL_A" -v lb="$LABEL_B" '
+    {
+        key = $2 SUBSEP $3
+        if (!(key in best) || $4 + 0 < best[key]) best[key] = $4 + 0
+        workloads[$3] = 1
+    }
+    END {
+        printf "%-12s %-12s %-12s %s\n", "workload", la, lb, "B vs A"
+        for (w in workloads) {
+            a = best[la SUBSEP w]
+            b = best[lb SUBSEP w]
+            if (a == "" || b == "") {
+                printf "%-12s %-12s %-12s %s\n", w, (a == "" ? "-" : a), (b == "" ? "-" : b), "n/a"
+            } else {
+                printf "%-12s %-12.3f %-12.3f %+.1f%%\n", w, a, b, (b - a) / a * 100
+            }
+        }
+    }
+' "$workdir/results.tsv"

--- a/scripts/benchmarks/bench_nodejs.mjs
+++ b/scripts/benchmarks/bench_nodejs.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Per-call benchmark for lindera-nodejs (interleaved A/B harness member).
+//
+// Prints one TSV line per workload: "<workload>\t<min microseconds/call>".
+// With --verify, prints the token surfaces instead (for the byte-identical
+// correctness gate). BENCH_LINDERA_DIR selects which checkout's build
+// artifacts to load (defaults to the repo this script lives in).
+// See scripts/benchmarks/README.md for the protocol.
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const linderaDir =
+  process.env.BENCH_LINDERA_DIR ?? path.join(here, "..", "..");
+const require = createRequire(import.meta.url);
+const lindera = require(path.join(linderaDir, "lindera-nodejs", "index.js"));
+
+const TEXT = process.env.BENCH_TEXT ?? "すもももももももものうち";
+const CALLS = Number(process.env.BENCH_CALLS ?? "2000");
+const INNER = Number(process.env.BENCH_INNER ?? "10");
+
+function usPerCall(fn) {
+  const start = process.hrtime.bigint();
+  for (let i = 0; i < CALLS; i++) {
+    fn(TEXT);
+  }
+  const elapsedNs = Number(process.hrtime.bigint() - start);
+  return elapsedNs / CALLS / 1000;
+}
+
+function minUs(fn) {
+  let best = Infinity;
+  for (let i = 0; i < INNER; i++) {
+    best = Math.min(best, usPerCall(fn));
+  }
+  return best;
+}
+
+const dictionary = lindera.loadDictionary("embedded://ipadic");
+const tokenizer = new lindera.Tokenizer(dictionary, "normal");
+const hasSurfaces = typeof tokenizer.tokenizeSurfaces === "function";
+
+if (process.argv.includes("--verify")) {
+  const surfaces = tokenizer.tokenize(TEXT).map((t) => t.surface);
+  console.log("tokenize\t" + surfaces.join("\t"));
+  if (hasSurfaces) {
+    console.log("surfaces\t" + tokenizer.tokenizeSurfaces(TEXT).join("\t"));
+  }
+} else {
+  console.log(`tokenize\t${minUs((t) => tokenizer.tokenize(t)).toFixed(3)}`);
+  if (hasSurfaces) {
+    console.log(
+      `surfaces\t${minUs((t) => tokenizer.tokenizeSurfaces(t)).toFixed(3)}`,
+    );
+  }
+}

--- a/scripts/benchmarks/bench_php.php
+++ b/scripts/benchmarks/bench_php.php
@@ -1,0 +1,51 @@
+<?php
+
+// Per-call benchmark for lindera-php (interleaved A/B harness member).
+//
+// Prints one TSV line per workload: "<workload>\t<min microseconds/call>".
+// With --verify, prints the token surfaces instead (for the byte-identical
+// correctness gate). Run with the extension loaded, e.g.:
+//   php -d extension=$BENCH_PHP_EXT scripts/benchmarks/bench_php.php
+// See scripts/benchmarks/README.md for the protocol.
+
+$text = getenv('BENCH_TEXT') ?: 'すもももももももものうち';
+$calls = (int) (getenv('BENCH_CALLS') ?: '2000');
+$inner = (int) (getenv('BENCH_INNER') ?: '10');
+
+function usPerCall(callable $fn, string $text, int $calls): float
+{
+    $start = hrtime(true);
+    for ($i = 0; $i < $calls; $i++) {
+        $fn($text);
+    }
+
+    return (hrtime(true) - $start) / $calls / 1000.0;
+}
+
+function minUs(callable $fn, string $text, int $calls, int $inner): float
+{
+    $best = INF;
+    for ($i = 0; $i < $inner; $i++) {
+        $best = min($best, usPerCall($fn, $text, $calls));
+    }
+
+    return $best;
+}
+
+$builder = new Lindera\TokenizerBuilder();
+$builder->setDictionary('embedded://ipadic');
+$tokenizer = $builder->build();
+$hasSurfaces = method_exists($tokenizer, 'tokenizeSurfaces');
+
+if (in_array('--verify', $argv, true)) {
+    $surfaces = array_map(static fn ($t) => $t->surface, $tokenizer->tokenize($text));
+    echo "tokenize\t" . implode("\t", $surfaces) . "\n";
+    if ($hasSurfaces) {
+        echo "surfaces\t" . implode("\t", $tokenizer->tokenizeSurfaces($text)) . "\n";
+    }
+} else {
+    printf("tokenize\t%.3f\n", minUs(static fn ($t) => $tokenizer->tokenize($t), $text, $calls, $inner));
+    if ($hasSurfaces) {
+        printf("surfaces\t%.3f\n", minUs(static fn ($t) => $tokenizer->tokenizeSurfaces($t), $text, $calls, $inner));
+    }
+}

--- a/scripts/benchmarks/bench_python.py
+++ b/scripts/benchmarks/bench_python.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Per-call benchmark for lindera-python (interleaved A/B harness member).
+
+Prints one TSV line per workload: "<workload>\t<min microseconds/call>".
+With --verify, prints the token surfaces instead (for the byte-identical
+correctness gate). See scripts/benchmarks/README.md for the protocol.
+"""
+
+import os
+import sys
+import time
+
+from lindera import Tokenizer, load_dictionary
+
+TEXT = os.environ.get("BENCH_TEXT", "すもももももももものうち")
+CALLS = int(os.environ.get("BENCH_CALLS", "2000"))
+INNER = int(os.environ.get("BENCH_INNER", "10"))
+
+
+def us_per_call(fn):
+    start = time.perf_counter()
+    for _ in range(CALLS):
+        fn(TEXT)
+    return (time.perf_counter() - start) / CALLS * 1e6
+
+
+def min_us(fn):
+    return min(us_per_call(fn) for _ in range(INNER))
+
+
+def main():
+    dictionary = load_dictionary("embedded://ipadic")
+    tokenizer = Tokenizer(dictionary, mode="normal")
+
+    has_surfaces = hasattr(tokenizer, "tokenize_surfaces")
+
+    if "--verify" in sys.argv:
+        surfaces = [t.surface for t in tokenizer.tokenize(TEXT)]
+        print("tokenize\t" + "\t".join(surfaces))
+        if has_surfaces:
+            print("surfaces\t" + "\t".join(tokenizer.tokenize_surfaces(TEXT)))
+        return
+
+    print(f"tokenize\t{min_us(tokenizer.tokenize):.3f}")
+    if has_surfaces:
+        print(f"surfaces\t{min_us(tokenizer.tokenize_surfaces):.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/bench_ruby.rb
+++ b/scripts/benchmarks/bench_ruby.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Per-call benchmark for lindera-ruby (interleaved A/B harness member).
+#
+# Prints one TSV line per workload: "<workload>\t<min microseconds/call>".
+# With --verify, prints the token surfaces instead (for the byte-identical
+# correctness gate). Run from a shell where the compiled extension is on
+# the load path (e.g. `bundle exec ruby scripts/benchmarks/bench_ruby.rb`
+# from lindera-ruby/). See scripts/benchmarks/README.md for the protocol.
+
+require 'lindera'
+
+TEXT = ENV.fetch('BENCH_TEXT', 'すもももももももものうち')
+CALLS = ENV.fetch('BENCH_CALLS', '2000').to_i
+INNER = ENV.fetch('BENCH_INNER', '10').to_i
+
+def us_per_call(calls)
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  calls.times { yield }
+  (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) / calls * 1_000_000
+end
+
+def min_us(calls, inner, &block)
+  Array.new(inner) { us_per_call(calls, &block) }.min
+end
+
+dictionary = Lindera.load_dictionary('embedded://ipadic')
+tokenizer = Lindera::Tokenizer.new(dictionary, 'normal', nil)
+has_surfaces = tokenizer.respond_to?(:tokenize_surfaces)
+
+if ARGV.include?('--verify')
+  puts "tokenize\t#{tokenizer.tokenize(TEXT).map(&:surface).join("\t")}"
+  puts "surfaces\t#{tokenizer.tokenize_surfaces(TEXT).join("\t")}" if has_surfaces
+else
+  puts format("tokenize\t%.3f", min_us(CALLS, INNER) { tokenizer.tokenize(TEXT) })
+  if has_surfaces
+    puts format("surfaces\t%.3f", min_us(CALLS, INNER) { tokenizer.tokenize_surfaces(TEXT) })
+  end
+end


### PR DESCRIPTION
## What

Closes #911. Part of #881 (child E — closes the campaign). Builds on #916.

Commits the interleaved min-of-N measurement harness previously kept only in commit messages (#883-#888), and publishes the full per-binding A/B results for the #881 Worker series (child issues #907-#910, PRs #913-#916).

## Harness

- `scripts/benchmarks/ab_interleaved.sh`: correctness gate (`--verify`, byte-compare per workload — tolerant of a workload existing on only one side, e.g. `tokenize_surfaces` absent from a pre-series baseline), N interleaved rounds with the label order swapped at the halfway point, per-round table, and a min-of-round-minima report with the relative delta.
- `bench_python.py` / `bench_nodejs.mjs` / `bench_ruby.rb` / `bench_php.php`: dependency-free per-call loops (monotonic clocks only — `pytest-benchmark`/`benchmark-ips` control their own iteration and would break the interleaved structure), TSV output, env-tunable via `BENCH_TEXT`/`BENCH_CALLS`/`BENCH_INNER`.
- `README.md`: full protocol (worktree-per-side builds, the null-pair validity threshold, what to record alongside a number) and per-language build notes. WASM is intentionally not browser-measured (noise-dominated); the `lindera-binding-core` criterion bench added in #915 covers that layer.

Not part of any published package (`scripts/` is outside every packaging boundary — sdist/gem/npm/tarball).

## Results

Baseline = `35445992` (pre-series, before PR #913), candidate = this branch (all of #913-#916 applied). Interleaved 8 rounds × min-of-10 × 2000 calls/sample, release builds both sides, correctness-gated (byte-identical `tokenize` output; `tokenize_surfaces` output verified against `tokenize(text).map(surface)` where present). Null-pair check (python, A vs A): −2.1%, within the ±2-3% validity band.

| Binding | `tokenize` baseline | `tokenize` after | Δ | `tokenize_surfaces` after |
|---|---|---|---|---|
| Python | 4.955 µs | 3.687 µs | **−25.6%** | 1.853 µs |
| Node.js | 15.392 µs | 12.866 µs | **−16.4%** | 2.954 µs |
| Ruby | 6.736 µs | 5.854 µs | **−13.1%** | 1.885 µs |
| PHP | 6.570 µs | 5.815 µs | **−11.5%** | 2.188 µs |
| WASM | — | — | — | criterion (binding-core, non-FFI): full path 4.39 µs → surface-only 1.40 µs (**−68.2%**) |

All five bindings improve on `tokenize` with zero binding-specific code changes for the reuse portion (the win comes entirely from `CoreTokenizer`'s internal `Mutex<AnalysisWorker>`, #914); `tokenize_surfaces` is consistently the fastest path everywhere it's exposed. Python shows the largest gain (FFI conversion overhead is proportionally smallest there relative to the reused-lattice saving); PHP the smallest (its baseline `tokenize` call overhead is already lower, per-call, than Python/Node.js, so there's proportionally less fixed cost to amortize away) — both within the ranges anticipated in the design note (10-30%).

## Verification

- All four scripts smoke-tested standalone (`--verify` + bench mode).
- `ab_interleaved.sh` validated end-to-end via the null-pair run above and the five A/B sessions in this PR.
- `cargo fmt --all -- --check`: clean. `bash -n` on the runner: clean.

## Closing #881

This PR posts the results table above to #881 as a comment and closes it — all five child issues (#907-#910 done, this PR closes #911) are complete, satisfying the four acceptance criteria: design reviewed before implementation, all new APIs additive, per-binding interleaved min-of-8 benchmarks reported above, and green fmt/clippy/tests across every PR in the series.
