### PR TITLE
perf: trie-walk, preprocessing, and CLI hot-path small wins

### DIFF
--- a/lindera-cli/src/commands/tokenize.rs
+++ b/lindera-cli/src/commands/tokenize.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use lindera::LinderaResult;
-use lindera::dictionary::Lattice;
 use lindera::error::{LinderaError, LinderaErrorKind};
 use lindera::mode::Mode;
 use lindera::token::Token;
@@ -157,7 +156,9 @@ fn mecab_output<W: Write>(
 ) -> LinderaResult<()> {
     for token in tokens.iter_mut() {
         details_buf.clear();
-        for (i, detail) in token.details().iter().enumerate() {
+        // details_iter avoids the fresh Vec<&str> that details() collects
+        // on every call (#942); the joined string reuses details_buf.
+        for (i, detail) in token.details_iter().enumerate() {
             if i > 0 {
                 details_buf.push(',');
             }
@@ -280,9 +281,11 @@ pub fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
     let nbest_unique = args.nbest_unique;
     let nbest_cost_threshold = args.nbest_cost_threshold;
 
-    // Reused across every line to avoid reallocating the lattice's internal
-    // buffers on each call.
-    let mut lattice = Lattice::default();
+    // Reusable analysis session: keeps the lattice, the backtrace scratch,
+    // and the character-filtered text buffer alive across lines, so token
+    // surfaces stay borrowed (no per-token String) even when character
+    // filters are configured (#942).
+    let mut worker = tokenizer.into_worker();
 
     // Buffer all output on a locked stdout: the default line-buffered stdout
     // would otherwise issue one write syscall per output line.
@@ -304,19 +307,14 @@ pub fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
         }
 
         if nbest >= 2 {
-            let results = tokenizer.tokenize_nbest_with_lattice(
-                text.trim(),
-                &mut lattice,
-                nbest,
-                nbest_unique,
-                nbest_cost_threshold,
-            )?;
+            let results =
+                worker.tokenize_nbest(text.trim(), nbest, nbest_unique, nbest_cost_threshold)?;
             for (rank, (tokens, cost)) in results.into_iter().enumerate() {
                 writeln!(writer, "NBEST {} (cost={})", rank + 1, cost).map_err(io_err)?;
                 write_output(&mut writer, output_format, tokens, &mut details_buf)?;
             }
         } else {
-            let tokens = tokenizer.tokenize_with_lattice(text.trim(), &mut lattice)?;
+            let tokens = worker.tokenize(text.trim())?;
             write_output(&mut writer, output_format, tokens, &mut details_buf)?;
         }
     }

--- a/lindera-dictionary/src/dictionary/character_definition.rs
+++ b/lindera-dictionary/src/dictionary/character_definition.rs
@@ -197,6 +197,44 @@ impl CharacterDefinition {
             self.mapping.eval(cp)
         }
     }
+
+    /// Returns the pool coordinates of `c`'s category set when the flat BMP
+    /// fast path can serve it, so callers can store the compact
+    /// `(offset, len)` pair instead of copying the categories (#942).
+    ///
+    /// # 引数
+    ///
+    /// * `c` - The character to look up.
+    ///
+    /// # 戻り値
+    ///
+    /// `Some((offset, len))` addressing [`Self::flat_category`] (offset is
+    /// at most 24 bits by construction), or `None` when the flat table is
+    /// unavailable or `c` is outside the BMP.
+    #[inline(always)]
+    pub(crate) fn lookup_categories_packed(&self, c: char) -> Option<(u32, u16)> {
+        let cp = c as usize;
+        if cp < FLAT_TABLE_LEN && !self.flat_index.is_empty() {
+            let packed = self.flat_index[cp];
+            Some((packed >> 8, (packed & 0xFF) as u16))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the category at `idx` in the flat pool.
+    ///
+    /// # 引数
+    ///
+    /// * `idx` - Pool index derived from [`Self::lookup_categories_packed`].
+    ///
+    /// # 戻り値
+    ///
+    /// The category id stored at that pool slot.
+    #[inline(always)]
+    pub(crate) fn flat_category(&self, idx: usize) -> CategoryId {
+        self.flat_categories[idx]
+    }
 }
 
 #[cfg(test)]

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -58,7 +58,10 @@ impl WordIdx {
 const OFFSET_MASK: u32 = 0x7fff_ffff;
 
 /// The code-mapper table value marking a character with no code assigned.
-const INVALID_CODE: u32 = u32::MAX;
+///
+/// Also used by [`PrefixDictionary::map_code_or_invalid`] callers (the
+/// lattice's per-sentence code buffer) to mark unmapped characters.
+pub(crate) const INVALID_CODE: u32 = u32::MAX;
 
 /// Byte offset where the code-mapper table starts inside `dict.trie`
 /// (after the `u32` table length).
@@ -102,6 +105,11 @@ pub struct PrefixDictionary {
     pub words_idx_data: Data,
     /// Word detail records.
     pub words_data: Data,
+    /// The root node's raw `base`, cached at load so every common-prefix
+    /// search starts with the current node's `base` already in hand and the
+    /// walk reads exactly one node per character step (#942). A trie with no
+    /// nodes stores a leaf-flagged value that ends any walk immediately.
+    root_base: u32,
 }
 
 impl PrefixDictionary {
@@ -276,6 +284,15 @@ impl PrefixDictionary {
             )));
         }
 
+        // Cache the root node's raw base (validated above: when node_len > 0
+        // the node array starts at nodes_start and is fully inside the file).
+        let root_base = if node_len > 0 {
+            LittleEndian::read_u32(&trie_data[nodes_start..nodes_start + 4])
+        } else {
+            // Leaf-flagged poison: TrieWalk::advance ends immediately.
+            !OFFSET_MASK
+        };
+
         Ok(PrefixDictionary {
             trie_data,
             table_len,
@@ -284,6 +301,7 @@ impl PrefixDictionary {
             vals_data: vals_data.into(),
             words_idx_data: words_idx_data.into(),
             words_data: words_data.into(),
+            root_base,
         })
     }
 
@@ -328,6 +346,25 @@ impl PrefixDictionary {
         (code != INVALID_CODE).then_some(code)
     }
 
+    /// Maps a character to its trie code, using [`INVALID_CODE`] for
+    /// characters that appear in no key.
+    ///
+    /// The lattice fills a per-sentence code buffer with this once per
+    /// character, so overlapping prefix walks stop re-querying the code
+    /// table for the same character (#942).
+    ///
+    /// # Arguments
+    ///
+    /// * `c` - The character to map.
+    ///
+    /// # Returns
+    ///
+    /// The mapped code, or [`INVALID_CODE`].
+    #[inline(always)]
+    pub(crate) fn map_code_or_invalid(&self, c: char) -> u32 {
+        self.map_code(c).unwrap_or(INVALID_CODE)
+    }
+
     /// Looks up the values run for trie key ordinal `key_ord`.
     ///
     /// # Arguments
@@ -366,7 +403,35 @@ impl PrefixDictionary {
             dict: self,
             chars,
             pos: 0,
-            node_idx: 0,
+            walk: TrieWalk::at_root(self),
+        }
+    }
+
+    /// [`Self::common_prefix_search`] over pre-mapped trie codes.
+    ///
+    /// The lattice maps every sentence character through
+    /// [`Self::map_code_or_invalid`] once (in the same pass that fills its
+    /// other per-char buffers) and hands each start position's suffix here,
+    /// so overlapping walks skip the per-step code-table probe (#942).
+    ///
+    /// # Arguments
+    ///
+    /// * `codes` - Codes for the sentence suffix starting at the query
+    ///   position, with [`INVALID_CODE`] marking unmapped characters.
+    ///
+    /// # Returns
+    ///
+    /// An iterator of `(serialized WordEntry records, chars consumed)`.
+    #[inline]
+    pub(crate) fn common_prefix_search_codes<'a, 'b>(
+        &'a self,
+        codes: &'b [u32],
+    ) -> CommonPrefixSearchCodes<'a, 'b> {
+        CommonPrefixSearchCodes {
+            dict: self,
+            codes,
+            pos: 0,
+            walk: TrieWalk::at_root(self),
         }
     }
 
