### PR TITLE
feat(bindings): add plain-data conversion methods to Token

### DIFF
--- a/lindera-php/README.md
+++ b/lindera-php/README.md
@@ -48,6 +48,25 @@ foreach ($tokens as $token) {
 }
 ```
 
+### Converting Tokens to Plain Data
+
+`toArray()` returns the token as an associative array, keeping each field's
+natural PHP type, so it serializes without a custom encoder:
+
+```php
+$data = $tokens[0]->toArray();
+// ['surface' => ..., 'byte_start' => 0, 'byte_end' => 9, 'position' => 0,
+//  'word_id' => 12345, 'is_unknown' => false, 'details' => [...]]
+
+echo json_encode(array_map(fn($t) => $t->toArray(), $tokens));
+```
+
+`Lindera\Token` does not implement `JsonSerializable`, so passing a token
+object straight to `json_encode` does not produce these fields — call
+`toArray()` first, as above. The extension is built with ext-php-rs, whose
+`#[php_class]` cannot declare implemented interfaces yet (upstream
+[ext-php-rs#326](https://github.com/davidcole1340/ext-php-rs/issues/326)).
+
 ### With Dictionary
 
 ```php

--- a/lindera-php/src/token.rs
+++ b/lindera-php/src/token.rs
@@ -3,7 +3,9 @@
 //! This module provides the PhpToken class that exposes morphological analysis
 //! results to PHP.
 
+use ext_php_rs::boxed::ZBox;
 use ext_php_rs::prelude::*;
+use ext_php_rs::types::ZendHashTable;
 
 use lindera::token::Token;
 
@@ -114,6 +116,35 @@ impl PhpToken {
     /// The detail string if found, otherwise null.
     pub fn get_detail(&self, index: i64) -> Option<String> {
         self.details.get(index as usize).cloned()
+    }
+
+    /// Returns the token as an associative array.
+    ///
+    /// Values keep their natural PHP types (int for the positions and word
+    /// id, bool for `is_unknown`, array of string for `details`), so the
+    /// result works directly with `json_encode`.
+    ///
+    /// # Returns
+    ///
+    /// An array with the keys `surface`, `byte_start`, `byte_end`,
+    /// `position`, `word_id`, `is_unknown`, and `details`.
+    pub fn to_array(&self) -> PhpResult<ZBox<ZendHashTable>> {
+        let mut arr = ZendHashTable::new();
+        arr.insert("surface", self.surface.as_str())
+            .map_err(|e| PhpException::default(e.to_string()))?;
+        arr.insert("byte_start", self.byte_start as i64)
+            .map_err(|e| PhpException::default(e.to_string()))?;
+        arr.insert("byte_end", self.byte_end as i64)
+            .map_err(|e| PhpException::default(e.to_string()))?;
+        arr.insert("position", self.position as i64)
+            .map_err(|e| PhpException::default(e.to_string()))?;
+        arr.insert("word_id", self.word_id as i64)
+            .map_err(|e| PhpException::default(e.to_string()))?;
+        arr.insert("is_unknown", self.is_unknown)
+            .map_err(|e| PhpException::default(e.to_string()))?;
+        arr.insert("details", self.details.clone())
+            .map_err(|e| PhpException::default(e.to_string()))?;
+        Ok(arr)
     }
 
     /// Returns a string representation of the token.

--- a/lindera-php/tests/LinderaTest.php
+++ b/lindera-php/tests/LinderaTest.php
@@ -204,6 +204,37 @@ class LinderaTest extends TestCase
         $this->assertNull($detailNull);
     }
 
+    // #952: toArray() returns plain data with natural PHP types.
+    public function testTokenToArray(): void
+    {
+        $builder = new Lindera\TokenizerBuilder();
+        $builder->setDictionary('embedded://ipadic');
+        $tokenizer = $builder->build();
+
+        $tokens = $tokenizer->tokenize('東京');
+        $this->assertGreaterThan(0, count($tokens));
+
+        $token = $tokens[0];
+        $array = $token->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertSame($token->surface, $array['surface']);
+        $this->assertIsInt($array['byte_start']);
+        $this->assertSame($token->byte_start, $array['byte_start']);
+        $this->assertSame($token->byte_end, $array['byte_end']);
+        $this->assertSame($token->position, $array['position']);
+        $this->assertSame($token->word_id, $array['word_id']);
+        $this->assertIsBool($array['is_unknown']);
+        $this->assertSame($token->is_unknown, $array['is_unknown']);
+        $this->assertIsArray($array['details']);
+        $this->assertSame($token->details, $array['details']);
+
+        // Serializes without a custom encoder.
+        $json = json_encode($array);
+        $this->assertIsString($json);
+        $this->assertSame($array, json_decode($json, true));
+    }
+
     public function testTokenizerBuilderSetMode(): void
     {
         $builder = new Lindera\TokenizerBuilder();

--- a/lindera-python/README.md
+++ b/lindera-python/README.md
@@ -107,6 +107,21 @@ for token in tokens:
     print(f"Text: {token.surface}, Position: {token.byte_start}-{token.byte_end}")
 ```
 
+### Converting Tokens to Plain Data
+
+`to_dict()` returns the token as a plain `dict`, keeping each field's natural
+Python type, so it serializes without a custom encoder:
+
+```python
+import json
+
+data = tokens[0].to_dict()
+# {'surface': ..., 'byte_start': 0, 'byte_end': 9, 'position': 0,
+#  'word_id': 12345, 'is_unknown': False, 'details': [...]}
+
+json.dumps([token.to_dict() for token in tokens])
+```
+
 ### Using Character Filters
 
 ```python

--- a/lindera-python/src/token.rs
+++ b/lindera-python/src/token.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 use lindera::token::Token;
 
@@ -50,6 +51,28 @@ impl PyToken {
     #[pyo3(signature = (index))]
     fn get_detail(&self, index: usize) -> Option<String> {
         self.details.get(index).cloned()
+    }
+
+    /// Returns the token as a plain dictionary.
+    ///
+    /// Field values keep their natural Python types (`int` for the
+    /// positions and word id, `bool` for `is_unknown`, `list[str]` for
+    /// `details`), so the result serializes directly with `json.dumps`.
+    ///
+    /// # Returns
+    ///
+    /// A dict with the keys `surface`, `byte_start`, `byte_end`,
+    /// `position`, `word_id`, `is_unknown`, and `details`.
+    fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item("surface", &self.surface)?;
+        dict.set_item("byte_start", self.byte_start)?;
+        dict.set_item("byte_end", self.byte_end)?;
+        dict.set_item("position", self.position)?;
+        dict.set_item("word_id", self.word_id)?;
+        dict.set_item("is_unknown", self.is_unknown)?;
+        dict.set_item("details", &self.details)?;
+        Ok(dict)
     }
 
     /// Returns a string representation of the token.

--- a/lindera-python/tests/test_pytoken.py
+++ b/lindera-python/tests/test_pytoken.py
@@ -64,6 +64,26 @@ def test_tokenize_returns_token_objects():
     # Check out of bounds
     assert token.get_detail(9999) is None
 
+    # to_dict() returns plain data with natural Python types (#952)
+    import json
+
+    data = token.to_dict()
+    assert isinstance(data, dict)
+    assert data["surface"] == token.surface
+    assert isinstance(data["byte_start"], int)
+    assert data["byte_start"] == token.byte_start
+    assert data["byte_end"] == token.byte_end
+    assert data["position"] == token.position
+    assert data["word_id"] == token.word_id
+    assert isinstance(data["is_unknown"], bool)
+    assert data["is_unknown"] == token.is_unknown
+    assert isinstance(data["details"], list)
+    assert data["details"] == token.details
+
+    # Serializes without a custom encoder.
+    restored = json.loads(json.dumps(data))
+    assert restored == data
+
     print("PyToken verify success!")
 
 

--- a/lindera-ruby/README.md
+++ b/lindera-ruby/README.md
@@ -49,6 +49,21 @@ tokens.each do |token|
 end
 ```
 
+### Converting Tokens to Plain Data
+
+`to_h` returns the token as a plain Hash keyed by Symbols, keeping each
+field's natural Ruby type, so it serializes without a custom encoder:
+
+```ruby
+require 'json'
+
+data = tokens.first.to_h
+# {surface: ..., byte_start: 0, byte_end: 9, position: 0,
+#  word_id: 12345, is_unknown: false, details: [...]}
+
+JSON.generate(tokens.map(&:to_h))
+```
+
 ### Using TokenizerBuilder
 
 ```ruby

--- a/lindera-ruby/src/token.rs
+++ b/lindera-ruby/src/token.rs
@@ -3,7 +3,7 @@
 //! This module wraps Lindera tokens for use in Ruby.
 
 use magnus::prelude::*;
-use magnus::{Error, Ruby, method};
+use magnus::{Error, RHash, Ruby, method};
 
 use lindera::token::Token;
 
@@ -111,6 +111,34 @@ impl RbToken {
         self.details.get(index).cloned()
     }
 
+    /// Returns the token as a plain Hash keyed by Symbols.
+    ///
+    /// Values keep their natural Ruby types (Integer for the positions and
+    /// word id, true/false for `:is_unknown`, Array of String for
+    /// `:details`), so the result works directly with `JSON.generate`.
+    ///
+    /// # Returns
+    ///
+    /// A Hash with the keys `:surface`, `:byte_start`, `:byte_end`,
+    /// `:position`, `:word_id`, `:is_unknown`, and `:details`, or a Magnus
+    /// `Error` if the Hash cannot be built.
+    fn to_hash(ruby: &Ruby, rb_self: &Self) -> Result<RHash, Error> {
+        let this = rb_self;
+        let hash = ruby.hash_new();
+        hash.aset(ruby.to_symbol("surface"), this.surface.as_str())?;
+        hash.aset(ruby.to_symbol("byte_start"), this.byte_start)?;
+        hash.aset(ruby.to_symbol("byte_end"), this.byte_end)?;
+        hash.aset(ruby.to_symbol("position"), this.position)?;
+        hash.aset(ruby.to_symbol("word_id"), this.word_id)?;
+        hash.aset(ruby.to_symbol("is_unknown"), this.is_unknown)?;
+        let details = ruby.ary_new();
+        for detail in &this.details {
+            details.push(detail.as_str())?;
+        }
+        hash.aset(ruby.to_symbol("details"), details)?;
+        Ok(hash)
+    }
+
     /// Returns the string representation of the token.
     fn to_s(&self) -> String {
         self.surface.clone()
@@ -150,6 +178,9 @@ pub fn define(ruby: &Ruby, module: &magnus::RModule) -> Result<(), Error> {
     token_class.define_method("unknown?", method!(RbToken::is_unknown, 0))?;
     token_class.define_method("details", method!(RbToken::details, 0))?;
     token_class.define_method("get_detail", method!(RbToken::get_detail, 1))?;
+    token_class.define_method("to_hash", method!(RbToken::to_hash, 0))?;
+    token_class.define_method("to_h", method!(RbToken::to_hash, 0))?;
+
     token_class.define_method("to_s", method!(RbToken::to_s, 0))?;
     token_class.define_method("inspect", method!(RbToken::inspect, 0))?;
 

--- a/lindera-ruby/test/test_token.rb
+++ b/lindera-ruby/test/test_token.rb
@@ -41,6 +41,34 @@ class TestToken < Minitest::Test
     assert_equal token.surface, token.to_s
   end
 
+  # #952: to_h returns plain data with natural Ruby types.
+  def test_token_to_h
+    require 'json'
+
+    token = @tokens[0]
+    hash = token.to_h
+
+    assert_kind_of Hash, hash
+    assert_equal token.surface, hash[:surface]
+    assert_kind_of Integer, hash[:byte_start]
+    assert_equal token.byte_start, hash[:byte_start]
+    assert_equal token.byte_end, hash[:byte_end]
+    assert_equal token.position, hash[:position]
+    assert_equal token.word_id, hash[:word_id]
+    assert_equal token.unknown?, hash[:is_unknown]
+    assert_kind_of Array, hash[:details]
+    assert_equal token.details, hash[:details]
+
+    # Serializes without a custom encoder.
+    assert_equal hash[:surface], JSON.parse(JSON.generate(hash))['surface']
+  end
+
+  # to_hash is the canonical name; to_h is the idiomatic alias.
+  def test_token_to_hash_alias
+    token = @tokens[0]
+    assert_equal token.to_h, token.to_hash
+  end
+
   def test_token_inspect
     token = @tokens[0]
     inspect_str = token.inspect


### PR DESCRIPTION
Closes #952. Part of #930. Completes the tracking issue alongside #953 (nodejs) and #954 (wasm).

Additive and non-breaking.

## What

Python, Ruby, and PHP keep their `Token` classes — their finalization is deterministic (pyo3 refcount, magnus `free_immediately`, Zend refcount), so they never had the deferred-finalizer accumulation that made the JS bindings drop theirs. What they lacked was an idiomatic way to get plain data out, which the JS bindings now have for free.

| binding | method | returns |
|---|---|---|
| Python | `to_dict()` | `dict` |
| Ruby | `to_hash`, aliased `to_h` | Symbol-keyed `Hash` |
| PHP | `toArray()` | associative array |

## Types are preserved

Each keeps the fields' natural types instead of stringifying them the way the existing `Metadata` converters do: `int` for the positions and word id, `bool` for `is_unknown`, list/Array/array of string for `details`. A token mixes types, so flattening to strings would lose information the caller has to parse back and would break JSON round-tripping. Each language's test asserts the values, the types, and a round-trip through `json.dumps` / `JSON.generate` / `json_encode` with no custom encoder.

## `JsonSerializable`: documented, not implemented

This was a stretch goal on the issue. ext-php-rs marks class inheritance and interface implementation as **"Not implemented #326"** in its own source (`describe/mod.rs:188-192`) — `ClassBuilder::implements()` exists but no `#[php_class]` attribute reaches it, so it is blocked upstream.

The PHP README now says so explicitly: `Lindera\Token` does not implement `JsonSerializable`, `json_encode($token)` will not produce these fields, use `toArray()` — with a link to the upstream issue. Better than leaving users to discover it by experiment.

## Note on the Ruby implementation

The obvious `RHash::new()` / `Symbol::new()` / `RArray::new()` calls are deprecated in the pinned magnus version and rejected by `clippy -D warnings`. Their replacements live on the `Ruby` handle, but fetching one via `Ruby::get()` yields an error type that doesn't convert to `magnus::Error`, and the existing workaround in this codebase is `.expect(...)` — banned by the project's code conventions.

Declaring the method as `fn to_hash(ruby: &Ruby, rb_self: &Self)` makes magnus pass the handle in, which removes the deprecated functions, the fallible lookup, and the `expect()` in one step. Registration is unchanged.

## Verification

- Python: 10 passed. Ruby: 22 runs, 192 assertions, 0 failures. PHP: 28 tests, 189 assertions, OK.
- `cargo fmt --check` and `clippy -D warnings` clean on all three crates.
- markdownlint clean on the Python and Ruby READMEs (the PHP README has 9 pre-existing table-style errors, confirmed unrelated by linting with this change stashed).