### PR TITLE
fix(nodejs): make the generated index.d.ts type-check

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -411,7 +411,12 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Run Node.js build
+      # `make test-lindera-nodejs` also type-checks the regenerated `index.d.ts` with `tsc`. The
+      # freshness check below only compares the file to a fresh regeneration, so it cannot catch a
+      # file that is internally inconsistent — it reproduces the same broken output. #959 was exactly
+      # that: `NbestResult.tokens` referenced a `JsTokenData` type the file never declared, so every
+      # TypeScript consumer of `tokenizeNbest` failed to compile while CI stayed green.
+      - name: Run Node.js build and type check
         run: |
           make test-lindera-nodejs
 

--- a/Makefile
+++ b/Makefile
@@ -180,9 +180,9 @@ test-lindera-python: setup-venv ## Test lindera-python (Rust unit tests + Python
 	cargo test -p lindera-python --lib
 	cd lindera-python && VIRTUAL_ENV=$(abspath $(PYTHON_VENV_DIR)) $(abspath $(MATURIN)) develop --quiet --features=embed-ipadic,train && $(abspath $(PYTEST)) tests/ -v
 
-test-lindera-nodejs: ## Test lindera-nodejs (Rust unit tests + Node.js test)
+test-lindera-nodejs: ## Test lindera-nodejs (Rust unit tests + Node.js test + generated type check)
 	cargo test -p lindera-nodejs --lib
-	cd lindera-nodejs && npm install --quiet && npx napi build --platform -p lindera-nodejs && npm test
+	cd lindera-nodejs && npm install --quiet && npx napi build --platform -p lindera-nodejs && npm test && npm run test:types
 
 memcheck-lindera-nodejs: ## Check lindera-nodejs releases token memory in synchronous loops
 	cd lindera-nodejs && npm install --quiet && npx napi build --platform -p lindera-nodejs --features embed-ipadic

