### PR TITLE
docs: correct and complete the v5-to-v6 migration guide

### DIFF
--- a/docs/ja/src/migration_v5_to_v6.md
+++ b/docs/ja/src/migration_v5_to_v6.md
@@ -1,27 +1,64 @@
 # v5 から v6 への移行
 
-Lindera v6.0.0 では、ビルド済み辞書のオンディスクフォーマットが変わり、
-`lindera-dictionary` の一部 Rust API が変わり、さらにトークナイズ結果も
-2 点（Decompose モードの精度修正と、新しいデフォルト有効な未知語機能）で
-変わります。ほとんどのユーザーは辞書の再ビルドまたは再ダウンロードだけで
-済みますが、`lindera_dictionary::viterbi`/`mode` の型を直接使っている場合や、
-未知語（辞書外の文字列）に対する厳密な旧出力に依存している場合は、追加で
-確認すべき点があります。
+Lindera v6.0.0 では、ビルド済みユーザー辞書の再ビルドが必要になり、
+トークナイズ結果が 2 点（Decompose モードの精度修正と、新しいデフォルト
+有効な未知語機能）で変わり、JavaScript バインディングのトークン型が変わり、
+`lindera-dictionary` の一部 Rust API が改名されます。ほとんどのユーザーは
+辞書の再ビルドだけで済みますが、`lindera_dictionary::viterbi`/`mode` の型を
+直接使っている場合、JavaScript を使っている場合、未知語（辞書外の文字列）に
+対する厳密な旧出力に依存している場合は、追加で確認すべき点があります。
+
+**v5.2 以前**からアップグレードする場合は、後述のシステム辞書フォーマット
+変更も対象になります。この変更は v5.3.0 で既にリリース済みのため、v5.3.0
+からのアップグレードではシステム辞書の再ビルドは不要です。ただしユーザー
+辞書の再ビルドは、これとは別の理由で必要です。
 
 ## 概要
 
 | 変更 | 影響範囲 | 対処方法 |
 | --- | --- | --- |
-| ビルド済み辞書フォーマットがバージョン 2 に（`dict.da` → `dict.trie` + `dict.valsidx`） | 自前ビルド辞書 | `lindera build` で再ビルド |
-| `metadata.json` が `format_version` を記録し、不一致はロード時に拒否 | v5 世代のビルド済み辞書を読み込むすべてのユーザー | 再ビルド、または `lindera download` で再取得 |
-| `loadDictionaryFromBytes()` が 9 引数に | バイトデータから辞書を読み込む WASM ユーザー | `dictDa` の代わりに `dictTrie` と `dictValsIdx` を渡す |
-| OPFS の `DictionaryFiles` が `dictDa` を `dictTrie` + `dictValsIdx` に置き換え | `opfs` ヘルパーを使う WASM ユーザー | OPFS にキャッシュ済みの辞書を再ダウンロード |
+| **ビルド済みユーザー辞書 `.bin` が読み込めなくなった** | `.bin` からユーザー辞書を読み込むすべてのユーザー | CSV から `lindera build --user` で再ビルド |
 | Decompose モードの長さペナルティが非 3 バイト文字に対して正確になった | 1・2・4 バイトの UTF-8 文字を含むテキストに対する `Mode::Decompose` の出力 | 対応不要（正確性修正）。出力を厳密に固定している場合は Decompose 出力を再確認 |
 | 未知語の候補ラダー（length ladder）がデフォルトで有効に | 辞書外テキストに対する Normal・Decompose 両モードの出力 | v5 と同一の出力が必要な場合は `unknown_word_ladder(false)` / `--disable-unknown-word-ladder` を設定 |
-| `lindera_dictionary::viterbi`/`mode` の一部項目が改名・削除 | `Lattice`/`Edge`/`Penalty`/`Mode` を直接利用するコード（`lindera` クレートの `Segmenter`/`Tokenizer`/`Worker` API 利用者は対象外） | 下記の表に従い呼び出し箇所を更新 |
+| `max_grouping_len` オプションの新設（`--max-grouping-len`、config キー、builder/worker setter） | MeCab の `max-grouping-size` 相当の上限を使いたいユーザー | 対応不要（デフォルトは従来どおり無制限） |
 | JS バインディングがプレーンオブジェクトを返すようになり `Token` クラスが廃止 | Node.js・WASM ユーザー | `token.getDetail(i)` を `token.details[i]` に置換。WASM ユーザーはフィールド名の camelCase 化にも対応 |
