### PR TITLE
fix(dictionary): bounds-check prefix-dictionary value packing

### DIFF
--- a/lindera-dictionary/src/builder/prefix_dictionary.rs
+++ b/lindera-dictionary/src/builder/prefix_dictionary.rs
@@ -489,7 +489,7 @@ impl PrefixDictionaryBuilder {
 
         for (key, word_entries) in word_entry_map {
             let len = word_entries.len() as u32;
-            let val = (id << 8) | len; // 24bit for word ID, 8bit for variant count (up to 255 per surface).
+            let val = pack_entry_value(key, id, len)?;
             keyset.push((key.as_bytes(), val));
             id += len;
         }
@@ -566,6 +566,45 @@ impl PrefixDictionaryBuilder {
     }
 }
 
+/// Maximum number of word entries that can share one surface form, imposed by
+/// the 8-bit count field of the packed prefix-dictionary value.
+pub(crate) const MAX_ENTRIES_PER_SURFACE: u32 = 0xff;
+
+/// Maximum entry offset representable by the 24-bit offset field of the packed
+/// prefix-dictionary value.
+pub(crate) const MAX_ENTRY_OFFSET: u32 = (1 << 24) - 1;
+
+/// Packs a prefix-dictionary match value as `(offset << 8) | count`.
+///
+/// Both fields are bounds-checked: exceeding either silently corrupted the
+/// value before (the count overflowed into the offset bits, and the offset
+/// shifted out of the u32 entirely), producing a dictionary that built without
+/// error but tokenized incorrectly.
+///
+/// # 引数
+///
+/// * `surface` - The surface form being packed, used for error reporting.
+/// * `offset` - Entry offset into the values file, in `WordEntry` records.
+/// * `count` - Number of entries sharing this surface form.
+///
+/// # 戻り値
+///
+/// The packed value, or an error naming the surface form and the limit it
+/// exceeded.
+pub(crate) fn pack_entry_value(surface: &str, offset: u32, count: u32) -> LinderaResult<u32> {
+    if count > MAX_ENTRIES_PER_SURFACE {
+        return Err(LinderaErrorKind::Build.with_error(anyhow::anyhow!(
+            "surface form {surface:?} has {count} entries, exceeding the limit of {MAX_ENTRIES_PER_SURFACE} per surface form"
+        )));
+    }
+    if offset > MAX_ENTRY_OFFSET {
+        return Err(LinderaErrorKind::Build.with_error(anyhow::anyhow!(
+            "entry offset {offset} at surface form {surface:?} exceeds the limit of {MAX_ENTRY_OFFSET}; the dictionary has too many entries"
+        )));
+    }
+    Ok((offset << 8) | count)
+}
+
 fn normalize(text: &str) -> String {
     text.to_string().replace('―', "—").replace('～', "〜")
 }
@@ -575,6 +614,42 @@ mod tests {
     use super::*;
     use crate::dictionary::schema::Schema;
     use csv::StringRecord;
+
+    #[test]
+    fn test_pack_entry_value_within_bounds() {
+        // Round-trips through the same decoding the dictionary performs.
+        let packed = pack_entry_value("すもも", 361_708, 1).expect("within bounds");
+        assert_eq!(packed >> 8, 361_708);
+        assert_eq!(packed & 0xff, 1);
+
+        // Both fields at their maximum still pack losslessly.
+        let packed = pack_entry_value("x", MAX_ENTRY_OFFSET, MAX_ENTRIES_PER_SURFACE)
+            .expect("boundary values are valid");
+        assert_eq!(packed >> 8, MAX_ENTRY_OFFSET);
+        assert_eq!(packed & 0xff, MAX_ENTRIES_PER_SURFACE);
+    }
+
+    #[test]
+    fn test_pack_entry_value_rejects_too_many_variants() {
+        // 256 variants would overflow the 8-bit count field and corrupt the
+        // offset bits above it; this used to build a silently wrong dictionary.
+        let err = pack_entry_value("かん", 0, MAX_ENTRIES_PER_SURFACE + 1)
+            .expect_err("256 variants must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("かん"), "error should name the surface: {msg}");
+        assert!(msg.contains("256"), "error should state the count: {msg}");
+    }
+
+    #[test]
+    fn test_pack_entry_value_rejects_offset_overflow() {
+        // An offset past 24 bits would shift out of the u32 entirely.
+        let err = pack_entry_value("x", MAX_ENTRY_OFFSET + 1, 1)
+            .expect_err("offset past 24 bits must be rejected");
+        assert!(
+            err.to_string().contains("too many entries"),
+            "error should explain the cause: {err}"
+        );
+    }
 
     #[test]
     fn test_new_with_schema() {

--- a/lindera-dictionary/src/builder/user_dictionary.rs
+++ b/lindera-dictionary/src/builder/user_dictionary.rs
@@ -262,7 +262,7 @@ impl UserDictionaryBuilder {
             // matching the system dictionary encoding. The legacy 5-bit user
             // encoding (max 31 variants) was retired in v4.0.0; user dictionary
             // `.bin` files built with v3 must be rebuilt from their CSV source.
-            let val = (id << 8) | len;
+            let val = crate::builder::prefix_dictionary::pack_entry_value(key, id, len)?;
             keyset.push((key.as_bytes(), val));
             id += len;
         }


### PR DESCRIPTION
## What

Closes #921.

The prefix-dictionary match value is packed as `(offset << 8) | count` in both the system builder (`builder/prefix_dictionary.rs:490-495`) and the user dictionary builder (`builder/user_dictionary.rs:259-268`), but neither field was bounds-checked:

- A surface form with **more than 255 entries** overflowed the 8-bit count field into the offset bits above it, so that surface's entries were then read from the wrong `dict.vals` offset.
- An entry offset past **24 bits** (16,777,216 entries) shifted out of the u32 entirely.

Both wrap silently in release builds — the dictionary builds "successfully" and mistokenizes at runtime, with no error anywhere. The 255 ceiling was documented on the decoder (`dictionary/prefix_dictionary.rs:125-131`) but enforced nowhere.

## Changes

Extracted a shared `pack_entry_value(surface, offset, count)` helper that validates both fields and returns `LinderaErrorKind::Build` naming the offending surface form and the limit exceeded. Both builders now call it, so the two copies of this encoding cannot drift apart again. The ceilings are named constants (`MAX_ENTRIES_PER_SURFACE`, `MAX_ENTRY_OFFSET`) rather than implied by shift arithmetic.

No behavior change below the limits. Current dictionaries have comfortable headroom: IPADIC 392,125 entries / 20 max variants per surface, UniDic 756,462 / 27, ko-dic 816,283.

## Verification

- New unit tests: round-trip within bounds, both fields exactly at maximum, and both overflow conditions (the offset case is tested against the helper directly rather than by building a 16M-entry dictionary).
- `cargo test -p lindera-dictionary`: 60 + 3 + 1 green.
- `cargo test -p lindera --features embed-ipadic --lib`: 37 green — exercises a real dictionary build end to end.
- `cargo fmt --all -- --check`, `cargo clippy -p lindera-dictionary --all-targets -- -D warnings`: clean.

## Related

Found during the #882 crawdad PoC investigation; this bug is entirely independent of that issue's outcome.