@@ -482,6 +547,114 @@ impl PrefixDictionary {
     }
 }
 
+/// Walk state shared by the common-prefix search iterators: the current node
+/// index and its cached raw `base`, loaded when the node was entered so each
+/// step reads exactly one node (#942 removed the per-step re-read of the
+/// node the previous step had already fetched).
+struct TrieWalk {
+    /// Current trie node.
+    node_idx: u32,
+    /// The current node's raw `base` (leaf flag included).
+    node_base: u32,
+}
+
+impl TrieWalk {
+    /// Creates a walk positioned at the trie root.
+    ///
+    /// # 引数
+    ///
+    /// * `dict` - The dictionary whose root to start from.
+    ///
+    /// # 戻り値
+    ///
+    /// A walk at node 0 with the load-time-cached root `base`.
+    #[inline(always)]
+    fn at_root(dict: &PrefixDictionary) -> TrieWalk {
+        TrieWalk {
+            node_idx: 0,
+            node_base: dict.root_base,
+        }
+    }
+
+    /// Follows the transition labeled `mc` from the current node.
+    ///
+    /// # 引数
+    ///
+    /// * `dict` - The dictionary being walked.
+    /// * `mc` - The mapped code of the next character.
+    ///
+    /// # 戻り値
+    ///
+    /// The child's raw `(base, check)` pair, or `None` when the walk ends
+    /// (the current node is a leaf, the transition does not exist, or the
+    /// bytes are malformed).
+    #[inline(always)]
+    fn advance(&mut self, dict: &PrefixDictionary, mc: u32) -> Option<(u32, u32)> {
+        // A leaf stores its value in `base`, not a child offset, so it
+        // has no children and the walk ends.
+        if self.node_base & !OFFSET_MASK != 0 {
+            return None;
+        }
+        let child_idx = (self.node_base & OFFSET_MASK) ^ mc;
+        let (child_base, child_check) = dict.node(child_idx)?;
+        if child_check & OFFSET_MASK != self.node_idx {
+            return None;
+        }
+        self.node_idx = child_idx;
+        self.node_base = child_base;
+        Some((child_base, child_check))
+    }
+}
+
+/// What one walk step produced, computed from the child's raw pair.
+enum StepOutput<'a> {
+    /// No key ends here; keep walking.
+    Continue,
+    /// Malformed bytes; end the search.
+    Stop,
+    /// A key ends here with these serialized `WordEntry` records.
+    Yield(&'a [u8]),
+}
+
+/// Resolves a just-entered node's `(base, check)` pair to its step output.
+///
+/// # 引数
+///
+/// * `dict` - The dictionary being walked.
+/// * `child_base` - The entered node's raw `base`.
+/// * `child_check` - The entered node's raw `check`.
+///
+/// # 戻り値
+///
+/// Whether the step yields a key's entries, continues, or stops.
+#[inline(always)]
+fn step_output<'a>(
+    dict: &'a PrefixDictionary,
+    child_base: u32,
+    child_check: u32,
+) -> StepOutput<'a> {
+    if child_base & !OFFSET_MASK != 0 {
+        // The node itself is a leaf: its base is the value.
+        return match dict.entry_bytes(child_base & OFFSET_MASK) {
+            Some(entries) => StepOutput::Yield(entries),
+            None => StepOutput::Stop,
+        };
+    }
+    if child_check & !OFFSET_MASK != 0 {
+        // The node has a leaf child reached by the end marker, whose
+        // code is 0, so the child index is just the base.
+        let leaf_idx = child_base & OFFSET_MASK;
+        return match dict
+            .node(leaf_idx)
+            .and_then(|(leaf_base, _)| dict.entry_bytes(leaf_base & OFFSET_MASK))
+        {
+            Some(entries) => StepOutput::Yield(entries),
+            None => StepOutput::Stop,
+        };
+    }
+    StepOutput::Continue
+}
+
 /// Iterator over the dictionary keys that are prefixes of a query.
 ///
 /// Mirrors crawdad 0.3's `CommonPrefixSearchIter` step for step, but walks