+| `lindera_dictionary::viterbi`/`mode` の一部項目が改名・削除、`Lattice::set_text`/`set_text_nbest` に引数 2 つ追加 | `Lattice`/`Edge`/`Penalty`/`Mode` を直接利用するコード（`lindera` クレートの `Segmenter`/`Tokenizer`/`Worker` API 利用者は対象外） | 下記の表に従い呼び出し箇所を更新 |
+| ビルド済み辞書フォーマットがバージョン 2（`dict.da` → `dict.trie` + `dict.valsidx`）— **v5.3.0 でリリース済み** | **v5.2 以前**で作成した自前ビルドのシステム辞書 | `lindera build` で再ビルド、または `lindera download` で再取得 |
+| `loadDictionaryFromBytes()` が 9 引数 — **v5.3.0 でリリース済み** | **v5.2 以前**からアップグレードする、バイトデータから辞書を読み込む WASM ユーザー | `dictDa` の代わりに `dictTrie` と `dictValsIdx` を渡す |
+| OPFS の `DictionaryFiles` が `dictDa` を `dictTrie` + `dictValsIdx` に置き換え — **v5.3.0 でリリース済み** | **v5.2 以前**からアップグレードする、`opfs` ヘルパーを使う WASM ユーザー | OPFS にキャッシュ済みの辞書を再ダウンロード |
 
-## 辞書フォーマットバージョン 2
+## ビルド済みユーザー辞書の再ビルドが必要
+
+Lindera v6 では `daachorse` を 4.x から 5.0 に更新しており、ユーザー辞書が
+内部に持つ Aho-Corasick オートマトンのシリアライズ形式が変わりました。
+そのため、v5 系でビルドした `.bin` ファイルはロードに失敗します:
+
+```text
+LinderaError(kind=Deserialize, source=InvalidAutomatonError: invalid serialized automaton)
+```
+
+システム辞書と異なり、ユーザー辞書の `.bin` には `format_version` が無いため
+バージョン検査ができず、より親切なメッセージを出せません。上記の
+デシリアライズエラーとして表面化します。
+
+CSV から v6 で再ビルドしてください:
+
+```sh
+lindera build --user \
+  --src ./user_dict.csv \
+  --dest ./build \
+  --metadata ./lindera-ipadic/metadata.json
+```
+
+`.bin` ではなく `.csv` からユーザー辞書を読み込んでいる場合は、ロード時に
+コンパイルされるため対応は不要です。
+
+## 辞書フォーマットバージョン 2（v5.3.0 でリリース済み）
+
+> この変更は v6.0.0 ではなく **v5.3.0** でリリース済みです。v5.3.0 から
+> アップグレードする場合、システム辞書は既にフォーマットバージョン 2 で
+> あり、そのままロードできます。この節は **v5.2 以前**からアップグレード
+> する場合にのみ従ってください。
 
 システム前方一致辞書は、シリアライズされた `daachorse` Aho-Corasick オートマトン
 （`dict.da`）として保存されなくなりました。ビルダはビルド時に `crawdad` で文字単位の
@@ -50,8 +87,8 @@ Lindera v6.0.0 では、ビルド済み辞書のオンディスクフォーマ�
 ### 古い辞書のロードは明確なエラーで失敗する
 
 ビルド済み辞書の `metadata.json` は `format_version: 2` を記録し、ローダーがこれを検証
