### PR TITLE
feat(dictionary)!: generate the MeCab/Vibrato unknown-word length ladder

### DIFF
--- a/docs/ja/src/lindera-cli/commands.md
+++ b/docs/ja/src/lindera-cli/commands.md
@@ -61,6 +61,7 @@ jieba           no        no          -
 - `--token-filter` / `-t`: トークンフィルタ設定 (JSON)
 - `--keep-whitespace`: 空白文字のトークンを出力に含める（デフォルトでは MeCab 互換のため空白は除去されます）
 - `--max-grouping-len`: 未知語グルーピングの上限（先頭を除いた文字数。MeCab の `max-grouping-size` に相当し、MeCab のデフォルトは 24）。上限を超えるランは 1 文字ずつの未知語になります。デフォルト: 無制限
+- `--disable-unknown-word-ladder`: MeCab/Vibrato 由来の未知語候補ラダー（`char.def` の `LENGTH` フィールド）を無効化する。デフォルトで有効。v6 以前の Lindera と同一の出力にするには無効化する
 - `--mmap`: 辞書ディレクトリの単語リストにメモリマップドファイル読み込みを使用する。`embedded://` 辞書、および `mmap` feature が無効な場合は無視される。プロセスがマップを保持している間に辞書ディレクトリを再ビルド・切り詰めると、次回のルックアップで SIGBUS を引き起こす可能性がある。
 - `--nbest` / `-N`: 返す N-best 結果の数（デフォルト: 1）。2以上に設定すると N-best 出力が有効になります。
 - `--nbest-unique`: 同じ分割を生成するパスの重複を排除します。

