### PR TITLE
perf(analysis): remove per-token allocations from the tag filters

### DIFF
--- a/lindera-analysis/Cargo.toml
+++ b/lindera-analysis/Cargo.toml
@@ -50,3 +50,8 @@ serde_json = { workspace = true }
 name = "bench_analysis_ipadic"
 harness = false
 required-features = ["embed-ipadic"]
+
+[[bench]]
+name = "bench_tag_filters_ipadic"
+harness = false
+required-features = ["embed-ipadic"]

--- a/lindera-analysis/benches/bench_tag_filters_ipadic.rs
+++ b/lindera-analysis/benches/bench_tag_filters_ipadic.rs
@@ -1,0 +1,214 @@
+//! Tag token filter benchmarks (#967).
+//!
+//! The four tag filters (`japanese_stop_tags`, `japanese_keep_tags`,
+//! `korean_stop_tags`, `korean_keep_tags`) share one helper,
+//! `apply_tag_filter`, whose per-token cost is what these benches target.
+//! Before #967 that helper allocated a comparison-key `String` per token, a
+//! `Vec<&str>` per token for the Japanese key, and one replacement token
+//! vector per call; it now reuses a single key buffer and filters in place.
+//!
+//! Two shapes are measured:
+//!
+//! - `apply-*`: [`TokenFilter::apply`] alone, over a token vector built (and
+//!   its details materialized) outside the timed region. This isolates the
+//!   filter's own cost, which is what changed.
+//! - `pipeline-*`: the full `Tokenizer::tokenize` with the filter configured,
+//!   so the filter's share of a realistic analysis chain stays visible.
+//!
+//! The corpus is `resources/bocchan.txt`, which yields a large token count --
+//! the per-token cost is invisible on the 12-character text the other
+//! analysis benches use.
+
+#[cfg(feature = "embed-ipadic")]
+use std::borrow::Cow;
+#[cfg(feature = "embed-ipadic")]
+use std::fs;
+#[cfg(feature = "embed-ipadic")]
+use std::path::PathBuf;
+
+#[cfg(feature = "embed-ipadic")]
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+
+#[cfg(feature = "embed-ipadic")]
+use lindera::dictionary::load_dictionary;
+#[cfg(feature = "embed-ipadic")]
+use lindera::mode::Mode;
+#[cfg(feature = "embed-ipadic")]
+use lindera::segmenter::Segmenter;
+#[cfg(feature = "embed-ipadic")]
+use lindera::token::Token;
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::token_filter::japanese_keep_tags::JapaneseKeepTagsTokenFilter;
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::token_filter::japanese_stop_tags::JapaneseStopTagsTokenFilter;
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::token_filter::{BoxTokenFilter, TokenFilter};
+#[cfg(feature = "embed-ipadic")]
+use lindera_analysis::tokenizer::Tokenizer;
+
+/// The 25 stop tags configured in `resources/config/lindera.yml`, i.e. what
+/// the shipped default pipeline actually runs.
+#[cfg(feature = "embed-ipadic")]
+const DEFAULT_STOP_TAGS: &[&str] = &[
+    "接続詞",
+    "助詞",
+    "助詞,格助詞",
+    "助詞,格助詞,一般",
+    "助詞,格助詞,引用",
+    "助詞,格助詞,連語",
+    "助詞,係助詞",
+    "助詞,副助詞",
+    "助詞,間投助詞",
+    "助詞,並立助詞",
+    "助詞,終助詞",
+    "助詞,副助詞／並立助詞／終助詞",
+    "助詞,連体化",
+    "助詞,副詞化",
+    "助詞,特殊",
+    "助動詞",
+    "記号",
+    "記号,一般",
+    "記号,読点",
+    "記号,句点",
+    "記号,空白",
+    "記号,括弧閉",
+    "記号,括弧開",
+    "記号,アルファベット",
+    "その他,間投",
+];
+
+/// Keep-tag counterpart: the content-word tags a search pipeline typically
+/// retains.
+#[cfg(feature = "embed-ipadic")]
+const KEEP_TAGS: &[&str] = &["名詞", "動詞", "形容詞", "副詞"];
+
+#[cfg(feature = "embed-ipadic")]
+fn corpus() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../resources")
+        .join("bocchan.txt");
+    fs::read_to_string(&path).unwrap()
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn segmenter() -> Segmenter {
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    Segmenter::new(Mode::Normal, dictionary, None)
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn tags_config(tags: &[&str]) -> serde_json::Value {
+    serde_json::json!({ "tags": tags })
+}
+
+/// Segments `text` and materializes every token's details, so a caller
+/// timing only `apply` does not measure the detail loading the first
+/// accessor call would otherwise trigger inside the filter.
+#[cfg(feature = "embed-ipadic")]
+fn prepared_tokens<'a>(segmenter: &'a Segmenter, text: &'a str) -> Vec<Token<'a>> {
+    let mut tokens = segmenter.segment(Cow::Borrowed(text)).unwrap();
+    for token in tokens.iter_mut() {
+        let _ = token.details_iter().count();
+    }
+    tokens
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_apply_japanese_stop_tags(c: &mut Criterion) {
+    let text = corpus();
+    let segmenter = segmenter();
+    let filter = JapaneseStopTagsTokenFilter::from_config(&tags_config(DEFAULT_STOP_TAGS)).unwrap();
+
+    c.bench_function("bench-tag-filters-apply-japanese-stop-tags-ipadic", |b| {
+        b.iter_batched(
+            || prepared_tokens(&segmenter, &text),
+            |mut tokens| {
+                filter.apply(&mut tokens).unwrap();
+                tokens.len()
+            },
+            BatchSize::LargeInput,
+        )
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_apply_japanese_keep_tags(c: &mut Criterion) {
+    let text = corpus();
+    let segmenter = segmenter();
+    let filter = JapaneseKeepTagsTokenFilter::from_config(&tags_config(KEEP_TAGS)).unwrap();
+
+    c.bench_function("bench-tag-filters-apply-japanese-keep-tags-ipadic", |b| {
+        b.iter_batched(
+            || prepared_tokens(&segmenter, &text),
+            |mut tokens| {
+                filter.apply(&mut tokens).unwrap();
+                tokens.len()
+            },
+            BatchSize::LargeInput,
+        )
+    });
+}
+
+/// The empty-tag-set fast path, which must stay free: it resolves the whole
+/// call without ever building a key.
+#[cfg(feature = "embed-ipadic")]
+fn bench_apply_empty_tag_set(c: &mut Criterion) {
+    let text = corpus();
+    let segmenter = segmenter();
+    let filter = JapaneseStopTagsTokenFilter::from_config(&tags_config(&[])).unwrap();
+
+    c.bench_function("bench-tag-filters-apply-empty-tag-set-ipadic", |b| {
+        b.iter_batched(
+            || prepared_tokens(&segmenter, &text),
+            |mut tokens| {
+                filter.apply(&mut tokens).unwrap();
+                tokens.len()
+            },
+            BatchSize::LargeInput,
+        )
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+fn bench_pipeline_with_stop_tags(c: &mut Criterion) {
+    let text = corpus();
+    let mut tokenizer = Tokenizer::new(segmenter());
+    let filter = JapaneseStopTagsTokenFilter::from_config(&tags_config(DEFAULT_STOP_TAGS)).unwrap();
+    tokenizer.token_filters.push(BoxTokenFilter::from(filter));
+
+    c.bench_function("bench-tag-filters-pipeline-stop-tags-ipadic", |b| {
+        let mut worker = tokenizer.new_worker();
+        b.iter(|| worker.tokenize(&text).unwrap().len())
+    });
+}
+
+/// Baseline for the pipeline bench: the same chain with no token filter, so
+/// the filter's share is readable as the difference.
+#[cfg(feature = "embed-ipadic")]
+fn bench_pipeline_without_filter(c: &mut Criterion) {
+    let text = corpus();
+    let tokenizer = Tokenizer::new(segmenter());
+
+    c.bench_function("bench-tag-filters-pipeline-no-filter-ipadic", |b| {
+        let mut worker = tokenizer.new_worker();
+        b.iter(|| worker.tokenize(&text).unwrap().len())
+    });
+}
+
+#[cfg(feature = "embed-ipadic")]
+criterion_group!(
+    benches,
+    bench_apply_japanese_stop_tags,
+    bench_apply_japanese_keep_tags,
+    bench_apply_empty_tag_set,
+    bench_pipeline_with_stop_tags,
+    bench_pipeline_without_filter,
+);
+
+#[cfg(feature = "embed-ipadic")]
+criterion_main!(benches);
+
+#[cfg(not(feature = "embed-ipadic"))]
+fn main() {
+    eprintln!("bench_tag_filters_ipadic requires --features embed-ipadic");
+}

--- a/lindera-analysis/src/token_filter/japanese_keep_tags.rs
+++ b/lindera-analysis/src/token_filter/japanese_keep_tags.rs
@@ -3,7 +3,9 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use crate::token_filter::TokenFilter;
-use crate::token_filter::tags::{TagPolicy, apply_tag_filter, normalize_japanese_tags, parse_tags};
+use crate::token_filter::tags::{
+    TagPolicy, apply_tag_filter, normalize_japanese_tags, parse_tags, write_japanese_pos_key,
+};
 use lindera::LinderaResult;
 use lindera::token::Token;
 
@@ -48,29 +50,22 @@ impl TokenFilter for JapaneseKeepTagsTokenFilter {
     /// # Process
     ///
     /// 1. **Token Filtering**:
-    ///    - The function iterates over the tokens and extracts the part-of-speech tags from each token's details.
-    ///    - If the token has at least 4 details, the first 4 elements are used as the tag. Otherwise, only the first element is used.
+    ///    - The function iterates over the tokens and reads the part-of-speech tags from each token's details.
+    ///    - At most the first 4 details form the tag. If the token has fewer, only the available details are used.
     ///
     /// 2. **Tag Matching**:
-    ///    - The tags are constructed as a comma-separated string and checked against the set of tags specified in the configuration (`self.config.tags`).
+    ///    - The tag is written into a single buffer reused across tokens, joined with commas, and checked against the set of tags specified in the configuration (`self.tags`).
     ///
-    /// 3. **Token Retention**:
-    ///    - Only the tokens whose tags match the configuration are retained in the resulting `filtered_tokens` vector.
-    ///
-    /// 4. **Replace Tokens**:
-    ///    - After filtering, the original tokens vector is replaced with the filtered list.
+    /// 3. **In-Place Retention**:
+    ///    - Filtering happens in place over the original tokens vector, preserving order; only the tokens whose tags match the configuration remain.
     ///
     /// # Errors
     ///
     /// If any issue arises during token processing or filtering, the function will return an error in the form of `LinderaResult`.
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
-        apply_tag_filter(tokens, &self.tags, TagPolicy::Keep, |token| {
-            let details = token.details();
-            // Determine the length of the tags to consider (either 4 or 1)
-            let tags_len = details.len().min(4);
-            // Construct the tag string from the token's details.
-            details[0..tags_len].join(",")
-        });
+        // The key is the first up-to-4 part-of-speech levels joined with `,`,
+        // written into a buffer `apply_tag_filter` reuses across tokens.
+        apply_tag_filter(tokens, &self.tags, TagPolicy::Keep, write_japanese_pos_key);
 
         Ok(())
     }

--- a/lindera-analysis/src/token_filter/japanese_stop_tags.rs
+++ b/lindera-analysis/src/token_filter/japanese_stop_tags.rs
@@ -3,7 +3,9 @@ use std::collections::HashSet;
 use serde_json::Value;
 
 use crate::token_filter::TokenFilter;
-use crate::token_filter::tags::{TagPolicy, apply_tag_filter, normalize_japanese_tags, parse_tags};
+use crate::token_filter::tags::{
+    TagPolicy, apply_tag_filter, normalize_japanese_tags, parse_tags, write_japanese_pos_key,
+};
 use lindera::LinderaResult;
 use lindera::token::Token;
 
@@ -48,16 +50,16 @@ impl TokenFilter for JapaneseStopTagsTokenFilter {
     /// # Process
     ///
     /// 1. **Token Filtering**:
-    ///    - The function iterates over the `tokens` vector and extracts the part-of-speech details of each token.
-    ///    - If the token has at least 4 details, the first 4 elements are used to create a tag. If it has fewer details, only the available details are used.
+    ///    - The function iterates over the `tokens` vector and reads the part-of-speech details of each token.
+    ///    - At most the first 4 details form the tag. If the token has fewer, only the available details are used.
     ///
     /// 2. **Tag Matching**:
-    ///    - A tag string is created by joining the extracted part-of-speech details with commas (`,`) for comparison.
-    ///    - If the tag is **not** found in the configuration (`self.config.tags`), the token is added to the `filtered_tokens` vector.
+    ///    - The tag is written into a single buffer reused across tokens, joining the part-of-speech details with commas (`,`) for comparison.
+    ///    - If the tag is **not** found in the configuration (`self.tags`), the token is retained.
     ///    - If the tag is present in the configuration, the token is discarded.
     ///
-    /// 3. **Token Replacement**:
-    ///    - Once the iteration is complete, the original `tokens` vector is replaced with the filtered tokens, i.e., only those tokens whose part-of-speech tags are not in the configuration remain.
+    /// 3. **In-Place Filtering**:
+    ///    - Filtering happens in place over the original `tokens` vector, preserving order, so only those tokens whose part-of-speech tags are not in the configuration remain.
     ///
     /// # Example
     ///
@@ -67,16 +69,14 @@ impl TokenFilter for JapaneseStopTagsTokenFilter {
     ///
     /// Returns a `LinderaResult` error if there is an issue during processing, but typically this function is expected to complete successfully unless there are issues with the token or tag data.
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
-        apply_tag_filter(tokens, &self.tags, TagPolicy::Remove, |token| {
-            let details = token.details();
-            // Use up to the first 4 part-of-speech levels as the tag. When fewer
-            // details are available (e.g. a token whose details were left empty),
-            // use only what is present. `min` also keeps the slice in bounds for
-            // empty details, which would otherwise panic.
-            let tags_len = details.len().min(4);
-            // Make a string of the part-of-speech tags.
-            details[0..tags_len].join(",")
-        });
+        // The key is the first up-to-4 part-of-speech levels joined with `,`,
+        // written into a buffer `apply_tag_filter` reuses across tokens.
+        apply_tag_filter(
+            tokens,
+            &self.tags,
+            TagPolicy::Remove,
+            write_japanese_pos_key,
+        );
 
         Ok(())
     }
@@ -408,5 +408,107 @@ mod tests {
 
         assert_eq!(tokens.len(), 1);
         assert_eq!(&tokens[0].surface, "テスト");
+    }
+
+    // The test above constructs the filter with an empty tag set, so since
+    // #825 it returns at `apply_tag_filter`'s empty-set fast path and the key
+    // builder never runs -- it no longer covers the #438 crash site. This
+    // variant uses a NON-empty tag set so extraction actually happens, and
+    // pins the key an empty-details token produces: the empty string, which
+    // matches no configured tag (every configured Japanese tag is normalized
+    // to four comma-separated parts).
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_japanese_stop_tags_empty_details_with_non_empty_tag_set() {
+        use std::borrow::Cow;
+        use std::collections::HashSet;
+
+        use crate::token_filter::TokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let mut tags = HashSet::new();
+        tags.insert("助詞".to_string());
+        let filter = JapaneseStopTagsTokenFilter::new(tags);
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let mut tokens: Vec<Token> = vec![Token {
+            surface: Cow::Borrowed("テスト"),
+            byte_start: 0,
+            byte_end: 9,
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, 0),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: Some(vec![]),
+        }];
+
+        filter.apply(&mut tokens).unwrap();
+
+        // The key is "" (zero details joined), which is not in the tag set,
+        // so a stop-tag filter keeps the token.
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(&tokens[0].surface, "テスト");
+    }
+
+    // The complement of the test above: with a non-empty tag set, a token
+    // whose details DO match is actually removed. Together these two pin
+    // both sides of the key comparison, so a broken key builder cannot pass
+    // by trivially keeping everything.
+    #[test]
+    #[cfg(feature = "embed-ipadic")]
+    fn test_japanese_stop_tags_removes_matching_token() {
+        use std::borrow::Cow;
+        use std::collections::HashSet;
+
+        use crate::token_filter::TokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let mut tags = HashSet::new();
+        tags.insert("名詞,固有名詞".to_string());
+        let filter = JapaneseStopTagsTokenFilter::new(tags);
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let details = |fields: &[&str]| -> Option<Vec<Cow<'static, str>>> {
+            Some(fields.iter().map(|f| Cow::Owned(f.to_string())).collect())
+        };
+
+        let mut tokens: Vec<Token> = vec![
+            Token {
+                surface: Cow::Borrowed("除去対象"),
+                byte_start: 0,
+                byte_end: 12,
+                position: 0,
+                position_length: 1,
+                word_id: WordId::new(LexType::System, 0),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                // Normalized configured tag is "名詞,固有名詞,*,*"; the key
+                // built from these four details must equal it.
+                details: details(&["名詞", "固有名詞", "*", "*"]),
+            },
+            Token {
+                surface: Cow::Borrowed("保持対象"),
+                byte_start: 12,
+                byte_end: 24,
+                position: 1,
+                position_length: 1,
+                word_id: WordId::new(LexType::System, 1),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: details(&["動詞", "自立", "*", "*"]),
+            },
+        ];
+
+        filter.apply(&mut tokens).unwrap();
+
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(&tokens[0].surface, "保持対象");
     }
 }

--- a/lindera-analysis/src/token_filter/korean_keep_tags.rs
+++ b/lindera-analysis/src/token_filter/korean_keep_tags.rs
@@ -60,10 +60,23 @@ impl TokenFilter for KoreanKeepTagsTokenFilter {
     /// # Errors
     ///
     /// The function returns a `LinderaResult<()>` if any issue occurs during token filtering, but typically no errors are expected during this operation.
+    /// Keeps the tokens whose first part-of-speech detail is present in the configured
+    /// tag set, filtering in place and preserving order.
+    ///
+    /// The comparison key is the token's first detail field, written into a
+    /// buffer reused across tokens rather than allocated per token.
+    ///
+    /// # 引数
+    ///
+    /// * `tokens` - The tokens to filter, modified in place.
+    ///
+    /// # 戻り値
+    ///
+    /// `Ok(())`; this filter cannot fail.
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
-        apply_tag_filter(tokens, &self.tags, TagPolicy::Keep, |token| {
+        apply_tag_filter(tokens, &self.tags, TagPolicy::Keep, |token, key| {
             // Use the first part-of-speech tag as the comparison key.
-            token.get_detail(0).unwrap_or_default().to_string()
+            key.push_str(token.get_detail(0).unwrap_or_default());
         });
 
         Ok(())

--- a/lindera-analysis/src/token_filter/korean_stop_tags.rs
+++ b/lindera-analysis/src/token_filter/korean_stop_tags.rs
@@ -392,4 +392,61 @@ mod tests {
         assert_eq!(&tokens[4].surface, "수");
         assert_eq!(&tokens[5].surface, "있");
     }
+
+    // The Korean key is `get_detail(0)`, which is `None` when the token has
+    // no details at all. `unwrap_or_default()` turns that into `""`, so the
+    // key matches no configured tag and a stop-tag filter keeps the token.
+    // This is the Korean counterpart of the #438 empty-details case, and it
+    // must survive the switch from an owned `String` key to a borrowed write
+    // into the shared buffer.
+    #[test]
+    #[cfg(feature = "embed-ko-dic")]
+    fn test_korean_stop_tags_missing_first_detail_keeps_token() {
+        use std::borrow::Cow;
+        use std::collections::HashSet;
+
+        use crate::token_filter::TokenFilter;
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
+
+        let mut tags = HashSet::new();
+        tags.insert("JKS".to_string());
+        let filter = KoreanStopTagsTokenFilter::new(tags);
+
+        let mut tokens: Vec<Token> = vec![
+            Token {
+                surface: Cow::Borrowed("없음"),
+                byte_start: 0,
+                byte_end: 6,
+                position: 0,
+                position_length: 1,
+                word_id: WordId::new(LexType::System, 0),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                // No details at all: get_detail(0) yields None.
+                details: Some(vec![]),
+            },
+            Token {
+                surface: Cow::Borrowed("제거"),
+                byte_start: 6,
+                byte_end: 12,
+                position: 1,
+                position_length: 1,
+                word_id: WordId::new(LexType::System, 1),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: Some(vec![Cow::Borrowed("JKS")]),
+            },
+        ];
+
+        filter.apply(&mut tokens).unwrap();
+
+        // The empty key matched nothing, so the first token stays; the second
+        // matched the stop tag and is gone.
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(&tokens[0].surface, "없음");
+    }
 }

--- a/lindera-analysis/src/token_filter/korean_stop_tags.rs
+++ b/lindera-analysis/src/token_filter/korean_stop_tags.rs
@@ -33,10 +33,23 @@ impl TokenFilter for KoreanStopTagsTokenFilter {
         KOREAN_STOP_TAGS_TOKEN_FILTER_NAME
     }
 
+    /// Removes the tokens whose first part-of-speech detail is absent from the configured
+    /// tag set, filtering in place and preserving order.
+    ///
+    /// The comparison key is the token's first detail field, written into a
+    /// buffer reused across tokens rather than allocated per token.
+    ///
+    /// # 引数
+    ///
+    /// * `tokens` - The tokens to filter, modified in place.
+    ///
+    /// # 戻り値
+    ///
+    /// `Ok(())`; this filter cannot fail.
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
-        apply_tag_filter(tokens, &self.tags, TagPolicy::Remove, |token| {
+        apply_tag_filter(tokens, &self.tags, TagPolicy::Remove, |token, key| {
             // Use the first part-of-speech tag as the comparison key.
-            token.get_detail(0).unwrap_or_default().to_string()
+            key.push_str(token.get_detail(0).unwrap_or_default());
         });
 
         Ok(())

--- a/lindera-analysis/src/token_filter/tags.rs
+++ b/lindera-analysis/src/token_filter/tags.rs
@@ -36,6 +36,17 @@ pub(crate) fn normalize_japanese_tags(tags: HashSet<String>) -> HashSet<String> 
         .collect()
 }
 
+/// Initial capacity of the comparison-key buffer [`apply_tag_filter`] reuses
+/// across tokens.
+///
+/// Sized for the longest key the filters build in practice: four
+/// comma-separated Japanese part-of-speech fields. The longest distinct
+/// 4-field key across the whole IPADIC lexicon is 47 bytes
+/// (`助詞,副助詞／並立助詞／終助詞,*,*`), so this leaves headroom without being
+/// a meaningful allocation. A longer key is still handled correctly; it just
+/// grows the buffer once.
+const KEY_BUFFER_CAPACITY: usize = 64;
+
 /// Whether a tag filter keeps or removes the tokens whose tag matches the set.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum TagPolicy {
@@ -46,23 +57,34 @@ pub(crate) enum TagPolicy {
 }
 
 /// Filters `tokens` in place, retaining or removing each token depending on
-/// whether the tag produced by `extract_tag` is present in `tags`, per
+/// whether the tag produced by `write_tag` is present in `tags`, per
 /// `policy`.
 ///
 /// The tag extraction strategy is supplied by the caller because each filter
 /// builds its comparison key differently (Japanese filters join up to four
-/// POS parts; Korean filters use only the first part).
+/// POS parts; Korean filters use only the first part). `write_tag` writes
+/// into a buffer this function owns and reuses for every token, rather than
+/// returning a fresh `String`, so a whole `apply` call costs at most one key
+/// allocation instead of one per token.
+///
+/// # 引数
+///
+/// * `tokens` - The tokens to filter, modified in place.
+/// * `tags` - The configured tag set to compare each key against.
+/// * `policy` - Whether a match keeps or removes the token.
+/// * `write_tag` - Writes a token's comparison key into the supplied buffer.
+///   The buffer is cleared before each call.
 pub(crate) fn apply_tag_filter<F>(
     tokens: &mut Vec<Token<'_>>,
     tags: &HashSet<String>,
     policy: TagPolicy,
-    extract_tag: F,
+    mut write_tag: F,
 ) where
-    F: Fn(&mut Token<'_>) -> String,
+    F: FnMut(&mut Token<'_>, &mut String),
 {
     // An empty tag set means every token's tag is trivially "not in the
     // set" -- resolve the outcome directly per policy without calling
-    // extract_tag (which typically reads dictionary details) for every
+    // write_tag (which typically reads dictionary details) for every
     // token.
     if tags.is_empty() {
         match policy {
@@ -72,21 +94,54 @@ pub(crate) fn apply_tag_filter<F>(
         return;
     }
 
-    let mut filtered_tokens = Vec::with_capacity(tokens.len());
+    // One key buffer for the whole call, reused across tokens. `contains`
+    // takes `&str` through `HashSet<String>`'s `Borrow<str>` impl, so no
+    // owned `String` is needed for the lookup itself.
+    //
+    // Presized so the buffer does not grow while the first few keys are
+    // written: a Japanese key is at most four comma-separated POS fields,
+    // which stays well inside this for every field set the bundled
+    // dictionaries define. A longer key still works -- `push_str` grows the
+    // buffer as usual, and the growth is paid once per call, not per token.
+    let mut key = String::with_capacity(KEY_BUFFER_CAPACITY);
 
-    for mut token in tokens.drain(..) {
-        let tag = extract_tag(&mut token);
-        let matched = tags.contains(&tag);
-        let keep = match policy {
+    // `retain_mut` compacts in place, so the second vector the previous
+    // drain-into-a-fresh-`Vec` approach allocated is gone. Order is
+    // preserved, exactly as before.
+    tokens.retain_mut(|token| {
+        key.clear();
+        write_tag(token, &mut key);
+        let matched = tags.contains(key.as_str());
+        match policy {
             TagPolicy::Keep => matched,
             TagPolicy::Remove => !matched,
-        };
-        if keep {
-            filtered_tokens.push(token);
         }
-    }
+    });
+}
 
-    *tokens = filtered_tokens;
+/// Writes a token's leading part-of-speech fields into `out`, joined with
+/// `,`, as the Japanese tag filters' comparison key.
+///
+/// Uses at most the first four fields, matching `normalize_japanese_tags`,
+/// which pads every configured tag to exactly four parts. A token with fewer
+/// details yields a shorter key (and, for zero details, the empty string),
+/// which is existing behavior that predates this helper -- such a key simply
+/// matches no configured tag.
+///
+/// `details_iter` is used rather than `details` so the per-token `Vec<&str>`
+/// the latter collects is not allocated.
+///
+/// # 引数
+///
+/// * `token` - The token whose details form the key.
+/// * `out` - The buffer to write into; assumed already cleared.
+pub(crate) fn write_japanese_pos_key(token: &mut Token<'_>, out: &mut String) {
+    for (i, detail) in token.details_iter().take(4).enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(detail);
+    }
 }
 
 // Every test here builds a `Token` against an embedded IPADIC dictionary, so
@@ -120,9 +175,8 @@ mod tests {
 
         let tags = HashSet::new();
         let extract_called = Cell::new(false);
-        apply_tag_filter(&mut tokens, &tags, TagPolicy::Keep, |_| {
+        apply_tag_filter(&mut tokens, &tags, TagPolicy::Keep, |_, _| {
             extract_called.set(true);
-            String::new()
         });
 
         assert_eq!(tokens.len(), 0);
@@ -156,9 +210,8 @@ mod tests {
 
         let tags = HashSet::new();
         let extract_called = Cell::new(false);
-        apply_tag_filter(&mut tokens, &tags, TagPolicy::Remove, |_| {
+        apply_tag_filter(&mut tokens, &tags, TagPolicy::Remove, |_, _| {
             extract_called.set(true);
-            String::new()
         });
 
         assert_eq!(tokens.len(), 1);
@@ -167,5 +220,185 @@ mod tests {
             !extract_called.get(),
             "extract_tag must be skipped for an empty tag set"
         );
+    }
+
+    /// The Japanese key builder must produce exactly what the retired
+    /// `details[0..len.min(4)].join(",")` produced: no leading or trailing
+    /// separator, at most four fields, and the empty string for zero details.
+    /// The zero-details case is the #438 crash site.
+    #[test]
+    fn test_write_japanese_pos_key_matches_join_semantics() {
+        use std::borrow::Cow;
+
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let cases: [(&[&str], &str); 7] = [
+            (&[], ""),
+            (&["名詞"], "名詞"),
+            (&["名詞", "一般"], "名詞,一般"),
+            (&["名詞", "固有名詞", "地域"], "名詞,固有名詞,地域"),
+            (
+                &["名詞", "固有名詞", "地域", "一般"],
+                "名詞,固有名詞,地域,一般",
+            ),
+            // Only the first four fields participate in the key.
+            (
+                &["名詞", "固有名詞", "地域", "一般", "余分", "無視"],
+                "名詞,固有名詞,地域,一般",
+            ),
+            // Empty fields are preserved as empty parts, not skipped.
+            (&["", "", "*", "*"], ",,*,*"),
+        ];
+
+        for (details, expected) in cases {
+            let mut token = Token {
+                surface: Cow::Borrowed("x"),
+                byte_start: 0,
+                byte_end: 1,
+                position: 0,
+                position_length: 1,
+                word_id: WordId::new(LexType::System, 0),
+                dictionary: &dictionary,
+                user_dictionary: None,
+                details: Some(details.iter().map(|d| Cow::Borrowed(*d)).collect()),
+            };
+
+            let mut key = String::new();
+            write_japanese_pos_key(&mut token, &mut key);
+            assert_eq!(key, expected, "details {details:?}");
+
+            // Equivalence with the retired implementation, on the same input.
+            let collected = token.details();
+            let tags_len = collected.len().min(4);
+            assert_eq!(key, collected[0..tags_len].join(","), "details {details:?}");
+        }
+    }
+
+    /// The key buffer is reused across tokens, so a stale key from a previous
+    /// token must never leak into the next one. A short key following a long
+    /// one is the case that would break if the buffer were not cleared.
+    #[test]
+    fn test_key_buffer_is_not_leaked_between_tokens() {
+        use std::borrow::Cow;
+
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        let make = |surface: &'static str, details: &[&'static str], id: u32| Token {
+            surface: Cow::Borrowed(surface),
+            byte_start: 0,
+            byte_end: surface.len(),
+            position: 0,
+            position_length: 1,
+            word_id: WordId::new(LexType::System, id),
+            dictionary: &dictionary,
+            user_dictionary: None,
+            details: Some(details.iter().map(|d| Cow::Borrowed(*d)).collect()),
+        };
+
+        // A long key first, then a short one, then an empty one.
+        let mut tokens = vec![
+            make("long", &["名詞", "固有名詞", "地域", "一般"], 0),
+            make("short", &["助詞"], 1),
+            make("empty", &[], 2),
+        ];
+
+        // Remove only the short one, so the others must survive with their
+        // own keys rather than a leftover of the previous token's key.
+        let mut tags = HashSet::new();
+        tags.insert("助詞".to_string());
+
+        apply_tag_filter(
+            &mut tokens,
+            &tags,
+            TagPolicy::Remove,
+            write_japanese_pos_key,
+        );
+
+        let surfaces: Vec<&str> = tokens.iter().map(|t| t.surface.as_ref()).collect();
+        assert_eq!(surfaces, vec!["long", "empty"]);
+    }
+
+    /// `retain_mut` compacts in place; order and contents must match the
+    /// retired drain-into-a-new-vector approach for every removal shape.
+    #[test]
+    fn test_retain_preserves_order_for_every_removal_shape() {
+        use std::borrow::Cow;
+
+        use lindera::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
+        use lindera::token::Token;
+        use lindera_dictionary::viterbi::LexType;
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+
+        // "drop" tokens carry the stop tag; "keep" tokens do not.
+        let build = |shape: &[bool]| -> Vec<Token<'_>> {
+            shape
+                .iter()
+                .enumerate()
+                .map(|(i, drop)| Token {
+                    surface: if *drop {
+                        Cow::Borrowed("drop")
+                    } else {
+                        Cow::Borrowed("keep")
+                    },
+                    byte_start: i,
+                    byte_end: i + 4,
+                    position: i,
+                    position_length: 1,
+                    word_id: WordId::new(LexType::System, i as u32),
+                    dictionary: &dictionary,
+                    user_dictionary: None,
+                    details: Some(if *drop {
+                        vec![Cow::Borrowed("助詞")]
+                    } else {
+                        vec![Cow::Borrowed("名詞")]
+                    }),
+                })
+                .collect()
+        };
+
+        let mut tags = HashSet::new();
+        tags.insert("助詞".to_string());
+
+        // first / last / middle / all / none / empty input
+        let shapes: [&[bool]; 6] = [
+            &[true, false, false],
+            &[false, false, true],
+            &[false, true, false],
+            &[true, true, true],
+            &[false, false, false],
+            &[],
+        ];
+
+        for shape in shapes {
+            let mut tokens = build(shape);
+            apply_tag_filter(
+                &mut tokens,
+                &tags,
+                TagPolicy::Remove,
+                write_japanese_pos_key,
+            );
+
+            let expected: Vec<usize> = shape
+                .iter()
+                .enumerate()
+                .filter(|(_, drop)| !**drop)
+                .map(|(i, _)| i)
+                .collect();
+            let actual: Vec<usize> = tokens.iter().map(|t| t.position).collect();
+            assert_eq!(actual, expected, "shape {shape:?}");
+            assert!(
+                tokens.iter().all(|t| t.surface == "keep"),
+                "shape {shape:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Background

Closes #967.

The four tag token filters (`japanese_stop_tags`, `japanese_keep_tags`,
`korean_stop_tags`, `korean_keep_tags`) all funnel through one helper,
`apply_tag_filter`. Its callback bound was `Fn(&mut Token<'_>) -> String`, and the
returned value was used for exactly one thing — a `HashSet<String>::contains` lookup —
before being dropped at the end of the iteration. Every token therefore paid a heap
allocation purely to be a lookup key. The Japanese filters paid a second one, because
`Token::details()` collects a fresh `Vec<&str>` on every call. On top of that, each
`apply` allocated a second token vector and drained the original into it.

This is not a cold path: `resources/config/lindera.yml` configures `japanese_stop_tags`
with 25 tags, so the empty-tag-set fast path is not taken and this runs for every token
of every analyzed text in the shipped default pipeline.

## Changes

**Callback shape.** `apply_tag_filter` now takes `FnMut(&mut Token<'_>, &mut String)`
and owns one key buffer that it reuses across tokens. `HashSet<String>::contains` accepts
`&str` through `Borrow<str>`, so no owned key is needed for the lookup at all.

**In-place filtering.** `Vec::retain_mut` replaces the drain-into-a-fresh-vector
approach, removing the second vector per call. Order is preserved identically.

**Shared Japanese key builder.** `write_japanese_pos_key` joins up to four fields from
`details_iter()` — not `details()` — directly into the buffer, so neither the
intermediate `Vec<&str>` nor the joined `String` is allocated.

**Buffer presizing.** The key buffer is created with a 64-byte capacity. The longest
distinct four-field key across the entire IPADIC lexicon is 47 bytes
(`助詞,副助詞／並立助詞／終助詞,*,*`), so in practice the buffer is allocated once per
call and never grows. A longer key still works; it just grows the buffer once.

**Korean filters** write the borrowed first detail straight into the buffer instead of
`.to_string()`-ing it.

## Measurements

Deterministic global-allocator counter (hooking `alloc`, `alloc_zeroed` and `realloc`)
around `TokenFilter::apply` only, with tokens and their details already materialized so
the figure isolates the filter itself. Same probe on both sides. Workload: the 25 stop
tags from `resources/config/lindera.yml` over a 51-token sentence, 1000 iterations.

| | Before | After |
| --- | ---: | ---: |
| allocations per `apply()` call | 103.00 | **1.00** |
| allocations per token | 2.020 | **0.020** |

The baseline matches the code exactly: 51 tokens × 2 (the `Vec<&str>` plus the joined
`String`) + 1 for the replacement vector. The single remaining allocation is the key
buffer.

### No wall-clock claim

**This PR claims removed allocations, not a speedup.** The machine available for this
work was too noisy to measure on — in the new bench's own control case
(`pipeline-no-filter`, which this PR does not touch) samples varied by ~20%, and the
`apply` bench varied ~2×. Per `scripts/benchmarks/README.md`, any published figure needs
the interleaved min-of-N protocol on an idle machine: two worktrees, the correctness
gate, a null-pair test, and the min of round minima.

## Behavior preservation

- The empty-tag-set fast path (added by #825) and both of its tests are kept: `write_tag`
  is still never invoked for an empty set.
- Filter order is preserved; `retain_mut` compacts in place.
- The `normalize_japanese_tags` / `min(4)` key asymmetry is untouched — a token with
  fewer than four details still produces a key that matches no configured tag. That is
  existing behavior and deliberately not "fixed" here.
- The IPADIC golden snapshots still pass.
- `apply_tag_filter` is `pub(crate)` in a private module; no public signature changes.

## Tests

**The #438 regression test no longer covered its own crash site.** It builds the filter
with `JapaneseStopTagsTokenFilter::new(HashSet::new())` — an empty tag set — so since
#825 it returns at the fast path and the key builder is never called. This PR adds:

- a variant with a **non-empty** tag set that pins the key an empty-details token
  produces (the empty string), which is the actual #438 crash site;
- a complement test where a matching token *is* removed, so a broken key builder cannot
  pass by trivially keeping everything.

Also added:

- `write_japanese_pos_key` equivalence with the retired
  `details[0..len.min(4)].join(",")` across seven shapes: zero, one, two, three, four and
  more-than-four details, plus a case with empty fields.
- The reused buffer not leaking a previous token's key (long → short → empty sequence).
- `retain_mut` order preservation across six removal shapes: first, last, middle, all,
  none, and empty input.

Doc comments describing the replaced mechanics are updated, and the two Korean `apply`
impls gain the doc comments they were missing.

## Benchmarks

`lindera-analysis/benches/bench_tag_filters_ipadic.rs` is new. Nothing previously
exercised these filters — the existing analysis bench builds a `MappingCharacterFilter`
plus a `LowercaseTokenFilter` over a 12-character text. Five benches over
`resources/bocchan.txt` (the corpus the segmenter benches already use):

| Bench | Purpose |
| --- | --- |
| `apply-japanese-stop-tags` | The changed path, via `iter_batched` so segmentation and detail materialization stay untimed |
| `apply-japanese-keep-tags` | The Keep policy |
| `apply-empty-tag-set` | Regression guard that the fast path stays free |
| `pipeline-stop-tags` | Full chain with the filter |
| `pipeline-no-filter` | Control for the above |

They were run only to confirm they execute; no numbers are recorded, for the reason
given above.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -p lindera-analysis --features embed-ipadic
--all-targets -- -D warnings`, `cargo test -p lindera-analysis --features embed-ipadic`
(115 tests) and the IPADIC golden snapshots are all green. `--all-targets` covers the new
bench. No `train`-gated code is touched.

Closes #967