-します。v5 でビルドした辞書のロードは、ヘッダを持たないバイナリファイルを誤読する
-代わりに、対処方法を含むエラーで失敗します:
+します。v5.2 以前でビルドした辞書のロードは、ヘッダを持たないバイナリファイルを
+誤読する代わりに、対処方法を含むエラーで失敗します:
 
 ```text
 Dictionary 'ipadic' has format version 1, but this build of Lindera reads format version 2. To fix this, rebuild it with `lindera build`, or download a matching prebuilt dictionary with `lindera download`.
@@ -92,8 +129,8 @@ v6.0.0 からは、このラダーがデフォルトで生成されるように�
 トークナイズされるようになります — 例えば、未知の 2 字熟語が従来は 2 つの
 未知語トークンに分かれていたのが、1 つの未知語トークンになります。
 
-これは v5.4 で導入されたラン全体のグルーピング上限オプション
-`max_grouping_len` とは独立した、加算的な機能です。
+これは後述の新オプション `max_grouping_len`（ラン全体のグルーピング上限）
+とは独立した、加算的な機能です。
 
 辞書外の漢字・かな連続を含むテキストで v5 と同一の出力を再現するには、
 ラダーを無効化してください:
@@ -110,6 +147,27 @@ lindera tokenize -d ipadic --disable-unknown-word-ladder input.txt
 `AnalysisWorker`/`SegmentWorker` は `set_unknown_word_ladder(bool)`、
 `TokenizerBuilder` は `set_segmenter_unknown_word_ladder(bool)` で同じ
 切り替えができます。
+
+### 新オプション: `max_grouping_len`（デフォルトは従来どおり）
+
+v6 では MeCab の `max-grouping-size` と同じ意味論を追加しました。辞書外
+文字のグルーピング可能なランが、先頭を除いて `max_grouping_len` 文字を
+超える場合、グループ候補を出さずに 1 文字ずつの未知語を使います。
+デフォルトは無制限で、これは v5 と同じ挙動です。つまり
+**明示的に設定しない限り何も変わりません**:
+
+```rust,ignore
+let segmenter = Segmenter::new(mode, dictionary, None)
+    .max_grouping_len(Some(24)); // MeCab 自体のデフォルト値
+```
+
+```sh
+lindera tokenize -d ipadic --max-grouping-len 24 input.txt
+```
+
+`SegmentWorker`/`AnalysisWorker` の `set_max_grouping_len(Option<usize>)`、
+`TokenizerBuilder` の `set_segmenter_max_grouping_len(usize)`、および
+segmenter 設定の `max_grouping_len` キーでも指定できます。
 
 ## `lindera_dictionary` の Rust API 変更
 
@@ -130,6 +188,14 @@ lindera tokenize -d ipadic --disable-unknown-word-ladder input.txt
 | `Edge::num_chars()` | 削除 | パック済み `Edge` は終了位置を保持しなくなった（常にラティススロットの添字と一致するため）ので、エッジ単体からは計算できなくなった |
 | `Penalty::penalty(&Edge)` | `Penalty::penalty(&Edge, num_chars: usize)` | 呼び出し側が正確な文字数スパンを渡すようになった（前述の Decompose 精度修正を参照） |
 | `Mode::penalty_cost(&Edge)` | 削除 | コードベース内に呼び出し元が無かった。必要であれば `Penalty::penalty` で再実装可能 |
+| `Lattice::set_text(..., search_mode)` | `Lattice::set_text(..., search_mode, max_grouping_len, unknown_word_ladder)` | 新オプション用に引数 2 つが末尾に追加。v6 のデフォルトに合わせるなら `None` と `true`、v5 の挙動にするなら `None` と `false` を渡す。`set_text_nbest` も同様に変更 |
+| — | `Lattice::take_max_char_len()`（新規） | 加算的な追加。処理した最大の文長を返してリセットする（worker の縮小判定用） |
+
+`set_text` と `set_text_nbest` には、文が `u16::MAX` 文字未満であることを
+検査する panic 契約も追加されました（エッジが開始位置を `u16` で保持する
+ようになったため）。`Segmenter` を経由する経路は `MAX_SENTENCE_BYTES` で
+文を分割するためすべて安全です。`Lattice` を直接駆動するコードだけが、
+自分で入力を分割する必要があります。
 
 ## JavaScript バインディング: トークンがプレーンオブジェクトに
 
@@ -173,7 +239,26 @@ const tokens = tokenizer.tokenize(text);
 ```
 
 `tokenizeNbest` もプレーンオブジェクトを返すようになったため、v5 で
-既知の制約として記載していた蓄積の問題は解消されています。
+既知の制約として記載していた蓄積の問題は解消されています。`NbestResult` も
+`Token` と同様にクラスではなくなり、同じ `tokens`・`cost` プロパティを
+持つプレーンオブジェクトになりました。
+
+どちらもクラスではなくなったため、パッケージから export されなくなりました。
+`Token`・`JsToken`・`NbestResult`・`JsNbestResult` はすべて `index.js` から
+削除され、`require("lindera-nodejs").Token` は `undefined` になります。
+`instanceof` による判定もできません:
+
+```javascript
+// v5
+const { Token } = require("lindera-nodejs");
+if (tokens[0] instanceof Token) { /* ... */ }
+
+// v6 — プレーンオブジェクトなので、プロパティで判定する
+if (typeof tokens[0].surface === "string") { /* ... */ }
+```
+
+TypeScript 利用者へ: トークンを表すインターフェース名は `Token` になりました
+（`Token` がクラスに使われていた間は `JsTokenData` という名前でした）。
 
 ### WASM: フィールド名が camelCase に
 
