### PR TITLE
chore(trainer): remove unused daachorse dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,6 @@ name = "lindera-trainer"
 version = "5.3.0"
 dependencies = [
  "anyhow",
- "daachorse",
  "lindera-crf",
  "lindera-dictionary",
  "regex",

--- a/lindera-trainer/Cargo.toml
+++ b/lindera-trainer/Cargo.toml
@@ -13,7 +13,6 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-daachorse = { workspace = true }
 lindera-crf = { workspace = true }
 lindera-dictionary = { workspace = true }
 regex = { workspace = true }


### PR DESCRIPTION
## Summary

`lindera-trainer` declared `daachorse` in its `Cargo.toml`, but no source file in the crate references it — it is a leftover from a past refactoring. This PR removes the unused dependency declaration.

The workspace-level `daachorse` dependency remains unchanged, as it is still used by:

- `lindera-dictionary`: user dictionary Aho-Corasick automaton (`UserPrefixDictionary`)
- `lindera-analysis`: mapping character filter / mapping token filter (leftmost-longest matching)

## Changes

- Remove `daachorse = { workspace = true }` from `lindera-trainer/Cargo.toml`
- Update `Cargo.lock` accordingly

## Verification

- `grep -rn daachorse lindera-trainer/` — no source references (only the removed Cargo.toml line)
- `cargo test -p lindera-trainer --all-features` — 20 tests + 1 doctest passed
- `cargo clippy -p lindera-trainer --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- No `daachorse` references in `Makefile` / `.github/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)