### PR TITLE
docs: add a Performance section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Pre-built dictionaries are available from [GitHub Releases](https://github.com/l
 Download a dictionary archive (e.g. `lindera-ipadic-*.zip`) and specify the path when loading.
 When using the CLI, `lindera download ipadic` downloads and installs a dictionary automatically.
 
+## Performance
+
+Lindera tokenizes Japanese text (IPADIC) at roughly 10-20 MB/s single-threaded, depending on hardware and whether the Viterbi lattice is reused across calls, with dictionary loading more than 5x faster than [Vibrato](https://github.com/daac-tools/vibrato). Run `make bench` to reproduce the benchmark suite (`lindera/benches/`) on your own machine; see [#875](https://github.com/lindera/lindera/issues/875) for detailed methodology and comparison numbers.
+
 ## Python Bindings
 
 Lindera also provides Python bindings. You can install it via pip:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When using the CLI, `lindera download ipadic` downloads and installs a dictionar
 
 ## Performance
 
-Lindera tokenizes Japanese text (IPADIC) at roughly 10-20 MB/s single-threaded, depending on hardware and whether the Viterbi lattice is reused across calls, with dictionary loading more than 5x faster than [Vibrato](https://github.com/daac-tools/vibrato). Run `make bench` to reproduce the benchmark suite (`lindera/benches/`) on your own machine; see [#875](https://github.com/lindera/lindera/issues/875) for detailed methodology and comparison numbers.
+Lindera tokenizes Japanese text (IPADIC) at roughly 10-20 MB/s single-threaded, depending on hardware and whether the Viterbi lattice is reused across calls. Run `make bench` to reproduce the benchmark suite (`lindera/benches/`) on your own machine; see [#875](https://github.com/lindera/lindera/issues/875) for detailed methodology and comparison numbers.
 
 ## Python Bindings
 

--- a/docs/ja/src/README.md
+++ b/docs/ja/src/README.md
@@ -48,6 +48,10 @@ graph LR
 | [APIリファレンス](./lindera/api_reference.md) | Rust APIドキュメント |
 | [コントリビュート](./development/contributing.md) | Linderaへの貢献方法 |
 
+## パフォーマンス
+
+Linderaは日本語テキスト（IPADIC）を、シングルスレッドで概ね10〜20 MB/sの速度でトークナイズします（速度はハードウェアや、Viterbiラティスを呼び出しをまたいで再利用するかどうかに依存します）。辞書のロードは[Vibrato](https://github.com/daac-tools/vibrato)より5倍以上高速です。ベンチマークスイート（`lindera/benches/`）を自分のマシンで再現するには`make bench`を実行してください。詳細な計測方法と比較データは[#875](https://github.com/lindera/lindera/issues/875)を参照してください。
+
 ## クイック例
 
 ```rust

--- a/docs/ja/src/README.md
+++ b/docs/ja/src/README.md
@@ -50,7 +50,7 @@ graph LR
 
 ## パフォーマンス
 
-Linderaは日本語テキスト（IPADIC）を、シングルスレッドで概ね10〜20 MB/sの速度でトークナイズします（速度はハードウェアや、Viterbiラティスを呼び出しをまたいで再利用するかどうかに依存します）。辞書のロードは[Vibrato](https://github.com/daac-tools/vibrato)より5倍以上高速です。ベンチマークスイート（`lindera/benches/`）を自分のマシンで再現するには`make bench`を実行してください。詳細な計測方法と比較データは[#875](https://github.com/lindera/lindera/issues/875)を参照してください。
+Linderaは日本語テキスト（IPADIC）を、シングルスレッドで概ね10〜20 MB/sの速度でトークナイズします（速度はハードウェアや、Viterbiラティスを呼び出しをまたいで再利用するかどうかに依存します）。ベンチマークスイート（`lindera/benches/`）を自分のマシンで再現するには`make bench`を実行してください。詳細な計測方法と比較データは[#875](https://github.com/lindera/lindera/issues/875)を参照してください。
 
 ## クイック例
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -48,6 +48,10 @@ graph LR
 | [API Reference](./lindera/api_reference.md) | Rust API documentation |
 | [Contributing](./development/contributing.md) | How to contribute to Lindera |
 
+## Performance
+
+Lindera tokenizes Japanese text (IPADIC) at roughly 10-20 MB/s single-threaded, depending on hardware and whether the Viterbi lattice is reused across calls, with dictionary loading more than 5x faster than [Vibrato](https://github.com/daac-tools/vibrato). Run `make bench` to reproduce the benchmark suite (`lindera/benches/`) on your own machine; see [#875](https://github.com/lindera/lindera/issues/875) for detailed methodology and comparison numbers.
+
 ## Quick Example
 
 ```rust

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -50,7 +50,7 @@ graph LR
 
 ## Performance
 
-Lindera tokenizes Japanese text (IPADIC) at roughly 10-20 MB/s single-threaded, depending on hardware and whether the Viterbi lattice is reused across calls, with dictionary loading more than 5x faster than [Vibrato](https://github.com/daac-tools/vibrato). Run `make bench` to reproduce the benchmark suite (`lindera/benches/`) on your own machine; see [#875](https://github.com/lindera/lindera/issues/875) for detailed methodology and comparison numbers.
+Lindera tokenizes Japanese text (IPADIC) at roughly 10-20 MB/s single-threaded, depending on hardware and whether the Viterbi lattice is reused across calls. Run `make bench` to reproduce the benchmark suite (`lindera/benches/`) on your own machine; see [#875](https://github.com/lindera/lindera/issues/875) for detailed methodology and comparison numbers.
 
 ## Quick Example
 


### PR DESCRIPTION
## What

Closes #318.

The issue's original ask was "a rough idea of the throughput of the tokenizers on the README page." The maintainer replied promising to measure and post it, but that never happened — `README.md` and the mdBook docs currently have no throughput information at all.

## Changes

Adds a short "Performance"/"パフォーマンス" section to `README.md`, `docs/src/README.md` (mdBook Introduction), and `docs/ja/src/README.md`:

- States an approximate range (~10-20 MB/s single-threaded, IPADIC) rather than a single precise number.
- Points readers to `make bench` (the existing `lindera/benches/` suite) and #875 for reproducible numbers on their own hardware and full methodology.

## Why a range instead of a precise number

Re-running the existing `bocchan.txt` benchmark (`bench-tokenize-long-text-ipadic`, 313,804 bytes, embedded IPADIC) on this machine right now gave 26.3-29.2 ms across 3 runs (~10-12 MB/s), vs ~17.7 ms (~17.7 MB/s) from a controlled, less-loaded run earlier in the #875 campaign — a ~1.6x spread on identical code from load/thermal conditions alone. A hardcoded exact figure would need constant upkeep and could mislead readers whose conditions differ, so the section states an honest range with a pointer to reproduce it locally instead.

## Verification

`markdownlint-cli2` on all three changed files: 0 errors.