@@ -202,15 +287,23 @@ const data = token.toJSON();
 const data = token; // 既にプレーンオブジェクト
 ```
 
+`Token` はモジュールから export されなくなったため、
+`import { Token } from 'lindera-wasm-...'` は失敗します。代わりに import
+すべきものはありません — `tokenize` が直接プレーンオブジェクトを返します。
+
 WASM の `tokenizeNbest` は v5 の時点で既にプレーンオブジェクトを
 返していたため、変更ありません。
 
 ## 対応が不要なケース
 
-- **ユーザー辞書**: ビルド済みユーザー辞書の `.bin` ファイルは影響を受けません。
-  内部では引き続き `daachorse` オートマトンを使用しており、再ビルドせずにそのまま
-  ロードできます。`.csv` から読み込むユーザー辞書も、従来どおりロード時に
-  コンパイルされます。
+- **Python・Ruby・PHP バインディング**: 上記の JavaScript の変更の影響を
+  受けません。これらは解放が決定的であり、JS 側の作り直しの動機となった
+  メモリ問題が元々無かったため、`Token` クラスをそのまま維持しています。
+  それぞれプレーンデータへの変換メソッド（`to_dict()`、`to_h`（`to_hash`）、
+  `toArray()`）が追加されましたが、削除・改名されたものはありません。
+- **`.csv` から読み込むユーザー辞書**: ロード時にコンパイルされるため、
+  新しいフォーマットが自動的に反映されます。（ビルド済みの `.bin` は
+  再ビルドが**必要**です — 冒頭の節を参照してください。）
 - **`lindera` クレートの公開 API**: `Segmenter`・`Tokenizer`・`SegmentWorker`・
   `AnalysisWorker` のシグネチャは変わっていません（加算的な
   `unknown_word_ladder`/`max_grouping_len` オプションを除く）。パスや URI から
@@ -220,15 +313,34 @@ WASM の `tokenizeNbest` は v5 の時点で既にプレーンオブジェクト
 
 ## アップグレードチェックリスト
 
-- 自前ビルドのシステム辞書を v6 の `lindera build` で再ビルドするか、`lindera
-  download` でビルド済み辞書を再取得する。
-- WASM: `loadDictionaryFromBytes()` の呼び出しを 9 引数のシグネチャに更新する
-  （`dictDa` の代わりに `dictTrie` と `dictValsIdx`）。
-- WASM: v5 世代の辞書を OPFS から削除し、v6 のアーカイブをダウンロードする。
+全員:
+
+- **ビルド済みユーザー辞書 `.bin` を CSV から再ビルドする**
+  （`lindera build --user`）。どの v5 からのアップグレードでも必要です。
 - 辞書外・非日本語テキストに対するトークナイズ結果を厳密に固定している場合は
   再確認する — Decompose ペナルティ修正と未知語ラダー（デフォルト有効）の
   両方が結果を変える可能性がある。v5 と同一の未知語出力が必要なら
   `unknown_word_ladder(false)` を設定する。
-- `lindera_dictionary::viterbi`/`mode` の型を直接利用している場合は、上記の
-  Rust API 表に従い呼び出し箇所を更新する。
-- ユーザー辞書の `.bin` ファイルは対応不要。
+
+JavaScript（Node.js・WASM）:
+
+- `token.getDetail(i)` を `token.details[i]` に置き換える。
+- Node.js: `tokenizeObjects(text)` を `tokenize(text)` に置き換え、
+  `Token`/`NbestResult` の import をやめる（export されなくなったため）。
+  TypeScript 利用者は型名 `JsTokenData` を `Token` に変更する。
+- WASM: トークンのフィールド参照を camelCase に変更し（`byteStart`・
+  `byteEnd`・`wordId`・`isUnknown`）、`toJSON()` の呼び出しを削除し、
+  `Token` の import をやめる。
+
+`lindera_dictionary` を直接利用している場合:
+
+- 上記の Rust API 表に従い呼び出し箇所を更新する（`set_text`/`set_text_nbest`
+  の追加引数 2 つを含む）。
+
+v5.2 以前からアップグレードする場合（以下は v5.3.0 でリリース済み）:
+
+- 自前ビルドのシステム辞書を `lindera build` で再ビルドするか、`lindera
+  download` でビルド済み辞書を再取得する。
+- WASM: `loadDictionaryFromBytes()` の呼び出しを 9 引数のシグネチャに更新する
+  （`dictDa` の代わりに `dictTrie` と `dictValsIdx`）。
+- WASM: v5 世代の辞書を OPFS から削除し、v6 のアーカイブをダウンロードする。

--- a/docs/src/migration_v5_to_v6.md
+++ b/docs/src/migration_v5_to_v6.md
@@ -1,27 +1,64 @@
 # Migrating from v5 to v6
 
-Lindera v6.0.0 changes the on-disk format of built dictionaries, changes a
-few `lindera-dictionary` Rust APIs, and changes tokenization output in two
-targeted ways (a Decompose-mode accuracy fix, and a new default-on
-unknown-word feature). Most users only need to rebuild or re-download their
-dictionaries; direct users of `lindera_dictionary::viterbi`/`mode` types and
-anyone relying on exact legacy output for out-of-vocabulary text have a
-couple of extra things to check.
+Lindera v6.0.0 rebuilds prebuilt user dictionaries, changes tokenization
+output in two targeted ways (a Decompose-mode accuracy fix and a new
+default-on unknown-word feature), reshapes the JavaScript bindings' token
+type, and renames several `lindera-dictionary` Rust APIs. Most users only
+need to rebuild their dictionaries; direct users of
+`lindera_dictionary::viterbi`/`mode` types, JavaScript users, and anyone
+relying on exact legacy output for out-of-vocabulary text have more to check.
+
+If you are upgrading from **v5.2 or earlier**, the system-dictionary format
+change described below applies to you as well. It shipped in v5.3.0, so
+upgrading from v5.3.0 does not require rebuilding system dictionaries — but
+it does require rebuilding user dictionaries, for an unrelated reason.
 
 ## Overview
 
 | Change | Affects | What you do |
 | --- | --- | --- |
-| Built dictionary format is now version 2 (`dict.da` → `dict.trie` + `dict.valsidx`) | Self-built dictionaries | Rebuild with `lindera build` |
-| `metadata.json` records `format_version`; mismatches are refused at load | Anyone loading a v5-era built dictionary | Rebuild, or re-download with `lindera download` |
-| `loadDictionaryFromBytes()` now takes 9 arguments | WASM users loading dictionaries from bytes | Pass `dictTrie` and `dictValsIdx` instead of `dictDa` |
-| OPFS `DictionaryFiles` replaces `dictDa` with `dictTrie` + `dictValsIdx` | WASM users of the `opfs` helpers | Re-download OPFS-cached dictionaries |
+| **Prebuilt user-dictionary `.bin` files no longer load** | Anyone loading a user dictionary from `.bin` | Rebuild from the CSV source with `lindera build --user` |
 | Decompose-mode length penalty is now exact for non-3-byte characters | `Mode::Decompose` output on text with 1-, 2-, or 4-byte UTF-8 characters | Nothing — this is a correctness fix; re-check Decompose output if you pin it exactly |
 | Unknown-word length ladder is on by default | Normal- and Decompose-mode output on out-of-vocabulary text | Set `unknown_word_ladder(false)` / `--disable-unknown-word-ladder` for v5-identical output |
-| Several `lindera_dictionary::viterbi`/`mode` items renamed or removed | Direct users of `Lattice`/`Edge`/`Penalty`/`Mode` (not the `lindera` crate's `Segmenter`/`Tokenizer`/`Worker` API) | Update call sites per the table below |
+| New `max_grouping_len` option (`--max-grouping-len`, config key, builder/worker setters) | Anyone who wants MeCab's `max-grouping-size` cap | Nothing — the default is unchanged (unbounded) |
 | JS bindings return plain objects; the `Token` class is gone | Node.js and WASM users | Replace `token.getDetail(i)` with `token.details[i]`; WASM users also switch to camelCase field names |
+| Several `lindera_dictionary::viterbi`/`mode` items renamed or removed, and `Lattice::set_text`/`set_text_nbest` take two more arguments | Direct users of `Lattice`/`Edge`/`Penalty`/`Mode` (not the `lindera` crate's `Segmenter`/`Tokenizer`/`Worker` API) | Update call sites per the table below |
+| Built dictionary format is version 2 (`dict.da` → `dict.trie` + `dict.valsidx`) — **shipped in v5.3.0** | Self-built system dictionaries created by **v5.2 or earlier** | Rebuild with `lindera build`, or re-download with `lindera download` |
+| `loadDictionaryFromBytes()` takes 9 arguments — **shipped in v5.3.0** | WASM users loading dictionaries from bytes, upgrading from **v5.2 or earlier** | Pass `dictTrie` and `dictValsIdx` instead of `dictDa` |
+| OPFS `DictionaryFiles` replaces `dictDa` with `dictTrie` + `dictValsIdx` — **shipped in v5.3.0** | WASM users of the `opfs` helpers, upgrading from **v5.2 or earlier** | Re-download OPFS-cached dictionaries |
 
-## Dictionary format version 2
+## Prebuilt user dictionaries must be rebuilt
+
+Lindera v6 upgrades `daachorse` from 4.x to 5.0, which changed the serialized
+form of the Aho-Corasick automaton that a user dictionary embeds. A `.bin`
+file built by any v5 release therefore fails to load:
+
+```text
+LinderaError(kind=Deserialize, source=InvalidAutomatonError: invalid serialized automaton)
+```
+
+Unlike system dictionaries, user-dictionary `.bin` files carry no
+`format_version`, so there is no version check to produce a friendlier
+message — the failure surfaces as the deserialize error above.
+
+Rebuild from the CSV source with v6:
+
+```sh
+lindera build --user \
+  --src ./user_dict.csv \
+  --dest ./build \
+  --metadata ./lindera-ipadic/metadata.json
+```
+
+If you load a user dictionary from a `.csv` file rather than a prebuilt
+`.bin`, it is compiled at load time and no action is needed.
+
+## Dictionary format version 2 (shipped in v5.3.0)
+
+> This change shipped in **v5.3.0**, not in v6.0.0. If you are upgrading
+> from v5.3.0 your system dictionaries already use format version 2 and load
+> unchanged. Follow this section only when upgrading from **v5.2 or
+> earlier**.
 
 The system prefix dictionary is no longer stored as a serialized `daachorse`
 Aho-Corasick automaton (`dict.da`). The builder now constructs a char-wise
@@ -51,8 +88,8 @@ All files other than `dict.trie` and `dict.valsidx` are unchanged from v5;
 ### Loading an old dictionary now fails with a clear error
 
 `metadata.json` in a built dictionary records `format_version: 2`, and the
-loader checks it. Loading a dictionary built by v5 fails with an actionable
-error instead of misreading the headerless binary files:
+loader checks it. Loading a dictionary built by v5.2 or earlier fails with an
+actionable error instead of misreading the headerless binary files:
 
 ```text
 Dictionary 'ipadic' has format version 1, but this build of Lindera reads format version 2. To fix this, rebuild it with `lindera build`, or download a matching prebuilt dictionary with `lindera download`.
