### PR TITLE
fix(ci): repair dictionary release packaging and bundle NOTICE files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,7 +348,12 @@ jobs:
 
       - name: Create artifact
         run: |
-          cd dictionaries/${{ steps.get_version.outputs.version }}
+          # The build cache directory is keyed on the dictionary format version
+          # (see build_embedded_dictionary in lindera-dictionary/src/assets.rs),
+          # so derive the suffix from the DICTIONARY_FORMAT_VERSION constant.
+          FORMAT_VERSION=$(grep -oP 'DICTIONARY_FORMAT_VERSION: u32 = \K[0-9]+' lindera-dictionary/src/dictionary/metadata.rs)
+          cp ${{ matrix.dictionary.name }}/NOTICE.txt "dictionaries/${{ steps.get_version.outputs.version }}-fmt${FORMAT_VERSION}/${{ matrix.dictionary.name }}/"
+          cd "dictionaries/${{ steps.get_version.outputs.version }}-fmt${FORMAT_VERSION}"
           zip -r ../../${{ matrix.dictionary.name }}-${{ steps.get_version.outputs.version }}.zip ${{ matrix.dictionary.name }}
 
       - name: Upload artifact

--- a/docs/ja/src/development/feature_flags.md
+++ b/docs/ja/src/development/feature_flags.md
@@ -51,6 +51,12 @@ lindera = { version = "5.0", features = ["embed-ipadic"] }
 let dictionary = load_dictionary("embedded://ipadic")?;
 ```
 
+> [!NOTE]
+> 辞書データには Lindera 本体とは別のライセンスが適用されます。辞書を埋め込んだ
+> バイナリを配布する場合（またはビルド済み辞書を再配布する場合）は、対応する
+> 辞書クレートの `NOTICE.txt`（例: `lindera-unidic/NOTICE.txt`）に記載された
+> 帰属表示を、配布物に付属するドキュメントや資料に転載してください。
+
 ### 組み合わせ Feature
 
 多言語アプリケーション向けに、複数の辞書を一度に有効にするメタ Feature です。

--- a/docs/src/development/feature_flags.md
+++ b/docs/src/development/feature_flags.md
@@ -52,6 +52,13 @@ When embedding is enabled, you can load the dictionary with:
 let dictionary = load_dictionary("embedded://ipadic")?;
 ```
 
+> [!NOTE]
+> Dictionary data carries its own license, separate from Lindera's. When you
+> distribute a binary with an embedded dictionary (or redistribute a built
+> dictionary), reproduce the attribution from the corresponding dictionary
+> crate's `NOTICE.txt` (e.g. `lindera-unidic/NOTICE.txt`) in the
+> documentation or other materials provided with your distribution.
+
 ### Combination Features
 
 These meta-features enable multiple dictionaries at once for multilingual applications.

--- a/lindera-cc-cedict/NOTICE.txt
+++ b/lindera-cc-cedict/NOTICE.txt
@@ -1,0 +1,24 @@
+===========================================================================
+Lindera Morphological Analyzer
+===========================================================================
+
+This software includes a binary and/or source version of data from
+
+  CC-CEDICT-MeCab-0.1.0-20200409
+
+which can be obtained from
+
+  https://lindera.dev/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz
+
+===========================================================================
+CC-CEDICT-MeCab Notice
+===========================================================================
+
+This MeCab dictionary is based on cedict.
+
+https://www.mdbg.net/chinese/dictionary?page=cedict
+
+This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License
+https://creativecommons.org/licenses/by-sa/4.0/
+
+It more or less means that you are allowed to use this data for both non-commercial and commercial purposes provided that you: mention where you got the data from (attribution) and that in case you improve / add to the data you will share these changes under the same license (share alike).

--- a/lindera-jieba/NOTICE.txt
+++ b/lindera-jieba/NOTICE.txt
@@ -1,0 +1,83 @@
+===========================================================================
+Lindera Morphological Analyzer
+===========================================================================
+
+This software includes a binary and/or source version of data from
+
+  mecab-jieba-0.1.1
+
+which can be obtained from
+
+  https://lindera.dev/mecab-jieba-0.1.1.tar.gz
+
+The mecab-jieba dictionary is built from jieba's word frequency dictionary
+(dict.txt.big) and enriched with CC-CEDICT data (pinyin, traditional and
+simplified forms, English definitions).
+
+===========================================================================
+mecab-jieba Notice
+===========================================================================
+
+MIT License
+
+Copyright (c) 2026 Lindera
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+===========================================================================
+jieba Notice
+===========================================================================
+
+The word frequency dictionary (dict.txt.big) is from the jieba project
+
+  https://github.com/fxsjy/jieba
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Sun Junyi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+===========================================================================
+CC-CEDICT Notice
+===========================================================================
+
+CC-CEDICT is a continuation of the CEDICT project, published by MDBG.
+
+  https://www.mdbg.net/chinese/dictionary?page=cedict
+
+This work is licensed under a Creative Commons Attribution-ShareAlike 4.0
+International License
+
+  https://creativecommons.org/licenses/by-sa/4.0/


### PR DESCRIPTION
## Summary

Closes #932.

While implementing the NOTICE bundling, a latent release bug was found in the same workflow step and is fixed here as well:

- **Release packaging path fix**: the `build-dictionary` job's `Create artifact` step still referenced `dictionaries/<version>`, but the build cache directory has been keyed as `<version>-fmt<format>` since #928. The next release would have failed at this step (`cd` into a non-existent directory). The suffix is now derived from the `DICTIONARY_FORMAT_VERSION` constant in `lindera-dictionary/src/dictionary/metadata.rs`, so future format bumps are picked up automatically.
- **NOTICE bundling**: each crate's `NOTICE.txt` is copied into the built dictionary directory before zipping, so every published `lindera-<dict>-<version>.zip` release asset carries its dictionary attribution.
- **New NOTICE files**: `lindera-cc-cedict/NOTICE.txt` (CC-CEDICT-MeCab / CC BY-SA 4.0, MDBG attribution) and `lindera-jieba/NOTICE.txt` (mecab-jieba MIT, jieba `dict.txt.big` MIT (c) Sun Junyi, and CC-CEDICT CC BY-SA 4.0 — `jieba.csv` is enriched with CC-CEDICT data per the mecab-jieba README). Both files follow the existing NOTICE format used by the other dictionary crates and are included in the crates.io package (verified with `cargo package --list`).
- **Docs**: added a note to `docs/src/development/feature_flags.md` (and the Japanese counterpart) that distributing binaries with embedded dictionaries requires reproducing the attribution from the crate's `NOTICE.txt`.

## Verification

- Reproduced the fixed `Create artifact` step locally against a real `embed-cc-cedict` build with `LINDERA_BUILD_DICTIONARY_CACHE_DIR` set: the cache is written to `5.2.0-fmt2/` (confirming the old path would fail), and the resulting zip contains the full dictionary plus `NOTICE.txt`.
- `markdownlint-cli2`: 0 errors on both `docs/src` and `docs/ja/src`; `mdbook build` succeeds for both books; `release.yml` passes YAML validation.