### PR TITLE
perf(dictionary): presize the token detail vectors

### DIFF
--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -29,7 +29,7 @@ use crate::loader::connection_cost_matrix::ConnectionCostMatrixLoader;
 use crate::loader::metadata::MetadataLoader;
 use crate::loader::prefix_dictionary::PrefixDictionaryLoader;
 use crate::loader::unknown_dictionary::UnknownDictionaryLoader;
-use crate::util::Data;
+use crate::util::{Data, detail_field_count};
 use crate::viterbi::WordEntry;
 
 pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec!["UNK"]);
@@ -68,21 +68,24 @@ impl Dictionary {
         .try_into()
         {
             Ok(value) => value,
-            Err(_) => return UNK.to_vec(), // return empty vector if conversion fails
+            Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
         };
         let data = &self.prefix_dictionary.words_data[idx..];
         let joined_details_len: usize = match LittleEndian::read_u32(data).try_into() {
             Ok(value) => value,
-            Err(_) => return UNK.to_vec(), // return empty vector if conversion fails
+            Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
         };
         let joined_details_bytes: &[u8] =
             &self.prefix_dictionary.words_data[idx + 4..idx + 4 + joined_details_len];
 
-        let mut details = Vec::new();
+        // Size the vector from the separator count so the pushes below never
+        // reallocate; growing from capacity zero cost two reallocations per
+        // token for a 9-field dictionary (#966).
+        let mut details = Vec::with_capacity(detail_field_count(joined_details_bytes));
         for bytes in joined_details_bytes.split(|&b| b == 0) {
             let detail = match str::from_utf8(bytes) {
                 Ok(s) => s,
-                Err(_) => return UNK.to_vec(), // return empty vector if conversion fails
+                Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
             };
             details.push(detail);
         }
@@ -246,7 +249,7 @@ impl UserDictionary {
 
     pub fn word_details(&self, word_id: usize) -> Vec<&str> {
         if 4 * word_id >= self.dict.words_idx_data.len() {
-            return UNK.to_vec(); // return empty vector if conversion fails
+            return UNK.to_vec(); // fall back to the UNK sentinel for an out-of-range word id
         }
         let idx = LittleEndian::read_u32(&self.dict.words_idx_data[4 * word_id..][..4]);
         let data = &self.dict.words_data[idx as usize..];
@@ -254,19 +257,101 @@ impl UserDictionary {
         // Parse the data in the same format as main Dictionary
         let joined_details_len: usize = match LittleEndian::read_u32(data).try_into() {
             Ok(value) => value,
-            Err(_) => return UNK.to_vec(), // return empty vector if conversion fails
+            Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
         };
         let joined_details_bytes: &[u8] =
             &self.dict.words_data[idx as usize + 4..idx as usize + 4 + joined_details_len];
 
-        let mut details = Vec::new();
+        // Presized from the separator count; see `Dictionary::word_details` (#966).
+        let mut details = Vec::with_capacity(detail_field_count(joined_details_bytes));
         for bytes in joined_details_bytes.split(|&b| b == 0) {
             let detail = match str::from_utf8(bytes) {
                 Ok(s) => s,
-                Err(_) => return UNK.to_vec(), // return empty vector if conversion fails
+                Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
             };
             details.push(detail);
         }
         details
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use daachorse::DoubleArrayAhoCorasickBuilder;
+
+    use super::{UNK, UserDictionary};
+    use crate::dictionary::prefix_dictionary::UserPrefixDictionary;
+
+    /// Builds a user dictionary whose words blob holds `entries`, each
+    /// encoded as a 4-byte LE length followed by its NUL-joined fields --
+    /// the layout `builder::user_dictionary` writes.
+    fn user_dictionary(entries: &[&[&str]]) -> UserDictionary {
+        let mut words_idx_data = Vec::new();
+        let mut words_data = Vec::new();
+        for fields in entries {
+            words_idx_data.extend_from_slice(&(words_data.len() as u32).to_le_bytes());
+            let joined = fields.join("\0");
+            words_data.extend_from_slice(&(joined.len() as u32).to_le_bytes());
+            words_data.extend_from_slice(joined.as_bytes());
+        }
+        // The automaton is irrelevant to `word_details`, but the type needs a
+        // real one; a single dummy key keeps the build valid.
+        let da = match DoubleArrayAhoCorasickBuilder::new().build_with_values([("x", 0u32)]) {
+            Ok(da) => da,
+            Err(err) => panic!("failed to build test automaton: {err}"),
+        };
+        UserDictionary {
+            dict: UserPrefixDictionary {
+                da,
+                vals_data: Vec::new().into(),
+                words_idx_data: words_idx_data.into(),
+                words_data: words_data.into(),
+                is_system: false,
+            },
+        }
+    }
+
+    /// Fields come back in order with the exact count that was written.
+    #[test]
+    fn user_word_details_returns_fields_in_order() {
+        let dict = user_dictionary(&[&["カスタム名詞", "*", "リンデラ"], &["動詞", "自立", "*"]]);
+
+        assert_eq!(dict.word_details(0), vec!["カスタム名詞", "*", "リンデラ"]);
+        assert_eq!(dict.word_details(1), vec!["動詞", "自立", "*"]);
+    }
+
+    /// A single-field entry has no separator, so the capacity must still be 1.
+    #[test]
+    fn user_word_details_handles_single_field() {
+        let dict = user_dictionary(&[&["ONLY"]]);
+        assert_eq!(dict.word_details(0), vec!["ONLY"]);
+    }
+
+    /// Empty fields are preserved rather than collapsed.
+    #[test]
+    fn user_word_details_preserves_empty_fields() {
+        let dict = user_dictionary(&[&["", "a", "", "b", ""]]);
+        assert_eq!(dict.word_details(0), vec!["", "a", "", "b", ""]);
+    }
+
+    /// Out-of-range ids fall back to the `UNK` sentinel -- note this differs
+    /// from `Dictionary::word_details`, which returns an empty vector.
+    #[test]
+    fn user_word_details_out_of_range_returns_unk() {
+        let dict = user_dictionary(&[&["名詞", "一般"]]);
+        assert_eq!(dict.word_details(1), UNK.to_vec());
+        assert_eq!(dict.word_details(usize::MAX / 4), UNK.to_vec());
+    }
+
+    /// Invalid UTF-8 falls back to the `UNK` sentinel rather than panicking.
+    #[test]
+    fn user_word_details_invalid_utf8_returns_unk() {
+        let mut dict = user_dictionary(&[&["ok", "fields"]]);
+        let words_data: &[u8] = &dict.dict.words_data;
+        let mut bytes = words_data.to_vec();
+        let last = bytes.len() - 1;
+        bytes[last] = 0xff;
+        dict.dict.words_data = bytes.into();
+        assert_eq!(dict.word_details(0), UNK.to_vec());
     }
 }

--- a/lindera-dictionary/src/dictionary/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/unknown_dictionary.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::LinderaResult;
 use crate::dictionary::character_definition::CategoryId;
 use crate::error::LinderaErrorKind;
+use crate::util::detail_field_count;
 use crate::viterbi::WordEntry;
 
 #[derive(Serialize, Deserialize, Clone, Archive, RkyvSerialize, RkyvDeserialize)]
@@ -53,7 +54,12 @@ impl UnknownDictionary {
             return None;
         }
         let text = std::str::from_utf8(&self.words_data[offset + 4..offset + 4 + len]).ok()?;
-        Some(text.split('\0').collect())
+        // `str::Split` reports a `(0, None)` size hint, so `collect()` would
+        // grow this vector from capacity zero. Size it from the separator
+        // count instead (#966).
+        let mut details = Vec::with_capacity(detail_field_count(text.as_bytes()));
+        details.extend(text.split('\0'));
+        Some(details)
     }
 
     /// Unknown word generation with callback system
@@ -320,4 +326,102 @@ pub fn parse_unk(
         words_idx_data,
         words_data,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UnknownDictionary;
+
+    /// Builds a dictionary whose `words_data` holds `entries`, each encoded
+    /// as a 4-byte LE length followed by its NUL-joined fields -- the layout
+    /// `unknown_dictionary_from_reader` writes.
+    fn with_entries(entries: &[&[&str]]) -> UnknownDictionary {
+        let mut words_idx_data = Vec::new();
+        let mut words_data = Vec::new();
+        for fields in entries {
+            words_idx_data.push(words_data.len() as u32);
+            let joined = fields.join("\0");
+            words_data.extend_from_slice(&(joined.len() as u32).to_le_bytes());
+            words_data.extend_from_slice(joined.as_bytes());
+        }
+        UnknownDictionary {
+            category_references: Vec::new(),
+            costs: Vec::new(),
+            words_idx_data,
+            words_data,
+        }
+    }
+
+    /// Fields come back in order, with the exact count that was written --
+    /// the property the presized vector must not disturb.
+    #[test]
+    fn word_details_returns_fields_in_order() {
+        let dict = with_entries(&[
+            &["名詞", "一般", "*", "*", "*", "*", "*"],
+            &["記号", "一般", "*", "*", "*", "*", "*"],
+        ]);
+
+        assert_eq!(
+            dict.word_details(0),
+            Some(vec!["名詞", "一般", "*", "*", "*", "*", "*"])
+        );
+        assert_eq!(
+            dict.word_details(1),
+            Some(vec!["記号", "一般", "*", "*", "*", "*", "*"])
+        );
+    }
+
+    /// A single-field entry has no separator at all, so the capacity must
+    /// still be 1 rather than 0.
+    #[test]
+    fn word_details_handles_single_field() {
+        let dict = with_entries(&[&["ONLY"]]);
+        assert_eq!(dict.word_details(0), Some(vec!["ONLY"]));
+    }
+
+    /// Empty fields are preserved rather than collapsed, including a leading
+    /// and a trailing one.
+    #[test]
+    fn word_details_preserves_empty_fields() {
+        let dict = with_entries(&[&["", "a", "", "b", ""]]);
+        assert_eq!(dict.word_details(0), Some(vec!["", "a", "", "b", ""]));
+    }
+
+    /// An entry with no bytes at all still yields one empty field, matching
+    /// `str::split`.
+    #[test]
+    fn word_details_empty_entry_yields_one_empty_field() {
+        let dict = with_entries(&[&[]]);
+        assert_eq!(dict.word_details(0), Some(vec![""]));
+    }
+
+    /// Out-of-range ids return `None` (the caller maps this to `UNK`).
+    #[test]
+    fn word_details_out_of_range_returns_none() {
+        let dict = with_entries(&[&["名詞", "一般"]]);
+        assert_eq!(dict.word_details(1), None);
+        assert_eq!(dict.word_details(u32::MAX), None);
+    }
+
+    /// Invalid UTF-8 in the blob returns `None` rather than panicking.
+    #[test]
+    fn word_details_invalid_utf8_returns_none() {
+        let mut dict = with_entries(&[&["ok"]]);
+        // Overwrite the payload (after the 4-byte length) with a lone
+        // continuation byte, which is never valid UTF-8.
+        let payload = dict.words_data.len() - 2;
+        dict.words_data[payload] = 0xff;
+        assert_eq!(dict.word_details(0), None);
+    }
+
+    /// A declared length running past the buffer returns `None`.
+    #[test]
+    fn word_details_truncated_entry_returns_none() {
+        let mut dict = with_entries(&[&["名詞", "一般"]]);
+        // Past the end of the blob, but small enough that `offset + 4 + len`
+        // cannot overflow a 32-bit `usize` (the crate builds for wasm32).
+        let past_end = (dict.words_data.len() + 1) as u32;
+        dict.words_data[0..4].copy_from_slice(&past_end.to_le_bytes());
+        assert_eq!(dict.word_details(0), None);
+    }
 }

--- a/lindera-dictionary/src/util.rs
+++ b/lindera-dictionary/src/util.rs
@@ -15,6 +15,27 @@ use crate::error::LinderaErrorKind;
 
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
+/// Counts the fields a NUL-joined detail blob splits into.
+///
+/// The dictionary builder joins a row's detail fields with `"\0"` and writes
+/// no trailing separator, so the field count is exactly one more than the
+/// number of NUL bytes. Callers use this to size their detail vectors up
+/// front instead of letting them grow from capacity zero, which cost two
+/// reallocations per token for a 9-field dictionary (#966).
+///
+/// # 引数
+///
+/// * `joined_details` - The NUL-joined detail blob.
+///
+/// # 戻り値
+///
+/// The number of fields, always at least 1 (an empty blob splits into a
+/// single empty field, matching `slice::split`).
+#[inline]
+pub(crate) fn detail_field_count(joined_details: &[u8]) -> usize {
+    memchr::memchr_iter(0, joined_details).count() + 1
+}
+
 /// Write data directly to the writer.
 pub fn write_data<W: Write>(buffer: &[u8], writer: &mut W) -> LinderaResult<()> {
     writer.write_all(buffer).map_err(|err| {
@@ -167,5 +188,46 @@ impl<'de> Deserialize<'de> for Data {
     {
         let v = <Vec<u8> as serde::Deserialize>::deserialize(deserializer)?;
         Ok(Data::Vec(v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detail_field_count;
+
+    /// The count must match what `slice::split` actually yields, which is the
+    /// invariant the presized detail vectors rely on.
+    #[test]
+    fn detail_field_count_matches_split() {
+        for blob in [
+            &b""[..],
+            &b"a"[..],
+            &b"a\0b"[..],
+            &b"\0"[..],
+            &b"\0\0"[..],
+            &b"a\0\0b"[..],
+            &b"NOUN\0general\0*\0*\0*\0*\0base\0reading\0pron"[..],
+        ] {
+            assert_eq!(
+                detail_field_count(blob),
+                blob.split(|&b| b == 0).count(),
+                "blob {blob:?}"
+            );
+        }
+    }
+
+    /// An empty blob still splits into one (empty) field, so the count is
+    /// never zero -- a zero capacity would reintroduce the growth this
+    /// helper exists to avoid.
+    #[test]
+    fn detail_field_count_is_never_zero() {
+        assert_eq!(detail_field_count(b""), 1);
+    }
+
+    /// The IPADIC shape: 9 fields joined by 8 separators.
+    #[test]
+    fn detail_field_count_ipadic_shape() {
+        let blob = b"\xe5\x90\x8d\xe8\xa9\x9e\0*\0*\0*\0*\0*\0a\0b\0c";
+        assert_eq!(detail_field_count(blob), 9);
     }
 }

--- a/lindera/src/token.rs
+++ b/lindera/src/token.rs
@@ -172,8 +172,6 @@ impl<'a> Token<'a> {
                 }
             };
 
-            let mut details: Vec<Cow<'a, str>> = tmp.into_iter().map(Cow::Borrowed).collect();
-
             // Pad details to match the dictionary schema's custom field count so that
             // token filters can safely access any field by index.
             let expected_len = self
@@ -182,6 +180,12 @@ impl<'a> Token<'a> {
                 .dictionary_schema
                 .get_custom_fields()
                 .len();
+
+            // Reserve for the padded length up front: collecting first and
+            // resizing afterwards allocated twice whenever the entry carried
+            // fewer fields than the schema (#966).
+            let mut details: Vec<Cow<'a, str>> = Vec::with_capacity(tmp.len().max(expected_len));
+            details.extend(tmp.into_iter().map(Cow::Borrowed));
             if details.len() < expected_len {
                 details.resize(expected_len, Cow::Borrowed("*"));
             }
@@ -348,6 +352,131 @@ mod tests {
 
     use crate::dictionary::load_dictionary;
     use crate::segmenter::Segmenter;
+
+    /// `Dictionary::word_details` must return every field the entry carries,
+    /// in schema order, for a real dictionary. IPADIC's schema is 13 fields
+    /// (4 common + 9 custom), so a system entry yields exactly 9 details --
+    /// the shape the presized vector in `word_details` depends on (#966).
+    #[test]
+    fn test_word_details_field_count_and_order() {
+        let dictionary = match load_dictionary("embedded://ipadic") {
+            Ok(dictionary) => dictionary,
+            Err(err) => panic!("failed to load embedded IPADIC: {err}"),
+        };
+        let expected_len = dictionary
+            .metadata
+            .dictionary_schema
+            .get_custom_fields()
+            .len();
+        assert_eq!(
+            expected_len, 9,
+            "IPADIC is expected to carry 9 custom fields"
+        );
+
+        let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+        let tokens = match segmenter.segment(Cow::Borrowed("東京都に住む")) {
+            Ok(tokens) => tokens,
+            Err(err) => panic!("segment failed: {err}"),
+        };
+        assert!(!tokens.is_empty());
+
+        for token in &tokens {
+            if !token.word_id.is_system() || token.word_id.id() == u32::MAX {
+                continue;
+            }
+            let details = token.dictionary.word_details(token.word_id.id() as usize);
+            assert_eq!(
+                details.len(),
+                expected_len,
+                "surface {:?} yielded {details:?}",
+                token.surface
+            );
+            // The first field is the major POS, never empty for a system entry.
+            assert!(!details[0].is_empty(), "surface {:?}", token.surface);
+        }
+    }
+
+    /// An out-of-range system word id yields an empty vector, while the user
+    /// dictionary's accessor falls back to the `UNK` sentinel. The two
+    /// fallbacks differ and both are load-bearing, so pin them here.
+    #[test]
+    fn test_word_details_out_of_range_returns_empty() {
+        let dictionary = match load_dictionary("embedded://ipadic") {
+            Ok(dictionary) => dictionary,
+            Err(err) => panic!("failed to load embedded IPADIC: {err}"),
+        };
+        assert!(dictionary.word_details(usize::MAX / 4).is_empty());
+    }
+
+    /// A user-dictionary entry declares only `surface, part_of_speech,
+    /// reading` (IPADIC's `user_dictionary_schema`), but the builder already
+    /// expands it onto the system schema's field positions, padding the rest
+    /// with `*`. So its details come back at the full custom-field width,
+    /// with the POS at index 0 and the reading at index 7 -- the positions
+    /// `part_of_speech` and `reading` occupy in the system schema. Pin that
+    /// here: `set_detail` indexes this vector directly, so any narrowing
+    /// would panic downstream (#966).
+    #[test]
+    fn test_user_dictionary_details_match_system_schema_positions() {
+        use std::path::PathBuf;
+
+        let userdic_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../resources")
+            .join("user_dict")
+            .join("ipadic_simple_userdic.csv");
+
+        let config = serde_json::json!({
+            "dictionary": "embedded://ipadic",
+            "user_dictionary": userdic_file.to_str().unwrap(),
+            "mode": "normal"
+        });
+
+        let segmenter = match Segmenter::from_config(&config) {
+            Ok(segmenter) => segmenter,
+            Err(err) => panic!("failed to build segmenter: {err}"),
+        };
+        let expected_len = segmenter
+            .dictionary
+            .metadata
+            .dictionary_schema
+            .get_custom_fields()
+            .len();
+
+        let tokens = match segmenter.segment(Cow::Borrowed("東京スカイツリーの近く")) {
+            Ok(tokens) => tokens,
+            Err(err) => panic!("segment failed: {err}"),
+        };
+
+        let mut saw_user_token = false;
+        for mut token in tokens {
+            if token.word_id.is_system() || token.word_id.is_unknown() {
+                continue;
+            }
+            saw_user_token = true;
+            let surface = token.surface.to_string();
+            let details = token.details();
+            assert_eq!(
+                details.len(),
+                expected_len,
+                "user token {surface:?} yielded {details:?}"
+            );
+            // `part_of_speech` is custom field 0, `reading` is custom field 7.
+            assert_eq!(details[0], "カスタム名詞", "{details:?}");
+            assert_eq!(details[7], "トウキョウスカイツリー", "{details:?}");
+            // Every position the user schema does not declare is filled with "*".
+            assert!(
+                details[1..7]
+                    .iter()
+                    .chain(details[8..].iter())
+                    .all(|d| *d == "*"),
+                "{details:?}"
+            );
+        }
+        assert!(
+            saw_user_token,
+            "expected at least one user-dictionary token"
+        );
+    }
 
     /// `details_iter` must yield exactly the same fields, in the same
     /// order, as the `Vec`-collecting `details()` accessor, for both known


### PR DESCRIPTION
## Background

Refs #966 — this is **step (a)** of that issue: presizing the detail vectors, with no
public API change. Step (b) (removing the intermediate `Vec<&str>` entirely, which needs
an additive API) is deliberately left out; see *Out of scope* below.

Materializing a token's dictionary details allocated **four vectors per token** on IPADIC,
none of which was required by the data layout. Every one of them started at capacity 0
even though the exact final length is cheaply computable: the builder joins a row's detail
fields with `"\0"` and writes no trailing separator, so the field count is exactly one more
than the number of NUL bytes.

## Changes

**New helper** — `lindera-dictionary/src/util.rs`:

```rust
#[inline]
pub(crate) fn detail_field_count(joined_details: &[u8]) -> usize {
    memchr::memchr_iter(0, joined_details).count() + 1
}
```

`memchr` was already a dependency of `lindera-dictionary`, so this adds none.

**Presized accessors:**

| Function | Before | After |
| --- | --- | --- |
| `Dictionary::word_details` | `Vec::new()` + push | `Vec::with_capacity(detail_field_count(..))` + push |
| `UserDictionary::word_details` | same | same |
| `UnknownDictionary::word_details` | `Some(text.split('\0').collect())` | presized `Vec` + `extend` |

The `UnknownDictionary` case was missed in the original issue write-up: `str::Split`
reports a `(0, None)` size hint (it is not `TrustedLen`), so its `collect()` grew from
capacity 0 exactly like the other two.

**`Token::ensure_details`** — the schema custom-field count is hoisted above the vector
construction, and `collect()` becomes `Vec::with_capacity(tmp.len().max(expected_len))` +
`extend`. This also removes the reallocation that the trailing `resize` padding caused for
entries shorter than the schema.

Capacity is derived from the **NUL count, not the schema length**: `UserDictionary` carries
no schema, and the field count is per-CSV-row (`row.iter().skip(4)`), so only the separator
count is exact at all three sites.

Stale `// return empty vector if conversion fails` comments on the `UNK` branches are
corrected — those branches return the `UNK` sentinel, not an empty vector.

## Measurements

Deterministic global-allocator counter hooking `alloc`, `alloc_zeroed` **and `realloc`**
(two of the three growth events are reallocs, so a counter that only hooks `alloc` would
not reproduce these numbers). Same probe, same workload, same machine on both sides; the
baseline side was built from this branch's merge-base sources.

**IPADIC** (9 custom fields, 51 tokens × 1000 iterations):

| Workload | Before | After |
| --- | ---: | ---: |
| `segment()` only | 1.00 | 1.00 |
| `segment()` + `details()` | 6.00 | **4.00** |
| `segment()` + `details_iter()` | 5.00 | **3.00** |

**ko-dic** (8 custom fields, 26 tokens × 1000 iterations):

| Workload | Before | After |
| --- | ---: | ---: |
| `segment()` only | 3.50 | 3.50 |
| `segment()` + `details()` | 7.50 | **6.50** |
| `segment()` + `details_iter()` | 6.50 | **5.50** |

The differing delta is the expected one, not noise: nine pushes grew `0 -> 4 -> 8 -> 16`
(three allocations, now one), eight grew `0 -> 4 -> 8` (two, now one).

### No wall-clock claim

**This PR claims removed allocations, not a speedup.** The measurement machine was heavily
loaded (load average 45 on 8 cores) — the unmodified `segment()`-only case alone varied
several-fold between runs there, so any timing taken would have been meaningless. Any
performance figure for this change must come from the interleaved min-of-N protocol in
`scripts/benchmarks/README.md` (two worktrees, `--verify` correctness gate, null-pair test,
min of round minima). A within-noise result would be an acceptable outcome; PR #841 is the
precedent for the same class of change.

## Behavior preservation

- IPADIC golden snapshots pass byte-for-byte: normal, decompose, nbest, and
  user-dictionary segmentation.
- The divergent fallbacks are preserved exactly: `Dictionary::word_details` returns a bare
  empty vector for an out-of-range word id but the `UNK` sentinel on conversion / UTF-8
  failure; `UserDictionary::word_details` returns `UNK` for out-of-range;
  `UnknownDictionary::word_details` returns `None`.
- The `ensure_details` padding is kept — `japanese_compound_word` indexes that vector
  directly via `set_detail`, so a shorter vector would panic downstream.
- No public signature changes.

## Tests

15 new tests. These paths had **no** coverage before.

| Target | Count | Coverage |
| --- | ---: | --- |
| `detail_field_count` | 3 | equality with `slice::split`, never-zero for an empty blob, IPADIC shape |
| `UnknownDictionary::word_details` | 7 | order, single field, empty fields preserved, empty entry, out-of-range → `None`, invalid UTF-8 → `None`, truncated entry → `None` |
| `UserDictionary::word_details` | 5 | order, single field, empty fields preserved, out-of-range → `UNK`, invalid UTF-8 → `UNK` |
| `lindera/src/token.rs` (real IPADIC) | 3 | field count and order, out-of-range → empty, user-dictionary detail positions |

Green: `lindera-dictionary` 100, `lindera` (`--features embed-ipadic`) 43 + integration
tests, `lindera-analysis` (`--features embed-ipadic`) 110, golden snapshots 4.
`cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` are clean for
both touched crates.

### A note on user-dictionary details

While writing the tests, one assumption in the issue turned out to be wrong and is worth
recording: IPADIC's `user_dictionary_schema` declares only `surface, part_of_speech,
reading`, but the builder **already expands entries onto the system schema's field
positions** (POS at custom index 0, reading at index 7, the rest filled with `*`). So the
normal user-dictionary path does not exercise the `resize` padding at all. The test now
pins that real behavior. The `resize` is still required for the defensive paths (e.g. the
one-element `UNK` fallback), and `with_capacity(len.max(expected_len))` covers those in a
single allocation.

## Out of scope

- **Step (b) of #966** — eliminating the intermediate `Vec<&str>` by building `Vec<Cow>`
  straight from the NUL-separated bytes. That needs an additive public API on `Dictionary`
  / `UserDictionary` / `UnknownDictionary` and should be a separate PR with explicit
  approval of the new surface.
- **Switching token filters off the allocating `details()` accessor** — tracked in #967.

Refs #966