@@ -93,8 +130,8 @@ characters can now be grouped into multi-character unknown words when that
 scores lower than splitting them one character at a time — for example, an
 unrecognized two-kanji compound is now tokenized as one word instead of two.
 
-This is additive to (and independent of) the `max_grouping_len` option
-introduced in v5.4 for capping whole-run grouping.
+This is additive to (and independent of) `max_grouping_len`, the new option
+described below for capping whole-run grouping.
 
 To reproduce v5-identical output on text containing out-of-vocabulary
 kanji/kana runs, disable the ladder:
@@ -111,6 +148,27 @@ lindera tokenize -d ipadic --disable-unknown-word-ladder input.txt
 `AnalysisWorker`/`SegmentWorker` expose the same toggle via
 `set_unknown_word_ladder(bool)`, and `TokenizerBuilder` via
 `set_segmenter_unknown_word_ladder(bool)`.
+
+### New option: `max_grouping_len` (default unchanged)
+
+v6 adds MeCab's `max-grouping-size` semantics: when a groupable run of
+out-of-vocabulary characters extends more than `max_grouping_len` characters
+beyond the first, the grouped candidate is not emitted and single-character
+unknown words are used instead. The default is unbounded, which is exactly
+what v5 did, so **this changes nothing unless you opt in**:
+
+```rust,ignore
+let segmenter = Segmenter::new(mode, dictionary, None)
+    .max_grouping_len(Some(24)); // MeCab's own default
+```
+
+```sh
+lindera tokenize -d ipadic --max-grouping-len 24 input.txt
+```
+
+Also available as `set_max_grouping_len(Option<usize>)` on
+`SegmentWorker`/`AnalysisWorker`, `set_segmenter_max_grouping_len(usize)` on
+`TokenizerBuilder`, and the `max_grouping_len` key in a segmenter config.
 
 ## Rust API changes in `lindera_dictionary`
 
