### PR TITLE
feat(wasm)!: return plain objects from tokenize, drop the Token class

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -504,3 +504,9 @@ jobs:
 
       - name: Run WASM test
         run: make test-lindera-wasm
+
+      # Tokens must stay plain objects: a wasm-bindgen class instance keeps its data on the
+      # Rust heap until the JS side drops it, so returning classes accumulates memory in
+      # synchronous loops that never yield (#930). This check fails if that pattern comes back.
+      - name: Check token memory is released in synchronous loops
+        run: make memcheck-lindera-wasm

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,10 @@ memcheck-lindera-nodejs: ## Check lindera-nodejs releases token memory in synchr
 	cd lindera-nodejs && npm install --quiet && npx napi build --platform -p lindera-nodejs --features embed-ipadic
 	node --expose-gc scripts/benchmarks/memcheck_nodejs.mjs
 
+memcheck-lindera-wasm: ## Check lindera-wasm releases token memory in synchronous loops
+	cd lindera-wasm && wasm-pack build --target nodejs --features=$(WASM_FEATURES) --out-dir pkg-node
+	node --expose-gc scripts/benchmarks/memcheck_wasm.mjs
+
 test-lindera-ruby: ## Test lindera-ruby (Rust unit tests + minitest)
 	$(CARGO_TEST_WITH_RBCONFIG) cargo test -p lindera-ruby --lib
 	cd lindera-ruby && bundle install --quiet && LINDERA_FEATURES="embed-ipadic,train" bundle exec rake compile && bundle exec rake test

--- a/docs/ja/src/migration_v5_to_v6.md
+++ b/docs/ja/src/migration_v5_to_v6.md
@@ -19,6 +19,7 @@ Lindera v6.0.0 では、ビルド済み辞書のオンディスクフォーマ�
 | Decompose モードの長さペナルティが非 3 バイト文字に対して正確になった | 1・2・4 バイトの UTF-8 文字を含むテキストに対する `Mode::Decompose` の出力 | 対応不要（正確性修正）。出力を厳密に固定している場合は Decompose 出力を再確認 |
 | 未知語の候補ラダー（length ladder）がデフォルトで有効に | 辞書外テキストに対する Normal・Decompose 両モードの出力 | v5 と同一の出力が必要な場合は `unknown_word_ladder(false)` / `--disable-unknown-word-ladder` を設定 |
 | `lindera_dictionary::viterbi`/`mode` の一部項目が改名・削除 | `Lattice`/`Edge`/`Penalty`/`Mode` を直接利用するコード（`lindera` クレートの `Segmenter`/`Tokenizer`/`Worker` API 利用者は対象外） | 下記の表に従い呼び出し箇所を更新 |
+| JS バインディングがプレーンオブジェクトを返すようになり `Token` クラスが廃止 | Node.js・WASM ユーザー | `token.getDetail(i)` を `token.details[i]` に置換。WASM ユーザーはフィールド名の camelCase 化にも対応 |
 
 ## 辞書フォーマットバージョン 2
 
@@ -129,6 +130,80 @@ lindera tokenize -d ipadic --disable-unknown-word-ladder input.txt
 | `Edge::num_chars()` | 削除 | パック済み `Edge` は終了位置を保持しなくなった（常にラティススロットの添字と一致するため）ので、エッジ単体からは計算できなくなった |
 | `Penalty::penalty(&Edge)` | `Penalty::penalty(&Edge, num_chars: usize)` | 呼び出し側が正確な文字数スパンを渡すようになった（前述の Decompose 精度修正を参照） |
 | `Mode::penalty_cost(&Edge)` | 削除 | コードベース内に呼び出し元が無かった。必要であれば `Penalty::penalty` で再実装可能 |
