### PR TITLE
chore: bump version to 5.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-analysis"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-binding-core"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "criterion",
  "lindera",
@@ -1620,14 +1620,14 @@ dependencies = [
 
 [[package]]
 name = "lindera-cc-cedict"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-cli"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-crf"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1688,35 +1688,35 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-ipadic-neologd"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-jieba"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-ko-dic"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-nodejs"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-php"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "ext-php-rs",
  "lindera",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-python"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-ruby"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-trainer"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "daachorse",
@@ -1781,14 +1781,14 @@ dependencies = [
 
 [[package]]
 name = "lindera-unidic"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-wasm"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "js-sys",
  "lindera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.1.0"
+version = "5.2.0"
 edition = "2024"
 description = "A morphological analysis libraries and command line interface."
 documentation = "https://docs.rs/lindera"
@@ -38,24 +38,24 @@ anyhow = "1.0.104"
 byteorder = "1.5.0"
 csv = "1.4.0"
 daachorse = "4.0.0"
-lindera = { version = "5.1.0", path = "lindera" }
-lindera-analysis = { version = "5.1.0", path = "lindera-analysis" }
-lindera-binding-core = { version = "5.1.0", path = "lindera-binding-core" }
-lindera-crf = { version = "5.1.0", path = "lindera-crf" }
-lindera-cc-cedict = { version = "5.1.0", path = "lindera-cc-cedict" }
-lindera-cli = { version = "5.1.0", path = "lindera-cli" }
-lindera-dictionary = { version = "5.1.0", path = "lindera-dictionary" }
-lindera-trainer = { version = "5.1.0", path = "lindera-trainer" }
-lindera-ipadic = { version = "5.1.0", path = "lindera-ipadic" }
-lindera-ipadic-neologd = { version = "5.1.0", path = "lindera-ipadic-neologd" }
-lindera-jieba = { version = "5.1.0", path = "lindera-jieba" }
-lindera-ko-dic = { version = "5.1.0", path = "lindera-ko-dic" }
-lindera-nodejs = { version = "5.1.0", path = "lindera-nodejs" }
-lindera-python = { version = "5.1.0", path = "lindera-python" }
-lindera-ruby = { version = "5.1.0", path = "lindera-ruby" }
-lindera-unidic = { version = "5.1.0", path = "lindera-unidic" }
-lindera-php = { version = "5.1.0", path = "lindera-php" }
-lindera-wasm = { version = "5.1.0", path = "lindera-wasm" }
+lindera = { version = "5.2.0", path = "lindera" }
+lindera-analysis = { version = "5.2.0", path = "lindera-analysis" }
+lindera-binding-core = { version = "5.2.0", path = "lindera-binding-core" }
+lindera-crf = { version = "5.2.0", path = "lindera-crf" }
+lindera-cc-cedict = { version = "5.2.0", path = "lindera-cc-cedict" }
+lindera-cli = { version = "5.2.0", path = "lindera-cli" }
+lindera-dictionary = { version = "5.2.0", path = "lindera-dictionary" }
+lindera-trainer = { version = "5.2.0", path = "lindera-trainer" }
+lindera-ipadic = { version = "5.2.0", path = "lindera-ipadic" }
+lindera-ipadic-neologd = { version = "5.2.0", path = "lindera-ipadic-neologd" }
+lindera-jieba = { version = "5.2.0", path = "lindera-jieba" }
+lindera-ko-dic = { version = "5.2.0", path = "lindera-ko-dic" }
+lindera-nodejs = { version = "5.2.0", path = "lindera-nodejs" }
+lindera-python = { version = "5.2.0", path = "lindera-python" }
+lindera-ruby = { version = "5.2.0", path = "lindera-ruby" }
+lindera-unidic = { version = "5.2.0", path = "lindera-unidic" }
+lindera-php = { version = "5.2.0", path = "lindera-php" }
+lindera-wasm = { version = "5.2.0", path = "lindera-wasm" }
 log = "0.4.33"
 num_cpus = "1.17.0"
 once_cell = "1.21.4"

--- a/docs/ja/src/lindera-wasm/tokenizer_api.md
+++ b/docs/ja/src/lindera-wasm/tokenizer_api.md
@@ -283,7 +283,7 @@ lindera-wasm パッケージのバージョン文字列を返します。
 ```javascript
 import { version } from 'lindera-wasm-web-ipadic';
 
-console.log(version()); // 例: "5.1.0"
+console.log(version()); // 例: "5.2.0"
 ```
 
 ## 列挙型とユーティリティクラス

--- a/docs/src/lindera-wasm/tokenizer_api.md
+++ b/docs/src/lindera-wasm/tokenizer_api.md
@@ -283,7 +283,7 @@ Returns the version string of the lindera-wasm package.
 ```javascript
 import { version } from 'lindera-wasm-web-ipadic';
 
-console.log(version()); // e.g., "5.1.0"
+console.log(version()); // e.g., "5.2.0"
 ```
 
 ## Enums and Utility Classes

--- a/lindera-nodejs/index.js
+++ b/lindera-nodejs/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-android-arm64')
         const bindingPackageVersion = require('lindera-nodejs-android-arm64/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-android-arm-eabi')
         const bindingPackageVersion = require('lindera-nodejs-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-win32-x64-gnu')
         const bindingPackageVersion = require('lindera-nodejs-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-win32-x64-msvc')
         const bindingPackageVersion = require('lindera-nodejs-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-win32-ia32-msvc')
         const bindingPackageVersion = require('lindera-nodejs-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-win32-arm64-msvc')
         const bindingPackageVersion = require('lindera-nodejs-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('lindera-nodejs-darwin-universal')
       const bindingPackageVersion = require('lindera-nodejs-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-darwin-x64')
         const bindingPackageVersion = require('lindera-nodejs-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-darwin-arm64')
         const bindingPackageVersion = require('lindera-nodejs-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-freebsd-x64')
         const bindingPackageVersion = require('lindera-nodejs-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-freebsd-arm64')
         const bindingPackageVersion = require('lindera-nodejs-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-x64-musl')
           const bindingPackageVersion = require('lindera-nodejs-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-x64-gnu')
           const bindingPackageVersion = require('lindera-nodejs-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-arm64-musl')
           const bindingPackageVersion = require('lindera-nodejs-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-arm64-gnu')
           const bindingPackageVersion = require('lindera-nodejs-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-arm-musleabihf')
           const bindingPackageVersion = require('lindera-nodejs-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-arm-gnueabihf')
           const bindingPackageVersion = require('lindera-nodejs-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-loong64-musl')
           const bindingPackageVersion = require('lindera-nodejs-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-loong64-gnu')
           const bindingPackageVersion = require('lindera-nodejs-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-riscv64-musl')
           const bindingPackageVersion = require('lindera-nodejs-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('lindera-nodejs-linux-riscv64-gnu')
           const bindingPackageVersion = require('lindera-nodejs-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-linux-ppc64-gnu')
         const bindingPackageVersion = require('lindera-nodejs-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-linux-s390x-gnu')
         const bindingPackageVersion = require('lindera-nodejs-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-openharmony-arm64')
         const bindingPackageVersion = require('lindera-nodejs-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-openharmony-x64')
         const bindingPackageVersion = require('lindera-nodejs-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('lindera-nodejs-openharmony-arm')
         const bindingPackageVersion = require('lindera-nodejs-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '5.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '5.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('lindera-nodejs-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '5.1.0') {
-            throw new Error(`WASI binding package version mismatch, expected 5.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '5.2.0') {
+            throw new Error(`WASI binding package version mismatch, expected 5.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('lindera-nodejs-wasm32-wasi')

--- a/lindera-nodejs/package.json
+++ b/lindera-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lindera-nodejs",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Node.js bindings for Lindera morphological analysis engine",
   "main": "index.js",
   "types": "index.d.ts",

--- a/lindera-php/composer.json
+++ b/lindera-php/composer.json
@@ -7,7 +7,7 @@
     "php": ">=8.1"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.75",
-    "phpunit/phpunit": "^13.1.0"
+    "friendsofphp/php-cs-fixer": "^3.95.18",
+    "phpunit/phpunit": "^13.3.1"
   }
 }

--- a/lindera-python/pyproject.toml
+++ b/lindera-python/pyproject.toml
@@ -28,7 +28,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
-maturin = "^1.12.6"
+maturin = "^1.14.1"
 patchelf = "^0.19.1.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/lindera-ruby/lindera.gemspec
+++ b/lindera-ruby/lindera.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "lindera"
-  spec.version = "5.1.0"
+  spec.version = "5.2.0"
   spec.authors = ["Lindera contributors"]
   spec.summary = "Ruby bindings for Lindera morphological analysis engine"
   spec.description = "Ruby bindings for Lindera, a morphological analysis library for CJK text (Japanese, Korean, Chinese)."

--- a/lindera-wasm/example/package.json
+++ b/lindera-wasm/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lindera-wasm-example",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Example project for Lindera WASM",
   "scripts": {
     "start": "webpack serve --config webpack.config.js",


### PR DESCRIPTION
## What

Bumps the workspace version 5.1.0 → 5.2.0 via `scripts/bump-up-version.sh`, releasing the #881 Worker series (PRs #912-#917, closed #881): reusable `SegmentWorker`/`AnalysisWorker` sessions and the `tokenize_surfaces` fast path across all five language bindings. Every change in that series is additive to the public API, so a minor bump is correct.

## Changes

- `Cargo.toml`: `workspace.package.version` + every internal `lindera-*` pin.
- `Cargo.lock`: version field of every lindera-owned workspace member (script-verified consistent via `cargo metadata --locked`).
- `lindera-ruby/lindera.gemspec`: `spec.version` (hand-maintained, not derivable from the workspace).
- `lindera-nodejs/index.js`: NAPI-generated binding-version guard (reproduced by literal substitution; no other content changes at this version).
- `docs/{src,ja/src}/lindera-wasm/tokenizer_api.md`: sample `version()` output in the WASM tokenizer API guide.
- `lindera-nodejs/package.json`, `lindera-wasm/example/package.json`: `version` field.
- Also included: dev dependency constraint bumps picked up alongside this release — `friendsofphp/php-cs-fixer` (^3.75 → ^3.95.18) and `phpunit/phpunit` (^13.1.0 → ^13.3.1) in `lindera-php/composer.json`; `maturin` (^1.12.6 → ^1.14.1) in `lindera-python/pyproject.toml`.

`lindera-python/pyproject.toml`'s package version itself is untouched (`dynamic = ["version"]`, derived from the workspace at build time), matching the script's design.

## Verification

- `scripts/bump-up-version.sh`'s own safety net (`git grep` for leftover `5.1.0` references) found only test fixtures and doc examples using it as an illustrative version string (`lindera-cli/src/dictionary_registry.rs`, `lindera-cli/src/commands/list.rs`, CLI docs) — not real version references, left untouched by design.
- `cargo metadata --locked --format-version=1`: `Cargo.lock` consistent with `Cargo.toml`.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p lindera-cli --all-targets --features train,embed-ipadic -D warnings`: clean.
- `cargo test -p lindera-cli --features train,embed-ipadic`: 50 tests green.
- `cargo build --workspace`: green.