@@ -130,6 +188,14 @@ options above but no signatures changed.
 | `Edge::num_chars()` | Removed | The packed `Edge` no longer stores its end position (it always equals the lattice slot it lives in), so this can no longer be computed from the edge alone |
 | `Penalty::penalty(&Edge)` | `Penalty::penalty(&Edge, num_chars: usize)` | The caller now passes the exact character span (see the Decompose accuracy fix above) |
 | `Mode::penalty_cost(&Edge)` | Removed | Had no callers in the codebase; re-implement via `Penalty::penalty` if needed |
+| `Lattice::set_text(..., search_mode)` | `Lattice::set_text(..., search_mode, max_grouping_len, unknown_word_ladder)` | Two trailing arguments for the new options; pass `None` and `true` to match v6 defaults, or `None` and `false` for v5 behavior. `set_text_nbest` changed identically |
+| — | `Lattice::take_max_char_len()` (new) | Additive: reports and resets the largest sentence seen, for worker-style shrink accounting |
+
+`set_text` and `set_text_nbest` also gained a documented panic: they assert
+that the sentence is shorter than `u16::MAX` characters, because an edge now
+stores its start position as a `u16`. Every path through `Segmenter` is safe
+because it splits sentences at `MAX_SENTENCE_BYTES`; only code that drives a
+`Lattice` directly needs to split its own input.
 
 ## JavaScript bindings: tokens are plain objects
 