--- a/docs/ja/src/lindera/segmenter.md
+++ b/docs/ja/src/lindera/segmenter.md
@@ -156,6 +156,16 @@ let segmenter = Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(t
 let segmenter = Segmenter::new(Mode::Normal, dictionary, None).max_grouping_len(Some(24));
 ```
 
+グルーピングとは独立に、Lindera はデフォルトで MeCab/Vibrato 由来の
+「候補ラダー（length ladder）」も生成します。各カテゴリの `char.def` の
+`LENGTH` フィールドまでの短い未知語候補を段階的に生成し、Viterbi 探索が
+最もコストの低い長さを選べるようにします。v6 以前と同一の出力にするには
+`unknown_word_ladder(false)` で無効化してください:
+
+```rust
+let segmenter = Segmenter::new(Mode::Normal, dictionary, None).unknown_word_ladder(false);
+```
+
 ## N-Best セグメンテーション
 
 `segment_nbest` は、コストの合計で並べた上位 `n` 件の分割結果を、それぞれのコストと共に返します。`unique` を指定すると、単語境界は同じで品詞タグのみ異なる結果を重複排除できます。`cost_threshold` を指定すると、`best_cost + threshold` を超えるコストのパスを除外できます：

--- a/docs/ja/src/migration_v5_to_v6.md
+++ b/docs/ja/src/migration_v5_to_v6.md
@@ -1,11 +1,12 @@
 # v5 から v6 への移行
 
-Lindera v6.0.0 では、ビルド済み辞書のオンディスクフォーマットが変わります。システム
-前方一致辞書のバイト単位 `daachorse` Aho-Corasick オートマトン（`dict.da`）が、文字単位の
-ダブル配列トライ（`dict.trie`）と単語値インデックス（`dict.valsidx`）に置き換えられました。
-また `metadata.json` がフォーマットバージョンを記録するようになり、バージョンが一致しない
-辞書は黙って誤読される代わりに、ロード時に明確なエラーで拒否されます。トークナイズ結果は
-変わりません — 同じ入力と辞書に対して、v6 は v5 とバイト単位で同一のトークンを出力します。
+Lindera v6.0.0 では、ビルド済み辞書のオンディスクフォーマットが変わり、
+`lindera-dictionary` の一部 Rust API が変わり、さらにトークナイズ結果も
+2 点（Decompose モードの精度修正と、新しいデフォルト有効な未知語機能）で
+変わります。ほとんどのユーザーは辞書の再ビルドまたは再ダウンロードだけで
+済みますが、`lindera_dictionary::viterbi`/`mode` の型を直接使っている場合や、
+未知語（辞書外の文字列）に対する厳密な旧出力に依存している場合は、追加で
+確認すべき点があります。
 
 ## 概要
 
@@ -15,6 +16,9 @@ Lindera v6.0.0 では、ビルド済み辞書のオンディスクフォーマ�
 | `metadata.json` が `format_version` を記録し、不一致はロード時に拒否 | v5 世代のビルド済み辞書を読み込むすべてのユーザー | 再ビルド、または `lindera download` で再取得 |
 | `loadDictionaryFromBytes()` が 9 引数に | バイトデータから辞書を読み込む WASM ユーザー | `dictDa` の代わりに `dictTrie` と `dictValsIdx` を渡す |
 | OPFS の `DictionaryFiles` が `dictDa` を `dictTrie` + `dictValsIdx` に置き換え | `opfs` ヘルパーを使う WASM ユーザー | OPFS にキャッシュ済みの辞書を再ダウンロード |
+| Decompose モードの長さペナルティが非 3 バイト文字に対して正確になった | 1・2・4 バイトの UTF-8 文字を含むテキストに対する `Mode::Decompose` の出力 | 対応不要（正確性修正）。出力を厳密に固定している場合は Decompose 出力を再確認 |
+| 未知語の候補ラダー（length ladder）がデフォルトで有効に | 辞書外テキストに対する Normal・Decompose 両モードの出力 | v5 と同一の出力が必要な場合は `unknown_word_ladder(false)` / `--disable-unknown-word-ladder` を設定 |
+| `lindera_dictionary::viterbi`/`mode` の一部項目が改名・削除 | `Lattice`/`Edge`/`Penalty`/`Mode` を直接利用するコード（`lindera` クレートの `Segmenter`/`Tokenizer`/`Worker` API 利用者は対象外） | 下記の表に従い呼び出し箇所を更新 |
 
 ## 辞書フォーマットバージョン 2
 
@@ -52,64 +56,79 @@ Lindera v6.0.0 では、ビルド済み辞書のオンディスクフォーマ�
 Dictionary 'ipadic' has format version 1, but this build of Lindera reads format version 2. To fix this, rebuild it with `lindera build`, or download a matching prebuilt dictionary with `lindera download`.
 ```
 
-## 対応が必要なケース
+## トークナイズ結果の変更
 
-### 自前ビルド辞書
+上記のフォーマット変更とは異なり、以下の 2 点は同じ入力・同じ辞書でも
+**Lindera が出力するトークン自体**を変える可能性があります。
 
-自分でソースファイルからコンパイルした辞書は、v6 の CLI で再ビルドしてください。
-コマンドラインインターフェースは変わっていないため、以前と同じ `lindera build` の
-呼び出しで再ビルドできます:
+### Decompose モードのペナルティ精度修正
+
+`Mode::Decompose` の長さペナルティは、スパンの文字数を
+`(終了バイト位置 - 開始バイト位置) / 3` で近似していました。これは全体が
+3 バイト UTF-8 文字（一般的な漢字・かな）で構成されたテキストに対してのみ
+正確です。Lindera の Viterbi ラティスは内部的に文字単位で索引されるように
+なったため、ペナルティは実際の文字数を使うようになりました。この変更が
+影響するのは 1 バイト（ASCII）・2 バイト・4 バイト（絵文字や一部の CJK
+拡張文字など）の UTF-8 文字を含むスパンの Decompose 出力のみで、純粋な
+日本語の Decompose 出力には影響しません。これは挙動選択ではなくバグ修正の
+ため、旧来の（不正確な）挙動に戻すオプションはありません。
+
+### 未知語の候補ラダー（新規・デフォルト有効）
+
+辞書に無い文字が連続する箇所に対して、MeCab や Vibrato は候補となる未知語の
+長さを `1..=LENGTH`（`LENGTH` は辞書の `char.def` にあるカテゴリごとの
+フィールド）まで段階的に（梯子＝ladder のように）生成し、Viterbi 探索に
+コスト最小の長さを選ばせます。Lindera は `char.def` から `LENGTH` を
+パースして保存はしていましたが、実行時には一切参照しておらず、常に
+1 文字の候補のみ（グルーピング対象カテゴリの場合はラン全体を覆う 1 候補のみ）
+しか生成していませんでした。
+
+v6.0.0 からは、このラダーがデフォルトで生成されるようになります。IPADIC で
+影響を受けるのは `KANJI`・`HIRAGANA`・`KATAKANA`（`LENGTH=2`）カテゴリで、
+それ以外の大半のカテゴリは `LENGTH=0` のため影響を受けません。実際の効果と
+しては、辞書に無い漢字・かなが連続する箇所で、1 文字ずつに分割するより
+複数文字でまとめたほうがコストが低い場合に、複数文字の未知語としてまとめて
+トークナイズされるようになります — 例えば、未知の 2 字熟語が従来は 2 つの
+未知語トークンに分かれていたのが、1 つの未知語トークンになります。
+
+これは v5.4 で導入されたラン全体のグルーピング上限オプション
+`max_grouping_len` とは独立した、加算的な機能です。
+
+辞書外の漢字・かな連続を含むテキストで v5 と同一の出力を再現するには、
+ラダーを無効化してください:
+
+```rust,ignore
+let segmenter = Segmenter::new(mode, dictionary, None)
+    .unknown_word_ladder(false);
+```
 
 ```sh
-lindera build \
-  --src ./dictionary-source \
-  --dest ./dictionary \
-  --metadata ./metadata.json
+lindera tokenize -d ipadic --disable-unknown-word-ladder input.txt
 ```
 
-または、対応するビルド済み辞書を再ダウンロードしてください:
+`AnalysisWorker`/`SegmentWorker` は `set_unknown_word_ladder(bool)`、
+`TokenizerBuilder` は `set_segmenter_unknown_word_ladder(bool)` で同じ
+切り替えができます。
 
-```sh
-lindera download ipadic
-```
+## `lindera_dictionary` の Rust API 変更
 
-ダウンロード済み辞書は `<データディレクトリ>/lindera/dictionaries/<バージョン>/`
-（例: Linux では `~/.local/share/lindera/dictionaries/6.0.0/`）にバージョン単位で
-隔離されるため、v5 のコピーが再利用・上書きされることはなく、掃除も必須では
-ありません。
+以下は `lindera_dictionary::viterbi::{Lattice, Edge}` や
+`lindera_dictionary::mode::{Mode, Penalty}` を直接利用するコード（独自の
+ラティス検査や代替トークナイザーフロントエンドなど）にのみ影響します。
+`lindera` クレートの `Segmenter`・`Tokenizer`・`SegmentWorker`・
+`AnalysisWorker` API は影響を受けません — 上記の
+`unknown_word_ladder`/`max_grouping_len` オプションが追加されただけで、
+シグネチャの変更はありません。
 
-### WASM: `loadDictionaryFromBytes()`
-
-従来の `dictDa` 引数が `dictTrie` と `dictValsIdx` に置き換えられ、シグネチャが
-8 引数から 9 引数になりました:
-
-```javascript
-// v5 — 8 引数
-const dictionary = loadDictionaryFromBytes(
-    files.metadata, files.dictDa, files.dictVals, files.dictWordsIdx,
-    files.dictWords, files.matrixMtx, files.charDef, files.unk,
-);
-
-// v6 — 9 引数
-const dictionary = loadDictionaryFromBytes(
-    files.metadata, files.dictTrie, files.dictValsIdx, files.dictVals,
-    files.dictWordsIdx, files.dictWords, files.matrixMtx, files.charDef, files.unk,
-);
-```
-
-### WASM: OPFS ヘルパー
-
-`loadDictionaryFiles()` が返す `DictionaryFiles` オブジェクトは、`dictDa` の代わりに
-`dictTrie` と `dictValsIdx` プロパティを持つようになり、OPFS に保存されるファイル
-一式も同様に変わりました。v5 で OPFS にダウンロードした辞書には `dict.trie` と
-`dict.valsidx` が無いため、削除して v6 のアーカイブをダウンロードしてください:
-
-```javascript
-import { downloadDictionary, removeDictionary } from 'lindera-wasm-web/opfs';
-
-await removeDictionary("ipadic");
-await downloadDictionary(DICT_URL_V6, "ipadic");
-```
+| v5 | v6 | 理由 |
+| --- | --- | --- |
+| `Lattice::text_len()` | `Lattice::char_len()` | ラティスがバイト索引から文字索引に変わったため。改名により、バイト前提のコードは黙って誤動作せずコンパイルエラーになる |
+| `Lattice::edges_at(pos)` | `Lattice::edges_at_char(pos)` | 同上（`pos` が文字位置になった） |
+| `Lattice::paths_at(pos)` | `Lattice::paths_at_char(pos)` | 同上 |
+| `Lattice::capacity()` / `shrink_to(n)` | 名前は同じだが単位がバイトから文字（スロット）に | バイト長は依然として `shrink_to` の有効な（安全側に倒れる）引数として使える（文はバイト数より文字数の方が少ないため） |
+| `Edge::num_chars()` | 削除 | パック済み `Edge` は終了位置を保持しなくなった（常にラティススロットの添字と一致するため）ので、エッジ単体からは計算できなくなった |
+| `Penalty::penalty(&Edge)` | `Penalty::penalty(&Edge, num_chars: usize)` | 呼び出し側が正確な文字数スパンを渡すようになった（前述の Decompose 精度修正を参照） |
+| `Mode::penalty_cost(&Edge)` | 削除 | コードベース内に呼び出し元が無かった。必要であれば `Penalty::penalty` で再実装可能 |
 
 ## 対応が不要なケース
 
@@ -117,12 +136,12 @@ await downloadDictionary(DICT_URL_V6, "ipadic");
   内部では引き続き `daachorse` オートマトンを使用しており、再ビルドせずにそのまま
   ロードできます。`.csv` から読み込むユーザー辞書も、従来どおりロード時に
   コンパイルされます。
-- **トークナイズ結果**: 変わりません。同じ入力と辞書に対して、v6 は v5 とバイト
-  単位で同一のトークンを出力します。
-- **Rust API**: シグネチャの変更はありません。パスや URI から辞書をロードする
-  コードは、辞書自体を再ビルドまたは再ダウンロードすればそのままコンパイル・動作
-  します。`embed-*` の埋め込み辞書は各辞書クレートのビルドスクリプトがコンパイル
-  するため、常に実行中のバージョンと一致します。
+- **`lindera` クレートの公開 API**: `Segmenter`・`Tokenizer`・`SegmentWorker`・
+  `AnalysisWorker` のシグネチャは変わっていません（加算的な
+  `unknown_word_ladder`/`max_grouping_len` オプションを除く）。パスや URI から
+  辞書をロードするコードは、辞書自体を再ビルドまたは再ダウンロードすればそのまま
+  コンパイル・動作します。`embed-*` の埋め込み辞書は各辞書クレートのビルド
+  スクリプトがコンパイルするため、常に実行中のバージョンと一致します。
 
 ## アップグレードチェックリスト
 
@@ -131,4 +150,10 @@ await downloadDictionary(DICT_URL_V6, "ipadic");
 - WASM: `loadDictionaryFromBytes()` の呼び出しを 9 引数のシグネチャに更新する
   （`dictDa` の代わりに `dictTrie` と `dictValsIdx`）。
 - WASM: v5 世代の辞書を OPFS から削除し、v6 のアーカイブをダウンロードする。
-- ユーザー辞書の `.bin` ファイルは対応不要。出力の再検証も不要。
+- 辞書外・非日本語テキストに対するトークナイズ結果を厳密に固定している場合は
+  再確認する — Decompose ペナルティ修正と未知語ラダー（デフォルト有効）の
+  両方が結果を変える可能性がある。v5 と同一の未知語出力が必要なら
+  `unknown_word_ladder(false)` を設定する。
+- `lindera_dictionary::viterbi`/`mode` の型を直接利用している場合は、上記の
+  Rust API 表に従い呼び出し箇所を更新する。
+- ユーザー辞書の `.bin` ファイルは対応不要。

--- a/docs/src/lindera-cli/commands.md
+++ b/docs/src/lindera-cli/commands.md
@@ -61,6 +61,7 @@ Perform morphological analysis (tokenization) on Japanese, Chinese, or Korean te
 - `--token-filter` / `-t`: Token filter configuration (JSON)
 - `--keep-whitespace`: Keep whitespace tokens in the output (by default, whitespace is dropped for MeCab compatibility)
 - `--max-grouping-len`: Maximum unknown-word grouping length in characters beyond the first (MeCab's `max-grouping-size`; MeCab defaults to 24). Runs longer than the cap fall back to single-character unknown words. Default: unbounded
+- `--disable-unknown-word-ladder`: Disable the MeCab/Vibrato-inspired unknown-word length ladder (`char.def`'s `LENGTH` field). Enabled by default; disable for output identical to pre-v6 Lindera
 - `--mmap`: Use memory-mapped file loading for the dictionary directory's word list. Ignored for `embedded://` dictionaries and when the `mmap` feature is disabled. Rebuilding or truncating the dictionary directory while a process holds it mapped can cause a SIGBUS on the next lookup.
 - `--nbest` / `-N`: Number of N-best results to return (default: 1). When set to 2 or more, N-best output is enabled.
 - `--nbest-unique`: Deduplicate N-best results by removing paths that produce the same segmentation.

--- a/docs/src/lindera/segmenter.md
+++ b/docs/src/lindera/segmenter.md
@@ -153,6 +153,12 @@ Unknown-word grouping is unbounded by default. `max_grouping_len(Some(n))` caps 
 let segmenter = Segmenter::new(Mode::Normal, dictionary, None).max_grouping_len(Some(24));
 ```
 
+Independently of grouping, Lindera also generates a MeCab/Vibrato-inspired "length ladder" of shorter unknown-word candidates (up to each category's `char.def` `LENGTH` field) by default, so the Viterbi search can pick whichever length scores lowest. Call `unknown_word_ladder(false)` to disable it and match pre-v6 output exactly:
+
+```rust
+let segmenter = Segmenter::new(Mode::Normal, dictionary, None).unknown_word_ladder(false);
+```
+
 ## N-Best Segmentation
 
 `segment_nbest` returns the top-`n` segmentations ordered by total path cost, each paired with its cost. Set `unique` to deduplicate results that share the same word boundaries but differ only in POS tags, and `cost_threshold` to discard paths whose cost exceeds `best_cost + threshold`:

--- a/docs/src/migration_v5_to_v6.md
+++ b/docs/src/migration_v5_to_v6.md
@@ -1,12 +1,12 @@
 # Migrating from v5 to v6
 
-Lindera v6.0.0 changes the on-disk format of built dictionaries: the system
-prefix dictionary's byte-wise `daachorse` Aho-Corasick automaton (`dict.da`) is
-replaced by a char-wise double-array trie (`dict.trie`) plus a word values
-index (`dict.valsidx`), and `metadata.json` now records the format version so
-that a mismatched dictionary fails loudly at load instead of decoding into
-garbage. Tokenization output is unchanged — v6 produces byte-for-byte
-identical tokens to v5 for the same input and dictionary.
+Lindera v6.0.0 changes the on-disk format of built dictionaries, changes a
+few `lindera-dictionary` Rust APIs, and changes tokenization output in two
+targeted ways (a Decompose-mode accuracy fix, and a new default-on
+unknown-word feature). Most users only need to rebuild or re-download their
+dictionaries; direct users of `lindera_dictionary::viterbi`/`mode` types and
+anyone relying on exact legacy output for out-of-vocabulary text have a
+couple of extra things to check.
 
 ## Overview
 
@@ -16,6 +16,9 @@ identical tokens to v5 for the same input and dictionary.
 | `metadata.json` records `format_version`; mismatches are refused at load | Anyone loading a v5-era built dictionary | Rebuild, or re-download with `lindera download` |
 | `loadDictionaryFromBytes()` now takes 9 arguments | WASM users loading dictionaries from bytes | Pass `dictTrie` and `dictValsIdx` instead of `dictDa` |
 | OPFS `DictionaryFiles` replaces `dictDa` with `dictTrie` + `dictValsIdx` | WASM users of the `opfs` helpers | Re-download OPFS-cached dictionaries |
+| Decompose-mode length penalty is now exact for non-3-byte characters | `Mode::Decompose` output on text with 1-, 2-, or 4-byte UTF-8 characters | Nothing — this is a correctness fix; re-check Decompose output if you pin it exactly |
+| Unknown-word length ladder is on by default | Normal- and Decompose-mode output on out-of-vocabulary text | Set `unknown_word_ladder(false)` / `--disable-unknown-word-ladder` for v5-identical output |
+| Several `lindera_dictionary::viterbi`/`mode` items renamed or removed | Direct users of `Lattice`/`Edge`/`Penalty`/`Mode` (not the `lindera` crate's `Segmenter`/`Tokenizer`/`Worker` API) | Update call sites per the table below |
 
 ## Dictionary format version 2
 
@@ -54,65 +57,78 @@ error instead of misreading the headerless binary files:
 Dictionary 'ipadic' has format version 1, but this build of Lindera reads format version 2. To fix this, rebuild it with `lindera build`, or download a matching prebuilt dictionary with `lindera download`.
 ```
 
-## Who needs to act
+## Tokenization output changes
 
-### Self-built dictionaries
+Unlike the format change above, these two changes can alter the *tokens*
+Lindera produces for the same input and dictionary.
 
-Rebuild any dictionary you compiled yourself from its source files with the
-v6 CLI, using the same `lindera build` invocation as before — the command-line
-interface is unchanged:
+### Decompose-mode penalty accuracy fix
+
+`Mode::Decompose`'s length penalty used to approximate a span's character
+count as `(stop_byte - start_byte) / 3`, which is exact only for text made
+entirely of 3-byte UTF-8 characters (common Japanese kanji/kana). Lindera's
+Viterbi lattice is now character-indexed internally, so the penalty uses the
+real character count. This only changes Decompose output for spans
+containing 1-byte (ASCII), 2-byte, or 4-byte (e.g. emoji, some CJK extension
+characters) UTF-8 characters; pure-Japanese Decompose output is unaffected.
+There is no option to restore the old (inexact) behavior, since it was a bug
+fix rather than a behavior choice.
+
+### Unknown-word length ladder (new, on by default)
+
+For a run of out-of-vocabulary characters, MeCab and Vibrato generate a
+"ladder" of candidate unknown-word lengths (`1..=LENGTH`, where `LENGTH` is
+a per-category field in the dictionary's `char.def`) and let the Viterbi
+search pick whichever length yields the lowest-cost path. Lindera parsed
+`LENGTH` from `char.def` but never used it at runtime, so it only ever
+generated a single 1-character candidate or (for grouping categories) one
+candidate spanning the whole run — never anything in between.
+
+Starting in v6.0.0, Lindera generates this candidate ladder by default. For
+IPADIC this affects the `KANJI`, `HIRAGANA`, and `KATAKANA` categories
+(`LENGTH=2`); most other categories declare `LENGTH=0` and are unaffected.
+The practical effect is that consecutive out-of-vocabulary kanji or kana
+characters can now be grouped into multi-character unknown words when that
+scores lower than splitting them one character at a time — for example, an
+unrecognized two-kanji compound is now tokenized as one word instead of two.
+
+This is additive to (and independent of) the `max_grouping_len` option
+introduced in v5.4 for capping whole-run grouping.
+
+To reproduce v5-identical output on text containing out-of-vocabulary
+kanji/kana runs, disable the ladder:
+
+```rust,ignore
+let segmenter = Segmenter::new(mode, dictionary, None)
+    .unknown_word_ladder(false);
+```
 
 ```sh
-lindera build \
-  --src ./dictionary-source \
-  --dest ./dictionary \
-  --metadata ./metadata.json
+lindera tokenize -d ipadic --disable-unknown-word-ladder input.txt
 ```
 
-Alternatively, re-download a matching prebuilt dictionary:
+`AnalysisWorker`/`SegmentWorker` expose the same toggle via
+`set_unknown_word_ladder(bool)`, and `TokenizerBuilder` via
+`set_segmenter_unknown_word_ladder(bool)`.
 
-```sh
-lindera download ipadic
-```
+## Rust API changes in `lindera_dictionary`
 
-Downloaded dictionaries are version-isolated under
-`<data dir>/lindera/dictionaries/<version>/` (for example
-`~/.local/share/lindera/dictionaries/6.0.0/` on Linux), so the v5 copies are
-neither reused nor overwritten and no cleanup is strictly needed.
+These affect only code that uses `lindera_dictionary::viterbi::{Lattice,
+Edge}` or `lindera_dictionary::mode::{Mode, Penalty}` directly (for example,
+custom lattice inspection or alternative tokenizer front-ends). The `lindera`
+crate's `Segmenter`, `Tokenizer`, `SegmentWorker`, and `AnalysisWorker` APIs
+are unaffected — they gained the `unknown_word_ladder`/`max_grouping_len`
+options above but no signatures changed.
 
-### WASM: `loadDictionaryFromBytes()`
-
-The former `dictDa` argument is replaced by `dictTrie` and `dictValsIdx`,
-growing the signature from 8 to 9 arguments:
-
-```javascript
-// v5 — 8 arguments
-const dictionary = loadDictionaryFromBytes(
-    files.metadata, files.dictDa, files.dictVals, files.dictWordsIdx,
-    files.dictWords, files.matrixMtx, files.charDef, files.unk,
-);
-
-// v6 — 9 arguments
-const dictionary = loadDictionaryFromBytes(
-    files.metadata, files.dictTrie, files.dictValsIdx, files.dictVals,
-    files.dictWordsIdx, files.dictWords, files.matrixMtx, files.charDef, files.unk,
-);
-```
-
-### WASM: OPFS helpers
-
-The `DictionaryFiles` object returned by `loadDictionaryFiles()` now carries
-`dictTrie` and `dictValsIdx` properties instead of `dictDa`, and the set of
-files stored in OPFS changed accordingly. A dictionary downloaded into OPFS
-with v5 lacks `dict.trie` and `dict.valsidx`, so remove it and download a v6
-archive:
-
-```javascript
-import { downloadDictionary, removeDictionary } from 'lindera-wasm-web/opfs';
-
-await removeDictionary("ipadic");
-await downloadDictionary(DICT_URL_V6, "ipadic");
-```
+| v5 | v6 | Why |
+| --- | --- | --- |
+| `Lattice::text_len()` | `Lattice::char_len()` | The lattice is now character-indexed instead of byte-indexed; the rename makes call sites that assumed bytes fail to compile instead of silently misbehaving |
+| `Lattice::edges_at(pos)` | `Lattice::edges_at_char(pos)` | Same reason: `pos` is now a character position |
+| `Lattice::paths_at(pos)` | `Lattice::paths_at_char(pos)` | Same reason |
+| `Lattice::capacity()` / `shrink_to(n)` | Same names, now denominated in characters (slots) instead of bytes | A byte length remains a valid, conservative `shrink_to` argument (a sentence never has more characters than bytes) |
+| `Edge::num_chars()` | Removed | The packed `Edge` no longer stores its end position (it always equals the lattice slot it lives in), so this can no longer be computed from the edge alone |
+| `Penalty::penalty(&Edge)` | `Penalty::penalty(&Edge, num_chars: usize)` | The caller now passes the exact character span (see the Decompose accuracy fix above) |
+| `Mode::penalty_cost(&Edge)` | Removed | Had no callers in the codebase; re-implement via `Penalty::penalty` if needed |
 
 ## Who does not need to act
 
@@ -120,12 +136,13 @@ await downloadDictionary(DICT_URL_V6, "ipadic");
   affected. They keep using a `daachorse` automaton internally and continue to
   load without rebuilding. User dictionaries loaded from `.csv` are compiled
   at load time as before.
-- **Tokenization output**: unchanged. For the same input and dictionary, v6
-  produces byte-for-byte identical tokens to v5.
-- **Rust API**: no signatures changed. Code that loads a dictionary from a
-  path or URI compiles and runs unchanged once the dictionary itself is
-  rebuilt or re-downloaded, and `embed-*` dictionaries are compiled by each
-  dictionary crate's build script, so they always match the running version.
+- **`lindera` crate's public API**: `Segmenter`, `Tokenizer`,
+  `SegmentWorker`, and `AnalysisWorker` signatures are unchanged (aside from
+  the additive `unknown_word_ladder`/`max_grouping_len` options); code that
+  loads a dictionary from a path or URI compiles and runs unchanged once the
+  dictionary itself is rebuilt or re-downloaded, and `embed-*` dictionaries
+  are compiled by each dictionary crate's build script, so they always match
+  the running version.
 
 ## Upgrade checklist
 
@@ -134,5 +151,10 @@ await downloadDictionary(DICT_URL_V6, "ipadic");
 - WASM: update `loadDictionaryFromBytes()` calls to the 9-argument signature
   (`dictTrie` and `dictValsIdx` in place of `dictDa`).
 - WASM: remove v5-era dictionaries from OPFS and download v6 archives.
-- Nothing to do for user-dictionary `.bin` files, and no output changes to
-  re-validate.
+- If you pin exact tokenization output for out-of-vocabulary or non-Japanese
+  text, re-check it — the Decompose penalty fix and the unknown-word ladder
+  (default on) can both change it. Set `unknown_word_ladder(false)` if you
+  need v5-identical unknown-word output.
+- If you use `lindera_dictionary::viterbi`/`mode` types directly, update
+  call sites per the Rust API table above.
+- Nothing to do for user-dictionary `.bin` files.

--- a/lindera-analysis/src/tokenizer.rs
+++ b/lindera-analysis/src/tokenizer.rs
@@ -155,6 +155,21 @@ impl TokenizerBuilder {
         self
     }
 
+    /// Enables/disables the unknown-word length ladder (see
+    /// `Segmenter::unknown_word_ladder`; defaults to `true`).
+    ///
+    /// # Arguments
+    ///
+    /// * `unknown_word_ladder` - Whether to emit the length ladder.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to `self`, for chaining.
+    pub fn set_segmenter_unknown_word_ladder(&mut self, unknown_word_ladder: bool) -> &mut Self {
+        self.config["segmenter"]["unknown_word_ladder"] = json!(unknown_word_ladder);
+        self
+    }
+
     /// Set whether to route filesystem-loaded dictionaries through
     /// memory-mapped reads. Ignored for `embedded://` dictionaries.
     ///

--- a/lindera-analysis/src/worker.rs
+++ b/lindera-analysis/src/worker.rs
@@ -228,6 +228,17 @@ impl AnalysisWorker {
         self.segment_worker.set_max_grouping_len(max_grouping_len);
     }
 
+    /// Enables/disables the unknown-word length ladder for subsequent
+    /// calls (see `Segmenter::unknown_word_ladder`; defaults to `true`).
+    ///
+    /// # 引数
+    ///
+    /// * `unknown_word_ladder` - Whether to emit the length ladder.
+    pub fn set_unknown_word_ladder(&mut self, unknown_word_ladder: bool) {
+        self.segment_worker
+            .set_unknown_word_ladder(unknown_word_ladder);
+    }
+
     /// Immediately shrinks the worker's internal buffers to what an input
     /// of `text_len_hint` bytes needs.
     ///

--- a/lindera-cli/src/commands/tokenize.rs
+++ b/lindera-cli/src/commands/tokenize.rs
@@ -71,6 +71,11 @@ pub struct TokenizeArgs {
     )]
     max_grouping_len: Option<usize>,
     #[clap(
+        long = "disable-unknown-word-ladder",
+        help = "Disable the MeCab/Vibrato-inspired unknown-word length ladder (char.def's LENGTH field), matching pre-v6 output exactly. Enabled by default"
+    )]
+    disable_unknown_word_ladder: bool,
+    #[clap(
         long = "mmap",
         help = "Use memory-mapped file loading for the dictionary directory's word list. Ignored for embedded:// dictionaries and when the mmap feature is disabled. Rebuilding or truncating the dictionary directory while a process holds it mapped can cause a SIGBUS on the next lookup."
     )]