+
+## JavaScript バインディング: トークンがプレーンオブジェクトに
+
+これまで両 JS バインディングは `Token` クラスのインスタンスを返していました。
+これらのインスタンスは JavaScript ヒープの外にメモリを保持し、ホストが
+ファイナライザを実行して初めて解放されます。napi はそのファイナライザを
+イベントループへ遅延させ、wasm-bindgen は解放を呼び出し側に委ねるため、
+大きな入力を yield せずに同期ループでトークナイズすると、強制 GC を
+挟んでもメモリが蓄積していました。v6 では両バインディングともプレーン
+オブジェクトを返すようになり、メモリは JavaScript の GC が完全に管理します。
+
+実用上の利点: バッチループでメモリがフラットに保たれ、結果を
+`JSON.stringify`・`structuredClone`・worker への転送にそのまま使えます。
+
+### `getDetail(i)` の廃止（Node.js・WASM 共通）
+
+プレーンオブジェクトにメソッドは無いため、配列を直接参照してください:
+
+```javascript
+// v5
+const pos = token.getDetail(0);
+
+// v6
+const pos = token.details[0];
+```
+
+範囲外の読み出しは `null` ではなく `undefined` になります。
+
+### Node.js: `tokenizeObjects` の廃止
+
+`tokenizeObjects` は上記のメモリ問題に対する v5 限定の回避策としてのみ
+存在していました。`tokenize` が同じプレーンオブジェクトを返すように
+なったため、呼び出しを置き換えてください:
+
+```javascript
+// v5
+const tokens = tokenizer.tokenizeObjects(text);
+
+// v6
+const tokens = tokenizer.tokenize(text);
+```
+
+`tokenizeNbest` もプレーンオブジェクトを返すようになったため、v5 で
+既知の制約として記載していた蓄積の問題は解消されています。
+
+### WASM: フィールド名が camelCase に
+
+廃止された `Token` クラスは snake_case のフィールドを公開する一方、
+同じクラスの `toJSON()` は既に camelCase を出力しており不整合がありました。
+v6 では Node.js バインディングに揃えて camelCase に統一します:
+
+```javascript
+// v5
+token.byte_start, token.byte_end, token.word_id, token.is_unknown
+
+// v6
+token.byteStart, token.byteEnd, token.wordId, token.isUnknown
+```
+
+`surface`・`position`・`details` は変更ありません。既に `toJSON()` を
+呼んでその結果を読んでいたコードは、これらの名前を使っていたため
+そのまま動作します。ただし `toJSON()` 自体は、トークンが既にプレーン
+オブジェクトであるため廃止されました:
+
+```javascript
+// v5
+const data = token.toJSON();
+
+// v6
+const data = token; // 既にプレーンオブジェクト
+```
+
+WASM の `tokenizeNbest` は v5 の時点で既にプレーンオブジェクトを
+返していたため、変更ありません。
 
 ## 対応が不要なケース
 