@@ -171,7 +237,26 @@ const tokens = tokenizer.tokenize(text);
 ```
 
 `tokenizeNbest` returns plain objects too, so it no longer has the
-accumulation behavior documented as a known limitation in v5.
+accumulation behavior documented as a known limitation in v5. `NbestResult`
+stopped being a class along with `Token`: it is now a plain object with the
+same `tokens` and `cost` properties.
+
+Because neither is a class any more, they are no longer exported from the
+package. `Token`, `JsToken`, `NbestResult`, and `JsNbestResult` are all gone
+from `index.js`, so `require("lindera-nodejs").Token` is `undefined` and
+`instanceof` checks against them no longer compile or run:
+
+```javascript
+// v5
+const { Token } = require("lindera-nodejs");
+if (tokens[0] instanceof Token) { /* ... */ }
+
+// v6 — the values are plain objects; check a property instead
+if (typeof tokens[0].surface === "string") { /* ... */ }
+```
+
+TypeScript users: the interface describing a token is now called `Token`
+(it was `JsTokenData` while `Token` was taken by the class).
 
 ### WASM: field names are now camelCase
 
@@ -200,15 +285,24 @@ const data = token.toJSON();
 const data = token; // already plain
 ```
 
+`Token` is also no longer exported from the module, so
+`import { Token } from 'lindera-wasm-...'` fails. There is nothing to import
+in its place — `tokenize` hands back plain objects directly.
+
 `tokenizeNbest` in WASM already returned plain objects in v5 and is
 unchanged.
 
 ## Who does not need to act
 
-- **User dictionaries**: prebuilt user-dictionary `.bin` files are not
-  affected. They keep using a `daachorse` automaton internally and continue to
-  load without rebuilding. User dictionaries loaded from `.csv` are compiled
-  at load time as before.
+- **Python, Ruby, and PHP bindings**: unaffected by the JavaScript changes
+  above. They keep their `Token` classes, because their finalization is
+  deterministic and never had the memory problem that motivated the JS
+  rework. They each gained a plain-data conversion method — `to_dict()`,
+  `to_h` (also `to_hash`), and `toArray()` respectively — but nothing was
+  removed or renamed.
+- **User dictionaries loaded from `.csv`**: compiled at load time, so they
+  pick up the new format automatically. (Prebuilt `.bin` files *do* need
+  rebuilding — see the first section.)
 - **`lindera` crate's public API**: `Segmenter`, `Tokenizer`,
   `SegmentWorker`, and `AnalysisWorker` signatures are unchanged (aside from
   the additive `unknown_word_ladder`/`max_grouping_len` options); code that
@@ -219,15 +313,34 @@ unchanged.
 
 ## Upgrade checklist
 
-- Rebuild self-built system dictionaries with the v6 `lindera build`, or
-  re-download prebuilt ones with `lindera download`.
-- WASM: update `loadDictionaryFromBytes()` calls to the 9-argument signature
-  (`dictTrie` and `dictValsIdx` in place of `dictDa`).
-- WASM: remove v5-era dictionaries from OPFS and download v6 archives.
+Everyone:
+
+- **Rebuild prebuilt user-dictionary `.bin` files** from their CSV source
+  with `lindera build --user`. This is required regardless of which v5 you
+  are coming from.
 - If you pin exact tokenization output for out-of-vocabulary or non-Japanese
   text, re-check it — the Decompose penalty fix and the unknown-word ladder
   (default on) can both change it. Set `unknown_word_ladder(false)` if you
   need v5-identical unknown-word output.