@@ -493,8 +666,8 @@ pub struct CommonPrefixSearch<'a, 'b> {
     chars: &'b [char],
     /// Characters consumed so far.
     pos: usize,
-    /// Current trie node.
-    node_idx: u32,
+    /// Walk state (current node and its cached `base`).
+    walk: TrieWalk,
 }
 
 impl<'a> Iterator for CommonPrefixSearch<'a, '_> {
@@ -510,32 +683,56 @@ impl<'a> Iterator for CommonPrefixSearch<'a, '_> {
     fn next(&mut self) -> Option<Self::Item> {
         while self.pos < self.chars.len() {
             let mc = self.dict.map_code(self.chars[self.pos])?;
-            let (base_raw, _) = self.dict.node(self.node_idx)?;
-            // A leaf stores its value in `base`, not a child offset, so it
-            // has no children and the walk ends.
-            if base_raw & !OFFSET_MASK != 0 {
-                return None;
-            }
-            let child_idx = (base_raw & OFFSET_MASK) ^ mc;
-            let (child_base, child_check) = self.dict.node(child_idx)?;
-            if child_check & OFFSET_MASK != self.node_idx {
-                return None;
-            }
-            self.node_idx = child_idx;
+            let (child_base, child_check) = self.walk.advance(self.dict, mc)?;
             self.pos += 1;
 
-            if child_base & !OFFSET_MASK != 0 {
-                // The node itself is a leaf: its base is the value.
-                let entries = self.dict.entry_bytes(child_base & OFFSET_MASK)?;
-                return Some((entries, self.pos));
+            match step_output(self.dict, child_base, child_check) {
+                StepOutput::Continue => {}
+                StepOutput::Stop => return None,
+                StepOutput::Yield(entries) => return Some((entries, self.pos)),
             }
-            if child_check & !OFFSET_MASK != 0 {
-                // The node has a leaf child reached by the end marker, whose
-                // code is 0, so the child index is just the base.
-                let leaf_idx = child_base & OFFSET_MASK;
-                let (leaf_base, _) = self.dict.node(leaf_idx)?;
-                let entries = self.dict.entry_bytes(leaf_base & OFFSET_MASK)?;
-                return Some((entries, self.pos));
+        }
+        None
+    }
+}
+
+/// [`CommonPrefixSearch`] over pre-mapped trie codes instead of characters.
+///
+/// See [`PrefixDictionary::common_prefix_search_codes`].
+pub(crate) struct CommonPrefixSearchCodes<'a, 'b> {
+    /// The dictionary being searched.
+    dict: &'a PrefixDictionary,
+    /// The query's pre-mapped codes ([`INVALID_CODE`] = unmapped).
+    codes: &'b [u32],
+    /// Codes consumed so far.
+    pos: usize,
+    /// Walk state (current node and its cached `base`).
+    walk: TrieWalk,
+}
+
+impl<'a> Iterator for CommonPrefixSearchCodes<'a, '_> {
+    type Item = (&'a [u8], usize);
+
+    /// Advances to the next key that is a prefix of the query.
+    ///
+    /// # Returns
+    ///
+    /// The key's serialized `WordEntry` records and the number of codes
+    /// consumed, or `None` when no further prefix matches.
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.pos < self.codes.len() {
+            let mc = self.codes[self.pos];
+            if mc == INVALID_CODE {
+                return None;
+            }
+            let (child_base, child_check) = self.walk.advance(self.dict, mc)?;
+            self.pos += 1;
+
+            match step_output(self.dict, child_base, child_check) {
+                StepOutput::Continue => {}
+                StepOutput::Stop => return None,
+                StepOutput::Yield(entries) => return Some((entries, self.pos)),
             }
         }
         None
@@ -791,6 +988,25 @@ mod tests {
                         "run length for key ordinal {key_ord}"
                     );
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn common_prefix_search_codes_matches_chars() {
+        let dict = PrefixDictionary::from_word_entry_map(&sample_map()).unwrap();
+
+        // Includes unmapped characters (ASCII, kana absent from the keys)
+        // to exercise the INVALID_CODE early-out.
+        for haystack in ["世界中で世論調査", "統計調査だ", "a世界", "世", ""] {
+            let chars: Vec<char> = haystack.chars().collect();
+            let codes: Vec<u32> = chars.iter().map(|&c| dict.map_code_or_invalid(c)).collect();
+            for start in 0..=chars.len() {
+                let expected: Vec<(&[u8], usize)> =
+                    dict.common_prefix_search(&chars[start..]).collect();
+                let actual: Vec<(&[u8], usize)> =
+                    dict.common_prefix_search_codes(&codes[start..]).collect();
+                assert_eq!(expected, actual, "at {haystack:?}[{start}..]");
             }
         }
     }

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -337,6 +337,11 @@ pub struct Lattice {
     /// char-wise trie consumes `&[char]` (byte offsets come from
     /// `char_info_buffer`, which is built in the same pass).
     chars_buf: Vec<char>,
+    /// The sentence's characters mapped through the system trie's code
+    /// table, one code per char (`INVALID_CODE` = unmapped), filled in the
+    /// same pass as `chars_buf` so overlapping prefix walks stop re-probing
+    /// the code table for the same character (#942).
+    codes_buf: Vec<u32>,
     /// Per-position system-dictionary matches (match end byte offset, word
     /// entry), buffered so they can be replayed in reverse discovery order --
     /// the order the retired whole-text pre-scan's head-inserted list drained
@@ -506,6 +511,7 @@ impl Lattice {
         self.matches_head.shrink_to(slots);
         self.matches_store.shrink_to(8 * slots);
         self.chars_buf.shrink_to(text_len);
+        self.codes_buf.shrink_to(text_len);
         self.sys_matches.shrink_to(64);
     }
 
@@ -519,13 +525,21 @@ impl Lattice {
     ///
     /// # 引数
     ///
+    /// * `dict` - The system prefix dictionary whose code table maps each
+    ///   character into `codes_buf`.
     /// * `char_definitions` - Character category definitions.
     /// * `text` - The sentence to prepare buffers for.
-    fn prepare_char_buffers(&mut self, char_definitions: &CharacterDefinition, text: &str) {
+    fn prepare_char_buffers(
+        &mut self,
+        dict: &PrefixDictionary,
+        char_definitions: &CharacterDefinition,
+        text: &str,
+    ) {
         let len = text.len();
         self.char_info_buffer.clear();
         self.categories_buffer.clear();
         self.chars_buf.clear();
+        self.codes_buf.clear();
 
         for (byte_offset, c) in text.char_indices() {
             let categories_start = self.categories_buffer.len() as u32;
@@ -548,6 +562,7 @@ impl Lattice {
                 kanji_run_byte_len: 0,
             });
             self.chars_buf.push(c);
+            self.codes_buf.push(dict.map_code_or_invalid(c));
         }
         // Sentinel for end of text
         self.char_info_buffer.push(CharData {
@@ -590,7 +605,7 @@ impl Lattice {
         self.set_capacity(len);
 
         // Pre-calculate character information for the text
-        self.prepare_char_buffers(char_definitions, text);
+        self.prepare_char_buffers(dict, char_definitions, text);
 
         let start_edge = Edge {
             path_cost: 0,
@@ -683,8 +698,8 @@ impl Lattice {
             // for the same reason (the old shared list held them on top).
             self.sys_matches.clear();
             {
-                let suffix = &self.chars_buf[char_idx..];
-                for (entries, end_char_offset) in dict.common_prefix_search(suffix) {
+                let suffix = &self.codes_buf[char_idx..];
+                for (entries, end_char_offset) in dict.common_prefix_search_codes(suffix) {
                     let end_char_idx = char_idx + end_char_offset;
                     let end = self.char_info_buffer[end_char_idx].byte_offset;
                     for chunk in entries.chunks_exact(WordEntry::SERIALIZED_LEN) {
@@ -1116,7 +1131,7 @@ impl Lattice {
         self.set_capacity_nbest(len);
 
         // Pre-calculate character information for the text
-        self.prepare_char_buffers(char_definitions, text);
+        self.prepare_char_buffers(dict, char_definitions, text);
 
         let start_edge = Edge {
             path_cost: 0,
@@ -1194,8 +1209,8 @@ impl Lattice {
             // for the same reason (the old shared list held them on top).
             self.sys_matches.clear();
             {
-                let suffix = &self.chars_buf[char_idx..];
-                for (entries, end_char_offset) in dict.common_prefix_search(suffix) {
+                let suffix = &self.codes_buf[char_idx..];
+                for (entries, end_char_offset) in dict.common_prefix_search_codes(suffix) {
                     let end_char_idx = char_idx + end_char_offset;
                     let end = self.char_info_buffer[end_char_idx].byte_offset;
                     for chunk in entries.chunks_exact(WordEntry::SERIALIZED_LEN) {

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -509,25 +509,20 @@ impl Lattice {
         self.sys_matches.shrink_to(64);
     }
 
-    #[inline(never)]
-    // Forward Viterbi implementation:
-    // Constructs the lattice and calculates the path costs simultaneously.
-    // This improves performance by avoiding a separate lattice traversal pass.
-    #[allow(clippy::too_many_arguments)]
-    pub fn set_text(
-        &mut self,
-        dict: &PrefixDictionary,
-        user_dict: &Option<&UserPrefixDictionary>,
-        char_definitions: &CharacterDefinition,
-        unknown_dictionary: &UnknownDictionary,
-        cost_matrix: &ConnectionCostMatrix,
-        text: &str,
-        search_mode: &Mode,
-    ) {
+    /// Fills the per-sentence character buffers (`char_info_buffer`,
+    /// `categories_buffer`, `chars_buf`) from `text`, appends the
+    /// end-of-text sentinel, and precomputes the kanji run lengths consumed
+    /// by the Decompose-mode penalty.
+    ///
+    /// Shared by `set_text` and `set_text_nbest` so the two hot paths cannot
+    /// drift apart.
+    ///
+    /// # 引数
+    ///
+    /// * `char_definitions` - Character category definitions.
+    /// * `text` - The sentence to prepare buffers for.
+    fn prepare_char_buffers(&mut self, char_definitions: &CharacterDefinition, text: &str) {
         let len = text.len();
-        self.set_capacity(len);
-
-        // Pre-calculate character information for the text
         self.char_info_buffer.clear();
         self.categories_buffer.clear();
         self.chars_buf.clear();
@@ -574,6 +569,28 @@ impl Lattice {
                 self.char_info_buffer[i].kanji_run_byte_len = 0;
             }
         }
+    }
+
+    #[inline(never)]
+    // Forward Viterbi implementation:
+    // Constructs the lattice and calculates the path costs simultaneously.
+    // This improves performance by avoiding a separate lattice traversal pass.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_text(
+        &mut self,
+        dict: &PrefixDictionary,
+        user_dict: &Option<&UserPrefixDictionary>,
+        char_definitions: &CharacterDefinition,
+        unknown_dictionary: &UnknownDictionary,
+        cost_matrix: &ConnectionCostMatrix,
+        text: &str,
+        search_mode: &Mode,
+    ) {
+        let len = text.len();
+        self.set_capacity(len);
+
+        // Pre-calculate character information for the text
+        self.prepare_char_buffers(char_definitions, text);
 
         let start_edge = Edge {
             path_cost: 0,
@@ -1099,52 +1116,7 @@ impl Lattice {
         self.set_capacity_nbest(len);
 
         // Pre-calculate character information for the text
-        self.char_info_buffer.clear();
-        self.categories_buffer.clear();
-        self.chars_buf.clear();
-
-        for (byte_offset, c) in text.char_indices() {
-            let categories_start = self.categories_buffer.len() as u32;
-
-            // Category lookup is O(1) for BMP codepoints via the flat table
-            // built at dictionary load (#878), so no per-lattice cache is
-            // needed.
-            let categories = char_definitions.lookup_categories(c);
-            for &category in categories {
-                self.categories_buffer.push(category);
-            }
-
-            let categories_len = (self.categories_buffer.len() as u32 - categories_start) as u16;
-
-            self.char_info_buffer.push(CharData {
-                byte_offset: byte_offset as u32,
-                is_kanji: is_kanji(c),
-                categories_start,
-                categories_len,
-                kanji_run_byte_len: 0,
-            });
-            self.chars_buf.push(c);
-        }
-        // Sentinel for end of text
-        self.char_info_buffer.push(CharData {
-            byte_offset: len as u32,
-            is_kanji: false,
-            categories_start: 0,
-            categories_len: 0,
-            kanji_run_byte_len: 0,
-        });
-
-        // Pre-calculate Kanji run lengths (backwards)
-        for i in (0..self.char_info_buffer.len() - 1).rev() {
-            if self.char_info_buffer[i].is_kanji {
-                let next_byte_offset = self.char_info_buffer[i + 1].byte_offset;
-                let char_byte_len = next_byte_offset - self.char_info_buffer[i].byte_offset;
-                self.char_info_buffer[i].kanji_run_byte_len =
-                    char_byte_len + self.char_info_buffer[i + 1].kanji_run_byte_len;
-            } else {
-                self.char_info_buffer[i].kanji_run_byte_len = 0;
-            }
-        }
+        self.prepare_char_buffers(char_definitions, text);
 
         let start_edge = Edge {
             path_cost: 0,

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -354,6 +354,13 @@ pub struct Lattice {
 /// at most 2 * 32,767, which cannot overflow from this clamp.
 const PATH_COST_CLAMP: i32 = i32::MAX - 131_072;
 
+/// Flag bit on `CharData::categories_start` marking that the offset indexes
+/// the `CharacterDefinition` flat category pool instead of the lattice's
+/// `categories_buffer` (#942). Both index spaces stay far below this bit:
+/// the pool offset is at most 24 bits by construction, and the fallback
+/// buffer holds at most 255 categories per char of a 32 KiB sentence.
+const CATEGORIES_IN_POOL: u32 = 1 << 31;
+
 #[derive(Clone, Copy, Debug, Default)]
 struct CharData {
     byte_offset: u32,
@@ -417,10 +424,33 @@ impl Lattice {
         self.char_info_buffer[char_idx].kanji_run_byte_len >= byte_len as u32
     }
 
+    /// Returns the `category_ord`-th category of the char at `char_idx`,
+    /// reading the `CharacterDefinition` flat pool or the fallback
+    /// `categories_buffer` as recorded by `prepare_char_buffers`.
+    ///
+    /// # 引数
+    ///
+    /// * `char_definitions` - The definitions whose pool backs the fast path.
+    /// * `char_idx` - Character index in `char_info_buffer`.
+    /// * `category_ord` - Ordinal within that char's category set.
+    ///
+    /// # 戻り値
+    ///
+    /// The category id.
     #[inline]
-    fn get_cached_category(&self, char_idx: usize, category_ord: usize) -> CategoryId {
+    fn get_cached_category(
+        &self,
+        char_definitions: &CharacterDefinition,
+        char_idx: usize,
+        category_ord: usize,
+    ) -> CategoryId {
         let char_data = &self.char_info_buffer[char_idx];
-        self.categories_buffer[char_data.categories_start as usize + category_ord]
+        let idx = (char_data.categories_start & !CATEGORIES_IN_POOL) as usize + category_ord;
+        if char_data.categories_start & CATEGORIES_IN_POOL != 0 {
+            char_definitions.flat_category(idx)
+        } else {
+            self.categories_buffer[idx]
+        }
     }
 
     fn set_capacity(&mut self, text_len: usize) {
@@ -529,34 +559,47 @@ impl Lattice {
     ///   character into `codes_buf`.
     /// * `char_definitions` - Character category definitions.
     /// * `text` - The sentence to prepare buffers for.
+    /// * `search_mode` - The segmentation mode; the kanji-run lengths are
+    ///   only computed in Decompose mode, their sole consumer
+    ///   (`Penalty::penalty` via `kanji_only`) — in Normal mode they stay
+    ///   zero and every edge gets `kanji_only = false`, which the Normal
+    ///   relaxation arms never read (#942).
     fn prepare_char_buffers(
         &mut self,
         dict: &PrefixDictionary,
         char_definitions: &CharacterDefinition,
         text: &str,
+        search_mode: &Mode,
     ) {
         let len = text.len();
+        let needs_kanji_runs = search_mode.is_search();
         self.char_info_buffer.clear();
         self.categories_buffer.clear();
         self.chars_buf.clear();
         self.codes_buf.clear();
 
         for (byte_offset, c) in text.char_indices() {
-            let categories_start = self.categories_buffer.len() as u32;
-
             // Category lookup is O(1) for BMP codepoints via the flat table
-            // built at dictionary load (#878), so no per-lattice cache is
-            // needed.
-            let categories = char_definitions.lookup_categories(c);
-            for &category in categories {
-                self.categories_buffer.push(category);
-            }
-
-            let categories_len = (self.categories_buffer.len() as u32 - categories_start) as u16;
+            // built at dictionary load (#878). On that fast path, store the
+            // pool coordinates directly instead of copying the categories
+            // into categories_buffer (#942); non-BMP codepoints (and the
+            // never-in-practice case of an unbuilt flat table) keep the
+            // copy, discriminated by the CATEGORIES_IN_POOL flag.
+            let (categories_start, categories_len) =
+                match char_definitions.lookup_categories_packed(c) {
+                    Some((offset, len)) => (offset | CATEGORIES_IN_POOL, len),
+                    None => {
+                        let start = self.categories_buffer.len() as u32;
+                        for &category in char_definitions.lookup_categories(c) {
+                            self.categories_buffer.push(category);
+                        }
+                        (start, (self.categories_buffer.len() as u32 - start) as u16)
+                    }
+                };
 
             self.char_info_buffer.push(CharData {
                 byte_offset: byte_offset as u32,
-                is_kanji: is_kanji(c),
+                is_kanji: needs_kanji_runs && is_kanji(c),
                 categories_start,
                 categories_len,
                 kanji_run_byte_len: 0,
@@ -573,15 +616,18 @@ impl Lattice {
             kanji_run_byte_len: 0,
         });
 
-        // Pre-calculate Kanji run lengths (backwards)
-        for i in (0..self.char_info_buffer.len() - 1).rev() {
-            if self.char_info_buffer[i].is_kanji {
-                let next_byte_offset = self.char_info_buffer[i + 1].byte_offset;
-                let char_byte_len = next_byte_offset - self.char_info_buffer[i].byte_offset;
-                self.char_info_buffer[i].kanji_run_byte_len =
-                    char_byte_len + self.char_info_buffer[i + 1].kanji_run_byte_len;
-            } else {
-                self.char_info_buffer[i].kanji_run_byte_len = 0;
+        // Pre-calculate Kanji run lengths (backwards); skipped in Normal
+        // mode where no consumer reads them (see `search_mode` above).
+        if needs_kanji_runs {
+            for i in (0..self.char_info_buffer.len() - 1).rev() {
+                if self.char_info_buffer[i].is_kanji {
+                    let next_byte_offset = self.char_info_buffer[i + 1].byte_offset;
+                    let char_byte_len = next_byte_offset - self.char_info_buffer[i].byte_offset;
+                    self.char_info_buffer[i].kanji_run_byte_len =
+                        char_byte_len + self.char_info_buffer[i + 1].kanji_run_byte_len;
+                } else {
+                    self.char_info_buffer[i].kanji_run_byte_len = 0;
+                }
             }
         }
     }
@@ -605,7 +651,7 @@ impl Lattice {
         self.set_capacity(len);
 
         // Pre-calculate character information for the text
-        self.prepare_char_buffers(dict, char_definitions, text);
+        self.prepare_char_buffers(dict, char_definitions, text, search_mode);
 
         let start_edge = Edge {
             path_cost: 0,
@@ -725,7 +771,8 @@ impl Lattice {
             {
                 let num_categories = self.char_info_buffer[char_idx].categories_len as usize;
                 for category_ord in 0..num_categories {
-                    let category = self.get_cached_category(char_idx, category_ord);
+                    let category =
+                        self.get_cached_category(char_definitions, char_idx, category_ord);
                     unknown_word_end = self.process_unknown_word(
                         char_definitions,
                         unknown_dictionary,
@@ -798,7 +845,8 @@ impl Lattice {
                     let num_categories = self.char_info_buffer[next_idx].categories_len as usize;
                     let mut found_cat = false;
                     if category_ord < num_categories {
-                        let cat = self.get_cached_category(next_idx, category_ord);
+                        let cat =
+                            self.get_cached_category(char_definitions, next_idx, category_ord);
                         if cat == category {
                             unknown_word_num_chars += 1;
                             found_cat = true;
@@ -1084,7 +1132,8 @@ impl Lattice {
                     let num_categories = self.char_info_buffer[next_idx].categories_len as usize;
                     let mut found_cat = false;
                     if category_ord < num_categories {
-                        let cat = self.get_cached_category(next_idx, category_ord);
+                        let cat =
+                            self.get_cached_category(char_definitions, next_idx, category_ord);
                         if cat == category {
                             unknown_word_num_chars += 1;
                             found_cat = true;
@@ -1131,7 +1180,7 @@ impl Lattice {
         self.set_capacity_nbest(len);
 
         // Pre-calculate character information for the text
-        self.prepare_char_buffers(dict, char_definitions, text);
+        self.prepare_char_buffers(dict, char_definitions, text, search_mode);
 
         let start_edge = Edge {
             path_cost: 0,
@@ -1235,7 +1284,8 @@ impl Lattice {
             {
                 let num_categories = self.char_info_buffer[char_idx].categories_len as usize;
                 for category_ord in 0..num_categories {
-                    let category = self.get_cached_category(char_idx, category_ord);
+                    let category =
+                        self.get_cached_category(char_definitions, char_idx, category_ord);
                     unknown_word_end = self.process_unknown_word_nbest(
                         char_definitions,
                         unknown_dictionary,

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -421,6 +421,18 @@ impl Segmenter {
         let mut position = 0_usize;
         let mut byte_position = 0_usize;
 
+        // Whitespace-filter configuration, hoisted out of the per-token
+        // loop: the per-char closure previously re-unwrapped the Option'd
+        // ASCII table (a by-value array copy at source level) on every
+        // character it examined (#942). `space_category_id` and
+        // `space_ascii_table` are built together, so `zip` preserves the
+        // old `keep_whitespace`/`Some` gating exactly.
+        let space_filter = if self.keep_whitespace {
+            None
+        } else {
+            self.space_category_id.zip(self.space_ascii_table.as_ref())
+        };
+
         // Process whole text without splitting first for better performance with borrowed text
         let text_len = text.len();
         let mut sentence_start = 0;
@@ -469,16 +481,14 @@ impl Segmenter {
                 let absolute_end = sentence_start + byte_end;
 
                 // Skip whitespace tokens if keep_whitespace is false (default MeCab behavior)
-                if !self.keep_whitespace
-                    && let Some(space_category_id) = self.space_category_id
-                {
+                if let Some((space_category_id, space_ascii_table)) = space_filter {
                     // Check if this token consists only of whitespace characters.
                     // ASCII/Latin-1 codepoints use the precomputed table (O(1));
                     // anything else falls back to the dictionary lookup.
                     let token_text = &sentence[byte_start..byte_end];
                     let is_space = token_text.chars().all(|c| {
                         if (c as u32) < 256 {
-                            self.space_ascii_table.unwrap()[c as usize]
+                            space_ascii_table[c as usize]
                         } else {
                             self.dictionary
                                 .character_definition
@@ -560,6 +570,13 @@ impl Segmenter {
     ) -> LinderaResult<Vec<(Vec<Token<'a>>, i64)>> {
         let mut all_results: Vec<(Vec<Token>, i64)> = Vec::with_capacity(n);
 
+        // Hoisted whitespace-filter configuration; see segment_with_buffers.
+        let space_filter = if self.keep_whitespace {
+            None
+        } else {
+            self.space_category_id.zip(self.space_ascii_table.as_ref())
+        };
+
         let text_len = text.len();
         let mut sentence_start = 0;
 
@@ -618,16 +635,14 @@ impl Segmenter {
                     let absolute_end = sentence_start + byte_end;
 
                     // Skip whitespace tokens if keep_whitespace is false
-                    if !self.keep_whitespace
-                        && let Some(space_category_id) = self.space_category_id
-                    {
+                    if let Some((space_category_id, space_ascii_table)) = space_filter {
                         // ASCII/Latin-1 codepoints use the precomputed table
                         // (O(1)); anything else falls back to the dictionary
                         // lookup.
                         let token_text = &sentence[byte_start..byte_end];
                         let is_space = token_text.chars().all(|c| {
                             if (c as u32) < 256 {
-                                self.space_ascii_table.unwrap()[c as usize]
+                                space_ascii_table[c as usize]
                             } else {
                                 self.dictionary
                                     .character_definition


### PR DESCRIPTION
Closes #942. Part of the #941 campaign.

## What

Four commits of small, format- and behavior-preserving hot-path optimizations:

1. **refactor**: extract the duplicated `set_text`/`set_text_nbest` preprocessing into a shared `prepare_char_buffers` (behavior-neutral, shrinks the nbest duplication).
2. **Trie walk**: cache the current node's raw `base` in the walk state (`TrieWalk`; the root's base is cached at load in a new `root_base` field) — each step previously re-read the node the previous step had already fetched. Pre-map every sentence character through the trie's code table once (`codes_buf`) and search via a codes-based iterator, so overlapping prefix walks stop re-querying the code table per step. The chars-based API remains for cold paths; shared step logic lives in one `step_output` helper.
3. **Preprocessing**: compute per-char `is_kanji` and the backward kanji-run pass only in Decompose mode (their sole consumer is `Penalty::penalty`, never read by the Normal-mode relaxation arms). Stop copying `CategoryId`s into `categories_buffer` for BMP chars: `CharData` stores `(offset, len)` into `CharacterDefinition`'s flat category pool, flag-discriminated from the non-BMP fallback buffer.
4. **Token construction / CLI**: hoist the whitespace-filter config out of the per-token loop (also removes a production `unwrap()`); switch the CLI tokenize loop to a reusable `AnalysisWorker` (no per-token surface `String` under `-c` filters, reused backtrace buffer); join MeCab details via `details_iter()` instead of the per-call `Vec<&str>` from `details()`.

## Correctness

- Output is **byte-identical** on all 7 golden outputs captured from `main` over bocchan.txt with a locally built IPADIC: mecab / wakati / json / decompose / keep-whitespace / nbest-3 / NFKC char filter. Token counts identical (1,184,118).
- Unit tests green (lindera-dictionary 84, lindera-analysis with embed-ipadic 110), including a new codes/chars iterator-equivalence test; `cargo fmt --all -- --check` and workspace `cargo clippy -- -D warnings` clean.

## Measurements

Protocol: interleaved min-of-8 (A/B alternating, minimum comparison) on a verified-quiet machine (load < 1.0, no builds running), IPADIC compiled from the same mecab-ipadic source for both engines, bocchan.txt concatenated to 5 MiB, worker reuse, surface-only access.

Per-group marginal effect (library, wakati-style):

| comparison | min | note |
|---|---|---|
| trie walk vs main | **−4.8%** (298.57 → 284.21 ms) | faster in all 8 rounds |
| preprocessing marginal | **−3.4%** (284.77 → 274.98 ms) | median −4.8% |
| token/CLI marginal (library) | within noise | expected: only the space-filter hoist touches this path |

CLI wall clock (dictionary load included), the token/CLI group's actual target:

| scenario | before → after (min) | note |
|---|---|---|
| mecab + NFKC char filter | **820.9 → 744.1 ms (−9.4%)** | faster in all 8 rounds |
| plain mecab | 649.3 → 643.3 ms (−0.9%; median −1.2%) | 6/8 rounds |

Final 3-way in a single quiet window:

| | main | this PR | Vibrato 0.5.2 |
|---|---|---|---|
| min | 288.49 ms | **274.20 ms** | 243.98 ms |
| vs main | — | **−5.0%** | — |
| vs Vibrato | 1.182x | **1.124x** | 1.0 |

The library-level gap to Vibrato narrows from ~1.17x to **~1.12x**; the remaining headroom is tracked in #943 (char-indexed lattice).