--- a/docs/src/migration_v5_to_v6.md
+++ b/docs/src/migration_v5_to_v6.md
@@ -19,6 +19,7 @@ couple of extra things to check.
 | Decompose-mode length penalty is now exact for non-3-byte characters | `Mode::Decompose` output on text with 1-, 2-, or 4-byte UTF-8 characters | Nothing — this is a correctness fix; re-check Decompose output if you pin it exactly |
 | Unknown-word length ladder is on by default | Normal- and Decompose-mode output on out-of-vocabulary text | Set `unknown_word_ladder(false)` / `--disable-unknown-word-ladder` for v5-identical output |
 | Several `lindera_dictionary::viterbi`/`mode` items renamed or removed | Direct users of `Lattice`/`Edge`/`Penalty`/`Mode` (not the `lindera` crate's `Segmenter`/`Tokenizer`/`Worker` API) | Update call sites per the table below |
+| JS bindings return plain objects; the `Token` class is gone | Node.js and WASM users | Replace `token.getDetail(i)` with `token.details[i]`; WASM users also switch to camelCase field names |
 
 ## Dictionary format version 2
 
@@ -129,6 +130,78 @@ options above but no signatures changed.
 | `Edge::num_chars()` | Removed | The packed `Edge` no longer stores its end position (it always equals the lattice slot it lives in), so this can no longer be computed from the edge alone |
 | `Penalty::penalty(&Edge)` | `Penalty::penalty(&Edge, num_chars: usize)` | The caller now passes the exact character span (see the Decompose accuracy fix above) |
 | `Mode::penalty_cost(&Edge)` | Removed | Had no callers in the codebase; re-implement via `Penalty::penalty` if needed |
+
+## JavaScript bindings: tokens are plain objects
+
+Both JS bindings previously returned `Token` class instances. Those instances
+own memory outside the JavaScript heap, released only when the host runs a
+finalizer — which napi defers to the event loop, and which wasm-bindgen leaves
+to the caller. A synchronous loop that tokenizes a large input without
+yielding therefore accumulated memory even under forced GC. In v6 both
+bindings return plain objects instead, which the JavaScript GC owns outright.
+
+Practical benefits: memory stays flat in batch loops, and results work
+directly with `JSON.stringify`, `structuredClone`, and worker transfer.
+
+### `getDetail(i)` is removed (Node.js and WASM)
+
+A plain object has no methods, so read the array instead:
+
+```javascript
+// v5
+const pos = token.getDetail(0);
+
+// v6
+const pos = token.details[0];
+```
+
+Out-of-range reads now yield `undefined` rather than `null`.
+
+### Node.js: `tokenizeObjects` is removed
+
+`tokenizeObjects` existed only as a v5-era workaround for the memory problem
+above. `tokenize` now returns the same plain objects, so drop the call:
+
+```javascript
+// v5
+const tokens = tokenizer.tokenizeObjects(text);
+
+// v6
+const tokens = tokenizer.tokenize(text);
+```
+
+`tokenizeNbest` returns plain objects too, so it no longer has the
+accumulation behavior documented as a known limitation in v5.
+
+### WASM: field names are now camelCase
+
+The removed `Token` class exposed snake_case fields while its own `toJSON()`
+already emitted camelCase. v6 settles on camelCase, matching the Node.js
+binding:
+
+```javascript
+// v5
+token.byte_start, token.byte_end, token.word_id, token.is_unknown
+
+// v6
+token.byteStart, token.byteEnd, token.wordId, token.isUnknown
+```
+
+`surface`, `position`, and `details` are unchanged. Code that already called
+`toJSON()` and read the result was using these names, and keeps working —
+except that `toJSON()` itself is gone, since the token is already a plain
+object:
+
+```javascript
+// v5
+const data = token.toJSON();
+
+// v6
+const data = token; // already plain
+```
+
+`tokenizeNbest` in WASM already returned plain objects in v5 and is
+unchanged.
 
 ## Who does not need to act
 

--- a/lindera-wasm/.gitignore
+++ b/lindera-wasm/.gitignore
@@ -1,5 +1,7 @@
 # wasm-pack build output
 pkg/
+# nodejs-target build used by the memory-regression check (see scripts/benchmarks/memcheck_wasm.mjs)
+pkg-node/
 
 # Node.js dependencies (for examples/tests)
 node_modules/

--- a/lindera-wasm/src/lib.rs
+++ b/lindera-wasm/src/lib.rs
@@ -51,7 +51,6 @@ pub use crate::mode::{JsMode as Mode, JsPenalty as Penalty};
 pub use crate::schema::{
     JsFieldDefinition as FieldDefinition, JsFieldType as FieldType, JsSchema as Schema,
 };
-pub use crate::token::JsToken as Token;
 pub use crate::tokenizer::{Tokenizer, TokenizerBuilder};
 
 // Top-level function aliases for consistency with Python API

--- a/lindera-wasm/src/token.rs
+++ b/lindera-wasm/src/token.rs
@@ -1,91 +1,49 @@
+//! Token representation for morphological analysis results.
+//!
+//! Tokens cross into JavaScript as plain objects rather than
+//! `#[wasm_bindgen]` class instances. A class instance keeps its data on the
+//! Rust heap and relies on the JS side dropping it (explicitly, or through a
+//! `FinalizationRegistry`) to release that memory, so a synchronous loop
+//! that tokenizes without yielding accumulates memory. Building a plain
+//! object instead means nothing is ever allocated on the Rust side for the
+//! caller to release, and the result survives `JSON.stringify` /
+//! `structuredClone` / worker transfer without conversion (#930).
+//!
+//! Field names are camelCase, matching the `lindera-nodejs` binding and what
+//! the former `Token.toJSON()` already emitted.
+
 use wasm_bindgen::prelude::*;
 
-use lindera::token::Token;
+use lindera_binding_core::TokenView;
 
-/// Token object wrapping the Rust Token data.
+/// Converts a binding-core `TokenView` into a plain JS object.
 ///
-/// This class provides robust access to token field and details.
-#[wasm_bindgen(js_name = "Token")]
-pub struct JsToken {
-    /// Surface form of the token.
-    #[wasm_bindgen(getter_with_clone)]
-    pub surface: String,
+/// # Arguments
+///
+/// * `view` - The token view produced by the binding-core tokenizer.
+///
+/// # Returns
+///
+/// A plain JS object with camelCase keys: `surface`, `byteStart`,
+/// `byteEnd`, `position`, `wordId`, `isUnknown`, and `details`.
+pub fn token_view_to_js(view: TokenView) -> JsValue {
+    let js_obj = js_sys::Object::new();
+    let _ = js_sys::Reflect::set(&js_obj, &"surface".into(), &view.surface.into());
+    let _ = js_sys::Reflect::set(
+        &js_obj,
+        &"byteStart".into(),
+        &(view.byte_start as f64).into(),
+    );
+    let _ = js_sys::Reflect::set(&js_obj, &"byteEnd".into(), &(view.byte_end as f64).into());
+    let _ = js_sys::Reflect::set(&js_obj, &"position".into(), &(view.position as f64).into());
+    let _ = js_sys::Reflect::set(&js_obj, &"wordId".into(), &(view.word_id as f64).into());
+    let _ = js_sys::Reflect::set(&js_obj, &"isUnknown".into(), &view.is_unknown.into());
 
-    /// Start byte position in the original text.
-    pub byte_start: usize,
-
-    /// End byte position in the original text.
-    pub byte_end: usize,
-
-    /// Position index of the token.
-    pub position: usize,
-
-    /// Word ID in the dictionary.
-    pub word_id: u32,
-
-    /// Whether this token is an unknown word (not found in the dictionary).
-    pub is_unknown: bool,
-
-    /// Morphological details of the token.
-    #[wasm_bindgen(getter_with_clone)]
-    pub details: Vec<String>,
-}
-
-#[wasm_bindgen(js_class = "Token")]
-impl JsToken {
-    /// Returns the detail at the specified index.
-    ///
-    /// # Parameters
-    ///
-    /// - `index`: Index of the detail to retrieve.
-    ///
-    /// # Returns
-    ///
-    /// The detail string if found, otherwise undefined.
-    #[wasm_bindgen(js_name = "getDetail")]
-    pub fn get_detail(&self, index: usize) -> Option<String> {
-        self.details.get(index).cloned()
+    let js_details = js_sys::Array::new();
+    for detail in view.details {
+        js_details.push(&detail.into());
     }
+    let _ = js_sys::Reflect::set(&js_obj, &"details".into(), &js_details.into());
 
-    #[wasm_bindgen(js_name = "toJSON")]
-    pub fn to_json(&self) -> JsValue {
-        let js_obj = js_sys::Object::new();
-        let _ = js_sys::Reflect::set(&js_obj, &"surface".into(), &self.surface.clone().into());
-        let _ = js_sys::Reflect::set(
-            &js_obj,
-            &"byteStart".into(),
-            &(self.byte_start as f64).into(),
-        );
-        let _ = js_sys::Reflect::set(&js_obj, &"byteEnd".into(), &(self.byte_end as f64).into());
-        let _ = js_sys::Reflect::set(&js_obj, &"position".into(), &(self.position as f64).into());
-        let _ = js_sys::Reflect::set(&js_obj, &"wordId".into(), &(self.word_id as f64).into());
-        let _ = js_sys::Reflect::set(&js_obj, &"isUnknown".into(), &self.is_unknown.into());
-
-        let js_details = js_sys::Array::new();
-        for detail in &self.details {
-            js_details.push(&detail.clone().into());
-        }
-        let _ = js_sys::Reflect::set(&js_obj, &"details".into(), &js_details.into());
-
-        js_obj.into()
-    }
-}
-
-impl JsToken {
-    pub fn from_token(token: Token) -> Self {
-        Self::from_view(lindera_binding_core::TokenView::from_token(token))
-    }
-
-    /// Creates a `JsToken` from a binding-core `TokenView`.
-    pub fn from_view(view: lindera_binding_core::TokenView) -> Self {
-        Self {
-            surface: view.surface,
-            byte_start: view.byte_start,
-            byte_end: view.byte_end,
-            position: view.position,
-            word_id: view.word_id,
-            is_unknown: view.is_unknown,
-            details: view.details,
-        }
-    }
+    js_obj.into()
 }

--- a/lindera-wasm/src/tokenizer.rs
+++ b/lindera-wasm/src/tokenizer.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 use lindera_binding_core::{CoreTokenizer, CoreTokenizerBuilder};
 
 use crate::dictionary::{JsDictionary, JsUserDictionary};
-use crate::token::JsToken;
+use crate::token::token_view_to_js;
 
 /// Parses optional filter arguments (a JS value) into a JSON value.
 fn parse_filter_args(args: JsValue) -> Result<Value, JsValue> {
@@ -216,13 +216,17 @@ impl Tokenizer {
     }
 
     /// Tokenizes the input text.
-    pub fn tokenize(&self, input_text: &str) -> Result<Vec<JsToken>, JsValue> {
+    ///
+    /// Tokens are returned as plain JS objects with camelCase fields, so
+    /// they carry no Rust-side allocation for the caller to release and
+    /// serialize without conversion.
+    pub fn tokenize(&self, input_text: &str) -> Result<Vec<JsValue>, JsValue> {
         let views = self
             .inner
             .tokenize(input_text)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
-        Ok(views.into_iter().map(JsToken::from_view).collect())
+        Ok(views.into_iter().map(token_view_to_js).collect())
     }
 
     /// Tokenizes the input text and returns only the token surfaces.
@@ -262,8 +266,7 @@ impl Tokenizer {
             let entry = js_sys::Object::new();
             let inner = js_sys::Array::new();
             for view in views {
-                let js_token = JsToken::from_view(view);
-                inner.push(&js_token.to_json());
+                inner.push(&token_view_to_js(view));
             }
             js_sys::Reflect::set(&entry, &"tokens".into(), &inner).unwrap();
             js_sys::Reflect::set(&entry, &"cost".into(), &JsValue::from(cost as f64)).unwrap();
@@ -297,6 +300,44 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test;
 
+    /// Reads a string field from a plain-object token (#930: tokens are
+    /// plain JS objects with camelCase keys, not class instances).
+    #[cfg(target_arch = "wasm32")]
+    fn token_str(token: &wasm_bindgen::JsValue, key: &str) -> String {
+        js_sys::Reflect::get(token, &key.into())
+            .unwrap()
+            .as_string()
+            .unwrap()
+    }
+
+    /// Reads a numeric field from a plain-object token.
+    #[cfg(target_arch = "wasm32")]
+    fn token_num(token: &wasm_bindgen::JsValue, key: &str) -> f64 {
+        js_sys::Reflect::get(token, &key.into())
+            .unwrap()
+            .as_f64()
+            .unwrap()
+    }
+
+    /// Reads a boolean field from a plain-object token.
+    #[cfg(target_arch = "wasm32")]
+    fn token_bool(token: &wasm_bindgen::JsValue, key: &str) -> bool {
+        js_sys::Reflect::get(token, &key.into())
+            .unwrap()
+            .as_bool()
+            .unwrap()
+    }
+
+    /// Reads the `details` array from a plain-object token.
+    #[cfg(target_arch = "wasm32")]
+    fn token_details(token: &wasm_bindgen::JsValue) -> Vec<String> {
+        let details = js_sys::Reflect::get(token, &"details".into()).unwrap();
+        js_sys::Array::from(&details)
+            .iter()
+            .map(|d| d.as_string().unwrap())
+            .collect()
+    }
+
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen_test]
     fn test_tokenize() {
@@ -311,10 +352,10 @@ mod tests {
         let tokens = tokenizer.tokenize("関西国際空港限定トートバッグ").unwrap();
 
         assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0].surface, "関西国際空港");
-        assert_eq!(tokens[1].surface, "限定");
-        assert_eq!(tokens[2].surface, "トートバッグ");
-        assert_eq!(tokens[0].get_detail(0), Some("名詞".to_string()));
+        assert_eq!(token_str(&tokens[0], "surface"), "関西国際空港");
+        assert_eq!(token_str(&tokens[1], "surface"), "限定");
+        assert_eq!(token_str(&tokens[2], "surface"), "トートバッグ");
+        assert_eq!(token_details(&tokens[0])[0], "名詞");
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -332,8 +373,8 @@ mod tests {
         let expected: Vec<String> = tokenizer
             .tokenize(text)
             .unwrap()
-            .into_iter()
-            .map(|t| t.surface)
+            .iter()
+            .map(|t| token_str(t, "surface"))
             .collect();
         let surfaces = tokenizer.tokenize_surfaces(text).unwrap();
         assert_eq!(expected, surfaces);
@@ -361,8 +402,8 @@ mod tests {
         let tokens = tokenizer.tokenize("すもももももももものうち").unwrap();
 
         assert_eq!(tokens.len(), 7);
-        assert_eq!(tokens[0].surface, "すもも");
-        assert_eq!(tokens[6].surface, "うち");
+        assert_eq!(token_str(&tokens[0], "surface"), "すもも");
+        assert_eq!(token_str(&tokens[6], "surface"), "うち");
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -381,18 +422,21 @@ mod tests {
         assert_eq!(tokens.len(), 1);
 
         let token = &tokens[0];
-        assert_eq!(token.surface, "関西国際空港");
-        assert_eq!(token.byte_start, 0);
-        assert_eq!(token.byte_end, "関西国際空港".len());
-        assert_eq!(token.position, 0);
-        assert!(!token.is_unknown);
-        assert!(!token.details.is_empty());
-        assert!(token.word_id > 0);
+        assert_eq!(token_str(token, "surface"), "関西国際空港");
+        assert_eq!(token_num(token, "byteStart"), 0.0);
+        assert_eq!(token_num(token, "byteEnd"), "関西国際空港".len() as f64);
+        assert_eq!(token_num(token, "position"), 0.0);
+        assert!(!token_bool(token, "isUnknown"));
+        assert!(!token_details(token).is_empty());
+        assert!(token_num(token, "wordId") > 0.0);
     }
 
+    /// #930: details are read by indexing the array, which replaces the
+    /// `getDetail(i)` method that existed while tokens were class
+    /// instances.
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen_test]
-    fn test_token_get_detail() {
+    fn test_token_details_by_index() {
         use crate::TokenizerBuilder;
 
         let mut builder = TokenizerBuilder::new().unwrap();
@@ -405,18 +449,21 @@ mod tests {
 
         assert!(!tokens.is_empty());
 
-        let token = &tokens[0];
+        let details = token_details(&tokens[0]);
+        assert!(!details.is_empty());
+        assert_eq!(details[0], "名詞");
 
-        let first_detail = token.get_detail(0);
-        assert!(first_detail.is_some());
-        assert_eq!(first_detail.unwrap(), token.details[0]);
-
-        assert!(token.get_detail(9999).is_none());
+        // Out-of-range reads yield undefined, as for any JS array.
+        let raw = js_sys::Reflect::get(&tokens[0], &"details".into()).unwrap();
+        let out_of_range = js_sys::Reflect::get_u32(&raw, 9999).unwrap();
+        assert!(out_of_range.is_undefined());
     }
 
+    /// #930: tokens are plain objects, so they serialize without any
+    /// conversion step and carry no Rust-side allocation to release.
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen_test]
-    fn test_token_to_json() {
+    fn test_token_is_plain_serializable_object() {
         use crate::TokenizerBuilder;
 
         let mut builder = TokenizerBuilder::new().unwrap();
@@ -426,11 +473,28 @@ mod tests {
         let tokenizer = builder.build().unwrap();
 
         let tokens = tokenizer.tokenize("東京").unwrap();
+        let token = &tokens[0];
 
-        let json = tokens[0].to_json();
+        // A plain object, not a wasm-bindgen class instance: its prototype
+        // is Object.prototype, i.e. its constructor is Object itself.
+        assert!(token.is_object());
+        let proto = js_sys::Object::get_prototype_of(token);
+        let ctor = js_sys::Reflect::get(&proto, &"constructor".into()).unwrap();
+        let ctor_name = js_sys::Reflect::get(&ctor, &"name".into())
+            .unwrap()
+            .as_string()
+            .unwrap();
+        assert_eq!(ctor_name, "Object");
 
-        assert!(!json.is_null());
-        assert!(!json.is_undefined());
+        // Round-trips through JSON with its fields intact.
+        let json = js_sys::JSON::stringify(token).unwrap();
+        let parsed = js_sys::JSON::parse(&String::from(json)).unwrap();
+        assert_eq!(token_str(&parsed, "surface"), token_str(token, "surface"));
+        assert_eq!(
+            token_num(&parsed, "byteStart"),
+            token_num(token, "byteStart")
+        );
+        assert_eq!(token_details(&parsed), token_details(token));
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -448,7 +512,7 @@ mod tests {
 
         assert!(!tokens.is_empty());
 
-        let reconstructed: String = tokens.iter().map(|t| t.surface.as_str()).collect();
+        let reconstructed: String = tokens.iter().map(|t| token_str(t, "surface")).collect();
         assert_eq!(reconstructed, "関西国際空港");
     }
 
@@ -510,7 +574,7 @@ mod tests {
         let tokens = tokenizer.tokenize("東京タワー").unwrap();
 
         assert!(!tokens.is_empty());
-        assert_eq!(tokens[0].surface, "東京");
+        assert_eq!(token_str(&tokens[0], "surface"), "東京");
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -529,7 +593,7 @@ mod tests {
         let tokens = tokenizer.tokenize("東京タワー").unwrap();
 
         assert!(!tokens.is_empty());
-        assert_eq!(tokens[0].surface, "東京");
+        assert_eq!(token_str(&tokens[0], "surface"), "東京");
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -548,7 +612,7 @@ mod tests {
         let tokens = tokenizer.tokenize("関西国際空港").unwrap();
 
         assert!(!tokens.is_empty());
-        let reconstructed: String = tokens.iter().map(|t| t.surface.as_str()).collect();
+        let reconstructed: String = tokens.iter().map(|t| token_str(t, "surface")).collect();
         assert_eq!(reconstructed, "関西国際空港");
     }
 

--- a/scripts/benchmarks/memcheck_wasm.mjs
+++ b/scripts/benchmarks/memcheck_wasm.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Memory-regression check for lindera-wasm (see #930).
+//
+// Same workload and assertion as memcheck_nodejs.mjs, against a
+// `wasm-pack build --target nodejs` artifact so the check runs in a plain
+// Node process rather than a browser. Exits non-zero on regression.
+//
+// Must be run with --expose-gc, and needs a nodejs-target build first:
+//   cd lindera-wasm && wasm-pack build --target nodejs --features embed-ipadic --out-dir pkg-node
+//   node --expose-gc scripts/benchmarks/memcheck_wasm.mjs
+//
+// Environment:
+//   MEMCHECK_WASM_PKG  package directory to load (default: lindera-wasm/pkg-node)
+//   MEMCHECK_ITER      measured iterations (default 24)
+//   MEMCHECK_WARMUP    warmup iterations (default 4)
+//   MEMCHECK_CHARS     size of the generated input text (default 100000)
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { measureRssGrowth, reportVerdict } from "./memcheck_common.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(here, "..", "..");
+const pkgDir =
+  process.env.MEMCHECK_WASM_PKG ??
+  path.join(repoRoot, "lindera-wasm", "pkg-node");
+
+const require = createRequire(import.meta.url);
+const lindera = require(pkgDir);
+
+const ITERATIONS = Number(process.env.MEMCHECK_ITER ?? "24");
+const WARMUP = Number(process.env.MEMCHECK_WARMUP ?? "4");
+const CHARS = Number(process.env.MEMCHECK_CHARS ?? "100000");
+
+const SENTENCE = "関西国際空港限定トートバッグを買った。";
+const TEXT = SENTENCE.repeat(Math.ceil(CHARS / SENTENCE.length)).slice(
+  0,
+  CHARS,
+);
+
+const builder = new lindera.TokenizerBuilder();
+builder.setMode("normal");
+builder.setDictionary("embedded://ipadic");
+const tokenizer = builder.build();
+
+// Sanity check: the loop below must actually produce tokens, otherwise the
+// measurement would pass trivially.
+const probe = tokenizer.tokenize(TEXT);
+if (!Array.isArray(probe) || probe.length === 0) {
+  console.error("FAIL: tokenize returned no tokens; nothing was measured");
+  process.exit(1);
+}
+console.log(`wasm\ttokens-per-call\t${probe.length}`);
+
+const growth = measureRssGrowth({
+  tokenizeOnce: () => {
+    tokenizer.tokenize(TEXT);
+  },
+  iterations: ITERATIONS,
+  warmup: WARMUP,
+});
+
+const passed = reportVerdict({
+  label: "wasm",
+  growth,
+  tolerance: 0.5,
+  ceilingBytes: 512 * 1024 * 1024,
+});
+
+process.exit(passed ? 0 : 1);


### PR DESCRIPTION
Closes #951. Part of #930. Follows #953, which did the same for lindera-nodejs.

**Breaking (JS API)** — targeted at the v6.0.0 window.

## What

A wasm-bindgen class instance keeps its data on the Rust heap and relies on the JS side dropping it to release that memory, so a synchronous loop that tokenizes without yielding accumulates memory — the same class of problem #922 measured for napi.

The fix is structural rather than a conversion layered on top: the field mapping `Token.toJSON()` already performed moves into a free function over `&TokenView` (`token_view_to_js`), so **no class instance is ever constructed** and there is nothing for the caller to release.

- `token.rs`: delete the `JsToken` class; add `token_view_to_js()`. Drop the `Token` re-export from `lib.rs`.
- `tokenizer.rs`: `tokenize()` returns `Vec<JsValue>` (wasm-bindgen turns that into a JS array itself, so no manual `js_sys::Array`); `tokenizeNbest` calls the same free function. Note nbest **already** returned plain objects in v5 — only `tokenize` still handed back class instances, the mirror image of nodejs where nbest was the straggler.
- Tests read tokens through `js_sys::Reflect` with camelCase keys via small helpers; the `getDetail`/`toJSON` tests are replaced by tests for `details[i]` and for the plain-object shape.
- `scripts/benchmarks/memcheck_wasm.mjs` reusing `memcheck_common.mjs` from #953, wired into `regression.yml` through a `memcheck-lindera-wasm` make target. `pkg-node/` is gitignored.
- Migration guide (en/ja): new section covering this plus the nodejs changes from #953.

## Breaking changes

- `tokenize()` returns plain objects instead of `Token` class instances.
- **Field names change from snake_case to camelCase** (`byte_start` → `byteStart`, `byte_end` → `byteEnd`, `word_id` → `wordId`, `is_unknown` → `isUnknown`). This resolves a pre-existing inconsistency: the class exposed snake_case fields while its own `toJSON()` already emitted camelCase. `surface`, `position`, `details` are unchanged.
- `token.getDetail(i)` → `token.details[i]` (out-of-range now yields `undefined`).
- `token.toJSON()` is gone — the token is already a plain object.

## Verification

**The memory check was confirmed to fail against the pre-change build**, which also empirically confirms the WASM binding really did accumulate (this issue assumed it by analogy with napi):

| | before (class) | after (plain object) |
|---|---|---|
| first-half growth | 182.7 MB | 1.2 MB |
| second-half growth | 182.3 MB | **0.0 MB** |
| total (24 iterations) | **365.0 MB, still climbing** | **1.3 MB, flat** |
| verdict | FAIL (exit 1) | OK (exit 0) |

100K-char input, ~36.8K tokens/call, `--expose-gc` with `global.gc()` between iterations.

- `wasm-pack test --node --features=embed-ipadic`: 29 pass, 0 fail.
- `cargo fmt --check` / `clippy -D warnings` on `wasm32-unknown-unknown` / markdownlint clean.