-- If you use `lindera_dictionary::viterbi`/`mode` types directly, update
-  call sites per the Rust API table above.
-- Nothing to do for user-dictionary `.bin` files.
+
+JavaScript (Node.js and WASM):
+
+- Replace `token.getDetail(i)` with `token.details[i]`.
+- Node.js: replace `tokenizeObjects(text)` with `tokenize(text)`; stop
+  importing `Token`/`NbestResult` (they are no longer exported); TypeScript
+  users rename the `JsTokenData` type to `Token`.
+- WASM: switch token field reads to camelCase (`byteStart`, `byteEnd`,
+  `wordId`, `isUnknown`), drop `toJSON()` calls, and stop importing `Token`.
+
+Direct `lindera_dictionary` users:
+
+- Update call sites per the Rust API table above, including the two new
+  `set_text`/`set_text_nbest` arguments.
+
+Upgrading from v5.2 or earlier (these shipped in v5.3.0):
+
+- Rebuild self-built system dictionaries with `lindera build`, or re-download
+  prebuilt ones with `lindera download`.
+- WASM: update `loadDictionaryFromBytes()` calls to the 9-argument signature
+  (`dictTrie` and `dictValsIdx` in place of `dictDa`).
+- WASM: remove v5-era dictionaries from OPFS and download v6 archives.


### PR DESCRIPTION
Closes #957.

## Why

An audit of every change in `v5.3.0..HEAD` against the guide found it **wrong in one place, scoped to the wrong release in another, and missing several breaking changes**. The guide already existed (created by #929, extended by #947/#949/#953/#954) — this fixes it before 6.0.0 ships.

## Corrections

### The guide told users the opposite of the truth about user dictionaries

It said prebuilt user-dictionary `.bin` files were "not affected … continue to load without rebuilding", and listed "Nothing to do" for them in the checklist. In fact the daachorse 4→5 bump (#900) changed the serialized automaton format — which is exactly why #940 had to regenerate all five checked-in fixtures.

Verified by loading a pre-#940 fixture against current code:

| file | result |
|---|---|
| `85f912aa^:…/ipadic_simple_userdic.bin` (v5-era, 3,428 B) | `LinderaError(kind=Deserialize, source=InvalidAutomatonError: invalid serialized automaton)` |
| current fixture (68,964 B) | `LOADED OK` |

This is now the guide's **first section**, quoting the real error text so a user who searches for it lands on the fix, and noting that user `.bin` files carry no `format_version` — so unlike a stale system dictionary, there is no friendlier version error. The rebuild instructions follow `migration_v3_to_v4.md`'s equivalent section, with one deliberate difference: that break was silent, this one is a hard error, so the section leads with the error rather than a warning about silence.

### `max_grouping_len` was attributed to a version that never existed

The guide credited it to "v5.4". It landed in #948 and ships in 6.0.0.

### Three sections were scoped to the wrong release

Format version 2, the 9-argument `loadDictionaryFromBytes()`, and the OPFS rename all shipped in the **released v5.3.0** (`git tag --contains 7e93ecb4` → `v5.3.0`). As written, the guide told v5.3.0 users to redo work already done, and its quoted "has format version 1" error cannot occur for them. Now marked as shipped in v5.3.0 and scoped to upgrades from v5.2 or earlier.

## Additions

- **`Lattice::set_text`/`set_text_nbest` take two more arguments** (`max_grouping_len`, `unknown_word_ladder`) and now **assert the sentence is under `u16::MAX` characters** — both breaking for direct callers, neither previously mentioned. Plus the additive `take_max_char_len()`.
- **Node.js**: `NbestResult` is no longer a class either; `Token`, `JsToken`, `NbestResult`, `JsNbestResult` are gone from `index.js` (so `require(...).Token` is `undefined` and `instanceof` breaks — with a before/after example); the TS type `JsTokenData` is now `Token`.
- **WASM**: `Token` is no longer an exported symbol, not merely no longer a class.
- **`max_grouping_len`** gets its own section and an overview row: new option, new `--max-grouping-len` flag, new config key, default unchanged.
- **Python/Ruby/PHP are unaffected** by the JS rework and gained `to_dict()`/`to_h`/`toArray()` — a reader of the JS section otherwise has no way to confirm their binding is safe.

The upgrade checklist is regrouped by audience (everyone / JavaScript / direct `lindera_dictionary` users / upgrading from v5.2 or earlier) so nobody follows steps that do not apply to them.

## Verification

- `markdownlint-cli2` clean on both files.
- EN and JA stay structurally identical: **16 headings, 24 code fences, 33 table rows** each.
- Grepped both for the retired phrases (`v5.4`, "not affected", "Nothing to do for user") — clean.
- Re-read `git log v5.3.0..HEAD` (13 commits) at the end; everything user-visible is covered, and the rest are dev-dependency bumps or internal changes.

## Follow-ups (already filed)

- #958 — reference docs outside the guide that still describe pre-v6 token APIs
- #959 — a real code bug the audit surfaced: `index.d.ts` references an undeclared type, breaking TypeScript consumers