@@ -253,6 +258,11 @@ pub fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
     // Unknown-word grouping cap (default: unbounded)
     if let Some(max_grouping_len) = args.max_grouping_len {
         builder.set_segmenter_max_grouping_len(max_grouping_len);
+    }
+
+    // Unknown-word length ladder (default: enabled)
+    if args.disable_unknown_word_ladder {
+        builder.set_segmenter_unknown_word_ladder(false);
     }
 
     // Memory-mapped dictionary loading (ignored for embedded:// dictionaries)

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -900,6 +900,7 @@ impl Lattice {
         text: &str,
         search_mode: &Mode,
         max_grouping_len: Option<usize>,
+        unknown_word_ladder: bool,
     ) {
         // Clear the previous sentence's slots (bounded by its char count),
         // then build the per-char buffers to learn this sentence's length.
@@ -1038,6 +1039,7 @@ impl Lattice {
                         cost_matrix,
                         search_mode,
                         max_grouping_len,
+                        unknown_word_ladder,
                         category,
                         category_ord,
                         unknown_word_end,
@@ -1075,6 +1077,127 @@ impl Lattice {
         }
     }
 
+    /// Emits one unknown-word edge per dictionary entry for `category`,
+    /// spanning `num_chars` characters from `char_idx`.
+    ///
+    /// Shared by the primary-candidate emission and the length-ladder
+    /// emission (#945) in both `process_unknown_word` and its nbest twin.
+    ///
+    /// # 引数
+    ///
+    /// * `unknown_dictionary` - Source of unknown-word entries.
+    /// * `cost_matrix` - The connection cost matrix.
+    /// * `search_mode` - The segmentation mode.
+    /// * `category` - The character category the edges belong to.
+    /// * `char_idx` - Start position, in characters.
+    /// * `num_chars` - Span length, in characters.
+    fn emit_unknown_word_edges(
+        &mut self,
+        unknown_dictionary: &UnknownDictionary,
+        cost_matrix: &ConnectionCostMatrix,
+        search_mode: &Mode,
+        category: CategoryId,
+        char_idx: usize,
+        num_chars: usize,
+    ) {
+        let end_char = char_idx + num_chars;
+        let kanji_only = self.is_kanji_all(char_idx, num_chars);
+        for &word_id in unknown_dictionary.lookup_word_ids(category) {
+            let word_entry = unknown_dictionary.word_entry(word_id);
+            let edge = Self::create_edge(word_entry, char_idx, kanji_only);
+            self.add_edge_in_lattice(edge, end_char, cost_matrix, search_mode);
+        }
+    }
+
+    /// [`Self::emit_unknown_word_edges`] for the nbest lattice.
+    ///
+    /// # 引数
+    ///
+    /// See [`Self::emit_unknown_word_edges`].
+    fn emit_unknown_word_edges_nbest(
+        &mut self,
+        unknown_dictionary: &UnknownDictionary,
+        cost_matrix: &ConnectionCostMatrix,
+        search_mode: &Mode,
+        category: CategoryId,
+        char_idx: usize,
+        num_chars: usize,
+    ) {
+        let end_char = char_idx + num_chars;
+        let kanji_only = self.is_kanji_all(char_idx, num_chars);
+        for &word_id in unknown_dictionary.lookup_word_ids(category) {
+            let word_entry = unknown_dictionary.word_entry(word_id);
+            let edge = Self::create_edge(word_entry, char_idx, kanji_only);
+            self.add_edge_in_lattice_nbest(edge, end_char, cost_matrix, search_mode);
+        }
+    }
+
+    /// Computes the length-ladder run length for `category_ord` at
+    /// `char_idx`: how many leading characters (from `char_idx`) belong to
+    /// the same category, capped at `category_data.length` (#945). Reuses
+    /// the group run length when one was already computed for the primary
+    /// candidate (`group_run_len`); otherwise scans forward, bounded by
+    /// `category_data.length` (at most 15, a 4-bit `char.def` field), so
+    /// this stays cheap even for categories the primary path never runs
+    /// grouping on.
+    ///
+    /// # 引数
+    ///
+    /// * `char_definitions` - Character category definitions.
+    /// * `search_mode` - The segmentation mode.
+    /// * `category` - The category to match against.
+    /// * `category_ord` - Ordinal within the char's category set.
+    /// * `char_idx` - Start position, in characters.
+    /// * `length_cap` - `category_data.length`, the ladder's upper bound.
+    /// * `group_run_len` - The raw run length already computed for
+    ///   grouping, if any.
+    ///
+    /// # 戻り値
+    ///
+    /// The number of leading same-category characters, capped at
+    /// `length_cap`.
+    #[allow(clippy::too_many_arguments)]
+    fn ladder_run_len(
+        &self,
+        char_definitions: &CharacterDefinition,
+        search_mode: &Mode,
+        category: CategoryId,
+        category_ord: usize,
+        char_idx: usize,
+        length_cap: usize,
+        group_run_len: Option<usize>,
+    ) -> usize {
+        if let Some(run) = group_run_len {
+            return run.min(length_cap);
+        }
+        if search_mode.is_search() {
+            // Decompose precomputes the exact run for every (char,
+            // ordinal) pair regardless of category_data.group (#944), so
+            // this is a single O(1) lookup here too.
+            let run = self.group_runs_buf
+                [self.group_runs_start_buf[char_idx] as usize + category_ord]
+                as usize;
+            return run.min(length_cap);
+        }
+        // Normal mode, no group scan available: scan forward, bounded by
+        // length_cap so this is at most a few iterations.
+        let mut run = 1;
+        for i in 1..length_cap {
+            let next_idx = char_idx + i;
+            if next_idx >= self.char_info_buffer.len() - 1 {
+                break;
+            }
+            let next = self.char_info_buffer[next_idx];
+            if category_ord >= next.categories_len as usize
+                || self.get_cached_category(char_definitions, next_idx, category_ord) != category
+            {
+                break;
+            }
+            run += 1;
+        }
+        run
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn process_unknown_word(
         &mut self,
@@ -1083,6 +1206,7 @@ impl Lattice {
         cost_matrix: &ConnectionCostMatrix,
         search_mode: &Mode,
         max_grouping_len: Option<usize>,
+        unknown_word_ladder: bool,
         category: CategoryId,
         category_ord: usize,
         unknown_word_index: Option<usize>,
@@ -1090,23 +1214,27 @@ impl Lattice {
         found: bool,
     ) -> Option<usize> {
         let mut unknown_word_num_chars: usize = 0;
+        // Raw (uncapped) grouping run length, captured for the length
+        // ladder before max_grouping_len can shrink unknown_word_num_chars
+        // to the fallback of 1 (#945).
+        let mut group_run_len: Option<usize> = None;
         let category_data = char_definitions.lookup_definition(category);
         if category_data.invoke || !found {
             unknown_word_num_chars = 1;
             if category_data.group {
-                if search_mode.is_search() {
+                let run_len = if search_mode.is_search() {
                     // Decompose re-enters the unknown-word logic at every
                     // position inside a run, so the forward rescan below
                     // was O(run^2) in total; read the run precomputed by
                     // prepare_char_buffers instead (#944).
-                    unknown_word_num_chars = self.group_runs_buf
-                        [self.group_runs_start_buf[char_idx] as usize + category_ord]
-                        as usize;
+                    self.group_runs_buf[self.group_runs_start_buf[char_idx] as usize + category_ord]
+                        as usize
                 } else {
                     // Normal mode: the unknown_word_end gate makes this
                     // scan run ~once per run, so it stays O(n) without the
                     // precompute (which would cost every Normal sentence a
                     // per-ordinal pass for nothing).
+                    let mut run = 1;
                     for i in 1.. {
                         let next_idx = char_idx + i;
                         if next_idx >= self.char_info_buffer.len() - 1 {
@@ -1119,7 +1247,7 @@ impl Lattice {
                             let cat =
                                 self.get_cached_category(char_definitions, next_idx, category_ord);
                             if cat == category {
-                                unknown_word_num_chars += 1;
+                                run += 1;
                                 found_cat = true;
                             }
                         }
@@ -1127,7 +1255,10 @@ impl Lattice {
                             break;
                         }
                     }
-                }
+                    run
+                };
+                group_run_len = Some(run_len);
+                unknown_word_num_chars = run_len;
                 // MeCab-style cap (#944): a grouped candidate with more
                 // than max_grouping_len characters beyond the first is not
                 // emitted; the single-char unknown word is emitted instead,
@@ -1142,17 +1273,48 @@ impl Lattice {
             }
         }
         if unknown_word_num_chars > 0 {
-            let end_char = char_idx + unknown_word_num_chars;
+            self.emit_unknown_word_edges(
+                unknown_dictionary,
+                cost_matrix,
+                search_mode,
+                category,
+                char_idx,
+                unknown_word_num_chars,
+            );
 
-            // Check Kanji status using pre-calculated buffer
-            let kanji_only = self.is_kanji_all(char_idx, unknown_word_num_chars);
-
-            for &word_id in unknown_dictionary.lookup_word_ids(category) {
-                let word_entry = unknown_dictionary.word_entry(word_id);
-                let edge = Self::create_edge(word_entry, char_idx, kanji_only);
-                self.add_edge_in_lattice(edge, end_char, cost_matrix, search_mode);
+            // Length ladder (#945): additional shorter candidates up to
+            // category_data.length, MeCab/Vibrato-inspired (char.def's
+            // LENGTH field, otherwise unread at runtime until this
+            // feature). Purely additive: never removes the primary
+            // candidate above, which keeps the reachability guarantee.
+            if unknown_word_ladder && category_data.length > 0 {
+                let length_cap = category_data.length as usize;
+                let run_len = self.ladder_run_len(
+                    char_definitions,
+                    search_mode,
+                    category,
+                    category_ord,
+                    char_idx,
+                    length_cap,
+                    group_run_len,
+                );
+                // ladder_run_len already applies length_cap.
+                for i in 1..=run_len {
+                    if i == unknown_word_num_chars {
+                        continue; // already emitted above
+                    }
+                    self.emit_unknown_word_edges(
+                        unknown_dictionary,
+                        cost_matrix,
+                        search_mode,
+                        category,
+                        char_idx,
+                        i,
+                    );
+                }
             }
-            return Some(end_char);
+
+            return Some(char_idx + unknown_word_num_chars);
         }
         unknown_word_index
     }
@@ -1519,6 +1681,7 @@ impl Lattice {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn process_unknown_word_nbest(
         &mut self,
         char_definitions: &CharacterDefinition,
@@ -1526,6 +1689,7 @@ impl Lattice {
         cost_matrix: &ConnectionCostMatrix,
         search_mode: &Mode,
         max_grouping_len: Option<usize>,
+        unknown_word_ladder: bool,
         category: CategoryId,
         category_ord: usize,
         unknown_word_index: Option<usize>,
@@ -1533,23 +1697,24 @@ impl Lattice {
         found: bool,
     ) -> Option<usize> {
         let mut unknown_word_num_chars: usize = 0;
+        let mut group_run_len: Option<usize> = None;
         let category_data = char_definitions.lookup_definition(category);
         if category_data.invoke || !found {
             unknown_word_num_chars = 1;
             if category_data.group {
-                if search_mode.is_search() {
+                let run_len = if search_mode.is_search() {
                     // Decompose re-enters the unknown-word logic at every
                     // position inside a run, so the forward rescan below
                     // was O(run^2) in total; read the run precomputed by
                     // prepare_char_buffers instead (#944).
-                    unknown_word_num_chars = self.group_runs_buf
-                        [self.group_runs_start_buf[char_idx] as usize + category_ord]
-                        as usize;
+                    self.group_runs_buf[self.group_runs_start_buf[char_idx] as usize + category_ord]
+                        as usize
                 } else {
                     // Normal mode: the unknown_word_end gate makes this
                     // scan run ~once per run, so it stays O(n) without the
                     // precompute (which would cost every Normal sentence a
                     // per-ordinal pass for nothing).
+                    let mut run = 1;
                     for i in 1.. {
                         let next_idx = char_idx + i;
                         if next_idx >= self.char_info_buffer.len() - 1 {
@@ -1562,7 +1727,7 @@ impl Lattice {
                             let cat =
                                 self.get_cached_category(char_definitions, next_idx, category_ord);
                             if cat == category {
-                                unknown_word_num_chars += 1;
+                                run += 1;
                                 found_cat = true;
                             }
                         }
@@ -1570,7 +1735,10 @@ impl Lattice {
                             break;
                         }
                     }
-                }
+                    run
+                };
+                group_run_len = Some(run_len);
+                unknown_word_num_chars = run_len;
                 // MeCab-style cap (#944): a grouped candidate with more
                 // than max_grouping_len characters beyond the first is not
                 // emitted; the single-char unknown word is emitted instead,
@@ -1585,16 +1753,43 @@ impl Lattice {
             }
         }
         if unknown_word_num_chars > 0 {
-            let end_char = char_idx + unknown_word_num_chars;
+            self.emit_unknown_word_edges_nbest(
+                unknown_dictionary,
+                cost_matrix,
+                search_mode,
+                category,
+                char_idx,
+                unknown_word_num_chars,
+            );
 
-            let kanji_only = self.is_kanji_all(char_idx, unknown_word_num_chars);
-
-            for &word_id in unknown_dictionary.lookup_word_ids(category) {
-                let word_entry = unknown_dictionary.word_entry(word_id);
-                let edge = Self::create_edge(word_entry, char_idx, kanji_only);
-                self.add_edge_in_lattice_nbest(edge, end_char, cost_matrix, search_mode);
+            // Length ladder (#945); see process_unknown_word.
+            if unknown_word_ladder && category_data.length > 0 {
+                let length_cap = category_data.length as usize;
+                let run_len = self.ladder_run_len(
+                    char_definitions,
+                    search_mode,
+                    category,
+                    category_ord,
+                    char_idx,
+                    length_cap,
+                    group_run_len,
+                );
+                for i in 1..=run_len {
+                    if i == unknown_word_num_chars {
+                        continue;
+                    }
+                    self.emit_unknown_word_edges_nbest(
+                        unknown_dictionary,
+                        cost_matrix,
+                        search_mode,
+                        category,
+                        char_idx,
+                        i,
+                    );
+                }
             }
-            return Some(end_char);
+
+            return Some(char_idx + unknown_word_num_chars);
         }
         unknown_word_index
     }
@@ -1613,6 +1808,7 @@ impl Lattice {
         text: &str,
         search_mode: &Mode,
         max_grouping_len: Option<usize>,
+        unknown_word_ladder: bool,
     ) {
         // Same clear -> prepare -> grow sequence as set_text.
         self.clear();
@@ -1735,6 +1931,7 @@ impl Lattice {
                         cost_matrix,
                         search_mode,
                         max_grouping_len,
+                        unknown_word_ladder,
                         category,
                         category_ord,
                         unknown_word_end,

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -105,6 +105,13 @@ pub struct Segmenter {
     /// leaves grouping unbounded, matching previous behavior.
     pub max_grouping_len: Option<usize>,
 
+    /// Whether to additionally emit MeCab/Vibrato-inspired shorter
+    /// unknown-word candidates up to each category's `char.def` `LENGTH`
+    /// field (#945). Lindera parsed but never read this field before this
+    /// option existed. Defaults to `true` starting with this release --
+    /// set to `false` to match pre-v6 output exactly.
+    pub unknown_word_ladder: bool,
+
     /// The category ID for space characters, used when keep_whitespace is false.
     space_category_id: Option<CategoryId>,
 
@@ -179,6 +186,7 @@ impl Segmenter {
             user_dictionary,
             keep_whitespace: false, // Default: ignore whitespace for MeCab compatibility
             max_grouping_len: None, // Default: unbounded grouping
+            unknown_word_ladder: true, // Default (v6+): honor char.def's LENGTH field
             space_category_id,
             space_ascii_table,
         }
@@ -228,6 +236,21 @@ impl Segmenter {
     /// `self`, for chaining.
     pub fn max_grouping_len(mut self, max_grouping_len: Option<usize>) -> Self {
         self.max_grouping_len = max_grouping_len;
+        self
+    }
+
+    /// Builder method to enable/disable the unknown-word length ladder
+    /// (see the `unknown_word_ladder` field; defaults to `true`).
+    ///
+    /// # 引数
+    ///
+    /// * `unknown_word_ladder` - Whether to emit the length ladder.
+    ///
+    /// # 戻り値
+    ///
+    /// `self`, for chaining.
+    pub fn unknown_word_ladder(mut self, unknown_word_ladder: bool) -> Self {
+        self.unknown_word_ladder = unknown_word_ladder;
         self
     }
 
@@ -332,9 +355,17 @@ impl Segmenter {
             .filter(|&n| n > 0)
             .map(|n| n as usize);
 
+        // Load the unknown_word_ladder option from the config.
+        // Absent means the default (true).
+        let unknown_word_ladder = config
+            .get("unknown_word_ladder")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+
         Ok(Self::new(mode, dictionary, user_dictionary)
             .keep_whitespace(keep_whitespace)
-            .max_grouping_len(max_grouping_len))
+            .max_grouping_len(max_grouping_len)
+            .unknown_word_ladder(unknown_word_ladder))
     }
 
     /// Segments the input text into tokens based on the dictionary and user-defined rules.
@@ -496,6 +527,7 @@ impl Segmenter {
                 sentence,
                 &self.mode,
                 self.max_grouping_len,
+                self.unknown_word_ladder,
             );
             // Forward Viterbi implementation handles cost calculation within `set_text`.
 
@@ -640,6 +672,7 @@ impl Segmenter {
                 sentence,
                 &self.mode,
                 self.max_grouping_len,
+                self.unknown_word_ladder,
             );
 
             let nbest_offsets = lattice.nbest_tokens_offset(n, unique, cost_threshold);

--- a/lindera/src/worker.rs
+++ b/lindera/src/worker.rs
@@ -221,6 +221,16 @@ impl SegmentWorker {
         self.segmenter.max_grouping_len = max_grouping_len;
     }
 
+    /// Enables/disables the unknown-word length ladder for subsequent
+    /// calls (see `Segmenter::unknown_word_ladder`; defaults to `true`).
+    ///
+    /// # 引数
+    ///
+    /// * `unknown_word_ladder` - Whether to emit the length ladder.
+    pub fn set_unknown_word_ladder(&mut self, unknown_word_ladder: bool) {
+        self.segmenter.unknown_word_ladder = unknown_word_ladder;
+    }
+
     /// Returns a shared reference to the underlying segmenter.
     ///
     /// No `&mut` accessor is provided on purpose: swapping the dictionary
@@ -420,11 +430,104 @@ mod tests {
         /// #944: max_grouping_len caps unknown-word grouping with MeCab
         /// semantics -- a run with more characters beyond the first than
         /// the cap falls back to single-char unknown words -- while None
+        /// #945: the length ladder must be additive and switchable. Using
+        /// two out-of-vocabulary KANJI characters (char.def: invoke=0,
+        /// group=0, length=2 in IPADIC) isolates the ladder from grouping
+        /// (which is off for this category) and from max_grouping_len
+        /// (irrelevant when group=false): with the ladder on, a 2-char
+        /// candidate becomes available and the best path takes it (lower
+        /// cost than two isolated 1-char unknown words); with it off,
+        /// only 1-char candidates exist, matching pre-#945 output.
+        #[test]
+        fn test_unknown_word_ladder_toggle() {
+            let segmenter = ipadic_segmenter();
+            let mut worker = segmenter.new_worker();
+
+            // Two rare kanji absent from IPADIC's dictionary.
+            let text = "龘龍";
+
+            let with_ladder = match worker.segment(text) {
+                Ok(tokens) => tokens
+                    .iter()
+                    .map(|t| t.surface.to_string())
+                    .collect::<Vec<_>>(),
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            assert_eq!(
+                with_ladder,
+                vec![text.to_string()],
+                "the ladder's 2-char candidate must win the best path"
+            );
+
+            worker.set_unknown_word_ladder(false);
+            let without_ladder = match worker.segment(text) {
+                Ok(tokens) => tokens
+                    .iter()
+                    .map(|t| t.surface.to_string())
+                    .collect::<Vec<_>>(),
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            assert_eq!(
+                without_ladder,
+                vec!["龘".to_string(), "龍".to_string()],
+                "disabling the ladder must fall back to single-char unknowns"
+            );
+
+            worker.set_unknown_word_ladder(true);
+            assert_eq!(
+                match worker.segment(text) {
+                    Ok(tokens) => tokens
+                        .iter()
+                        .map(|t| t.surface.to_string())
+                        .collect::<Vec<_>>(),
+                    Err(err) => panic!("worker.segment failed: {err}"),
+                },
+                with_ladder,
+                "re-enabling the ladder must restore the default output"
+            );
+        }
+
+        /// #945: the length ladder must also fire on the Decompose-mode
+        /// path, which reads run lengths from the #944 precomputed buffer
+        /// instead of Normal mode's forward scan.
+        #[test]
+        fn test_unknown_word_ladder_decompose_mode() {
+            use lindera_dictionary::mode::Penalty;
+
+            let segmenter = ipadic_segmenter();
+            let mut worker = segmenter.new_worker();
+            worker.set_mode(Mode::Decompose(Penalty::default()));
+
+            let text = "龘龍";
+            let with_ladder = match worker.segment(text) {
+                Ok(tokens) => tokens
+                    .iter()
+                    .map(|t| t.surface.to_string())
+                    .collect::<Vec<_>>(),
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            assert_eq!(with_ladder, vec![text.to_string()]);
+
+            worker.set_unknown_word_ladder(false);
+            let without_ladder = match worker.segment(text) {
+                Ok(tokens) => tokens
+                    .iter()
+                    .map(|t| t.surface.to_string())
+                    .collect::<Vec<_>>(),
+                Err(err) => panic!("worker.segment failed: {err}"),
+            };
+            assert_eq!(without_ladder, vec!["龘".to_string(), "龍".to_string()]);
+        }
+
         /// (the default) keeps grouping unbounded.
         #[test]
         fn test_max_grouping_len_caps_unknown_grouping() {
             let segmenter = ipadic_segmenter();
             let mut worker = segmenter.new_worker();
+            // Isolate max_grouping_len from the length ladder (#945,
+            // default on), which would otherwise also contribute
+            // candidates and change the best path independently.
+            worker.set_unknown_word_ladder(false);
 
             // An out-of-vocabulary katakana run (5 chars); IPADIC's
             // KATAKANA category groups, so the default spans the run.


### PR DESCRIPTION
Closes #945. Part of the #941 campaign. **Breaking (default behavior change)** — targeted at the pending v6.0.0 window.

## What

Lindera parsed `char.def`'s per-category `LENGTH` field into `CategoryData.length` but never read it at runtime, so out-of-vocabulary runs only ever got a single 1-char, or (for grouping categories) one whole-run, candidate — never MeCab/Vibrato's `1..=LENGTH` ladder of in-between lengths for the Viterbi search to pick the lowest-cost one from.

New `unknown_word_ladder: bool` option, **defaulting to `true`**. When on, `process_unknown_word(_nbest)` additionally emits candidates for lengths `1..=min(category_data.length, run_len)`, deduped against the primary candidate. The primary candidate itself (today's grouping + the `max_grouping_len` cap from #944) is unchanged, so this is purely additive when enabled and a no-op when disabled.

Run length for the ladder is read cheaply:
- **Decompose mode**: reuses #944's precomputed `group_runs_buf` — an O(1) lookup, valid for any category regardless of its `group` flag.
- **Normal mode**: reuses the existing group scan when `category_data.group == true`; otherwise a new scan bounded by `category_data.length` (≤ 15, a 4-bit `char.def` field) — for IPADIC, most categories declare `LENGTH=0` and never enter this loop at all (only `KANJI`/`HIRAGANA`/`KATAKANA` are affected).

Plumbing mirrors `max_grouping_len`: `Segmenter` field/builder/`from_config` key, `SegmentWorker`/`AnalysisWorker::set_unknown_word_ladder`, `TokenizerBuilder::set_segmenter_unknown_word_ladder`, and a CLI `--disable-unknown-word-ladder` flag.

## Correctness

- Two new unit tests exercise the ladder end-to-end against real IPADIC data (Normal and Decompose mode), covering the toggle and the dedup-against-primary case.
- **CLI output with the ladder disabled is byte-identical to the pre-#945 golden captures** — confirms the feature is purely opt-out-safe.
- All 10 `embed-ipadic`/`unidic`/`ko-dic`/`jieba` golden snapshots pass **unchanged** with the ladder on (their corpora don't exercise the affected categories).
- **bocchan.txt does show real differences** (83 diff blocks) with the ladder on — manually reviewed, all legitimate: e.g. previously-split two-kanji unknown-word pairs now tokenize as one unknown word when that's the lower-cost path (「怙贔」「騒々」「支那」「襯衣」...), and one case shows the ladder improving a *split* by exposing a shorter candidate that combines better with a following known particle.
- `fmt --check` / workspace `clippy -D warnings --all-features` clean.

## Docs

Updated the segmenter and CLI pages (en/ja). Also rewrote `migration_v5_to_v6.md` (en/ja) — its "byte-for-byte identical output" claim was already stale before this PR (the #943 Decompose `num_chars` fix and its `Lattice`/`Edge`/`Mode`/`Penalty` API renames were never documented there); it now covers both tokenization-output-affecting changes in v6 plus a Rust API rename table for direct `lindera_dictionary::viterbi`/`mode` users.

## Performance (informational — this is an accuracy feature, not a perf one)

Interleaved min-of-8 on bocchan.txt: 274.19 ms (pre-ladder) vs 267.85 ms (ladder on) — within noise on this corpus. Cost scales with how much genuinely out-of-vocabulary kanji/kana text a workload contains.