--- a/lindera-nodejs/index.d.ts
+++ b/lindera-nodejs/index.d.ts
@@ -517,7 +517,7 @@ export interface MetadataOptions {
  */
 export interface NbestResult {
   /** Tokens in this result. */
-  tokens: Array<JsTokenData>
+  tokens: Array<Token>
   /** Total path cost of this tokenization. */
   cost: number
 }

--- a/lindera-nodejs/package.json
+++ b/lindera-nodejs/package.json
@@ -34,7 +34,8 @@
     "build": "napi build --platform --release -p lindera-nodejs",
     "build:debug": "napi build --platform -p lindera-nodejs",
     "artifacts": "napi artifacts",
-    "test": "node --test tests/test_*.js tests/test_*.mjs"
+    "test": "node --test tests/test_*.js tests/test_*.mjs",
+    "test:types": "tsc --noEmit --project types-check/tsconfig.json"
   },
   "files": [
     "index.js",
@@ -63,6 +64,7 @@
     "napi"
   ],
   "devDependencies": {
-    "@napi-rs/cli": "^3.6.0"
+    "@napi-rs/cli": "^3.6.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/lindera-nodejs/src/token.rs
+++ b/lindera-nodejs/src/token.rs
@@ -11,10 +11,10 @@
 /// N-best tokenization result.
 ///
 /// Contains a list of tokens and their total path cost.
-#[napi(object, js_name = "NbestResult")]
-pub struct JsNbestResult {
+#[napi(object)]
+pub struct NbestResult {
     /// Tokens in this result.
-    pub tokens: Vec<JsTokenData>,
+    pub tokens: Vec<Token>,
     /// Total path cost of this tokenization.
     pub cost: i64,
 }
@@ -23,8 +23,8 @@ pub struct JsNbestResult {
 ///
 /// Represents a single token from morphological analysis with its surface
 /// form, position information, and morphological details.
-#[napi(object, js_name = "Token")]
-pub struct JsTokenData {
+#[napi(object)]
+pub struct Token {
     /// Surface form of the token.
     pub surface: String,
     /// Start byte position in the original text.
@@ -41,8 +41,8 @@ pub struct JsTokenData {
     pub details: Vec<String>,
 }
 
-impl JsTokenData {
-    /// Creates a JsTokenData from a binding-core `TokenView`.
+impl Token {
+    /// Creates a Token from a binding-core `TokenView`.
     ///
     /// # Arguments
     ///
@@ -50,7 +50,7 @@ impl JsTokenData {
     ///
     /// # Returns
     ///
-    /// A new JsTokenData instance.
+    /// A new Token instance.
     pub fn from_view(view: lindera_binding_core::TokenView) -> Self {
         Self {
             surface: view.surface,

--- a/lindera-nodejs/src/tokenizer.rs
+++ b/lindera-nodejs/src/tokenizer.rs
@@ -11,7 +11,7 @@ use lindera_binding_core::{CoreTokenizer, CoreTokenizerBuilder};
 
 use crate::dictionary::{JsDictionary, JsUserDictionary};
 use crate::error::to_napi_error;
-use crate::token::{JsNbestResult, JsTokenData};
+use crate::token::{NbestResult, Token};
 use crate::util::js_value_to_serde_value;
 
 /// Builder for creating a Tokenizer with custom configuration.
@@ -183,9 +183,9 @@ impl JsTokenizer {
     /// An array of token objects containing morphological features, in
     /// reading order.
     #[napi]
-    pub fn tokenize(&self, text: String) -> napi::Result<Vec<JsTokenData>> {
+    pub fn tokenize(&self, text: String) -> napi::Result<Vec<Token>> {
         let views = self.inner.tokenize(&text).map_err(to_napi_error)?;
-        Ok(views.into_iter().map(JsTokenData::from_view).collect())
+        Ok(views.into_iter().map(Token::from_view).collect())
     }
 
     /// Tokenizes the given text and returns only the token surfaces.
@@ -227,16 +227,16 @@ impl JsTokenizer {
         n: u32,
         unique: Option<bool>,
         cost_threshold: Option<i64>,
-    ) -> napi::Result<Vec<JsNbestResult>> {
+    ) -> napi::Result<Vec<NbestResult>> {
         let results = self
             .inner
             .tokenize_nbest(&text, n as usize, unique.unwrap_or(false), cost_threshold)
             .map_err(to_napi_error)?;
 
-        let js_results: Vec<JsNbestResult> = results
+        let js_results: Vec<NbestResult> = results
             .into_iter()
-            .map(|(views, cost)| JsNbestResult {
-                tokens: views.into_iter().map(JsTokenData::from_view).collect(),
+            .map(|(views, cost)| NbestResult {
+                tokens: views.into_iter().map(Token::from_view).collect(),
                 cost,
             })
             .collect();

--- a/lindera-nodejs/types-check/index.ts
+++ b/lindera-nodejs/types-check/index.ts
@@ -1,0 +1,50 @@
+// Type-level regression guard for the generated `index.d.ts`.
+//
+// `napi build` regenerates `index.d.ts`, and CI already fails if the committed
+// copy is stale. That check compares the file against a fresh regeneration, so
+// it cannot catch a file that is internally inconsistent — it happily
+// reproduces the same broken output. #959 was exactly that: `NbestResult.tokens`
+// referenced a `JsTokenData` type the file never declared, so every TypeScript
+// consumer of `tokenizeNbest` failed to compile while CI stayed green.
+//
+// Compiling this file with `tsc --noEmit` fails if any type the public API
+// exposes does not resolve. It is never executed; only type-checked.
+
+import {
+  loadDictionary,
+  Tokenizer,
+  type Token,
+  type NbestResult,
+} from "../index.js";
+
+export function checkTokenShape(text: string): void {
+  const dictionary = loadDictionary("embedded://ipadic");
+  const tokenizer = new Tokenizer(dictionary, "normal");
+
+  // `tokenize` yields plain token objects (#953).
+  const tokens: Array<Token> = tokenizer.tokenize(text);
+  const token: Token = tokens[0];
+
+  const surface: string = token.surface;
+  const byteStart: number = token.byteStart;
+  const byteEnd: number = token.byteEnd;
+  const position: number = token.position;
+  const wordId: number = token.wordId;
+  const isUnknown: boolean = token.isUnknown;
+  const details: Array<string> = token.details;
+
+  void [surface, byteStart, byteEnd, position, wordId, isUnknown, details];
+
+  // The surfaces fast path.
+  const surfaces: Array<string> = tokenizer.tokenizeSurfaces(text);
+  void surfaces;
+
+  // `tokenizeNbest` is the API that #959 broke: its result type referenced an
+  // undeclared type, so naming `NbestResult` here is the actual regression
+  // guard.
+  const nbest: Array<NbestResult> = tokenizer.tokenizeNbest(text, 3);
+  const nbestTokens: Array<Token> = nbest[0].tokens;
+  const cost: number = nbest[0].cost;
+
+  void [nbestTokens, cost];
+}

--- a/lindera-nodejs/types-check/tsconfig.json
+++ b/lindera-nodejs/types-check/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "types": [],
+    "skipLibCheck": false
+  },
+  "include": ["index.ts", "../index.d.ts"]
+}


### PR DESCRIPTION
## Summary

`lindera-nodejs/index.d.ts` referenced a type it never declared, so any TypeScript consumer of `tokenizeNbest` failed to compile:

```text
index.d.ts(520,17): error TS2304: Cannot find name 'JsTokenData'.
```

**No published package is affected.** The defect landed in #953, after `v5.3.0` (`git tag --contains 91cef4a4` is empty), so it only ever existed on `main` and is fixed before the v6.0.0 release. JavaScript consumers were never affected — this is a type-declaration-only failure.

## Cause

```rust
#[napi(object, js_name = "Token")]
pub struct JsTokenData { ... }
```

`js_name` renames only the **emitted interface**. Type names appearing as *fields of other types* are rendered from the Rust struct name, so `NbestResult.tokens` kept `Array<JsTokenData>` while the declaration was emitted as `Token`.

## Fix

Rename the Rust structs to `Token` / `NbestResult` and drop the now-redundant `js_name`, so the emitted field type and interface name agree by construction rather than by coincidence. There is no collision with `lindera::token::Token` — `src/token.rs` imports only `lindera_binding_core::TokenView`.

Runtime behaviour is unchanged; the only `.d.ts` delta is `Array<JsTokenData>` → `Array<Token>`.

## Regression guard

The existing "Verify generated entry points are up to date" step runs `git diff --exit-code -- index.js index.d.ts`, which asserts only that the committed file matches a fresh regeneration. This defect regenerates identically, so that check is green by construction — **a self-inconsistent file is undetectable by it in principle**. "Is the generated file current?" and "is the generated file valid?" are different properties.

This PR adds `lindera-nodejs/types-check/`: a fixture that names every shape of the public API at the type level (never executed, only type-checked) plus a `tsconfig.json` with `skipLibCheck: false` — with `skipLibCheck: true` the contents of `index.d.ts` are not checked at all, defeating the purpose. It runs via `npm run test:types`, appended to `make test-lindera-nodejs`, so both CI and local development get the guard from the same command. `types-check/` is not in the `files` allowlist, so it stays out of the published tarball.

`typescript` was only a transitive dependency of `@napi-rs/cli`; it is now a direct `devDependency`.

## Verification

- **The guard was confirmed to fail against the pre-fix file.** `git show afe1c0e2:lindera-nodejs/index.d.ts` restored in place → `tsc --noEmit` exits 2 with `TS2304`; with the fix → exits 0. A guard never observed failing is a guard that only ever passes (same principle as the memory checks in #930).
- `index.d.ts` now has zero `JsTokenData` references.
- `cargo check -p lindera-nodejs --features embed-ipadic` clean.
- `npm test` — 27/27 pass.
- CI freshness equivalent: regenerated without `embed-ipadic`, output identical to the committed file.
- `cargo fmt --all -- --check`, `prettier --check` pass.

Closes #959
