### PR TITLE
perf(trainer): stop cloning the template list on every extract call

### DIFF
--- a/lindera-trainer/src/feature_extractor.rs
+++ b/lindera-trainer/src/feature_extractor.rs
@@ -31,7 +31,7 @@ enum FeatureType {
 }
 
 /// Parsed template structure
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct ParsedTemplate {
     raw_template: String,
     required_indices: Vec<usize>,
@@ -265,7 +265,24 @@ impl FeatureExtractor {
         }
     }
 
-    /// Apply a parsed template to generate feature string
+    /// Applies a parsed template to produce its generated feature string.
+    ///
+    /// An associated function rather than a method: it reads nothing from the
+    /// extractor, and keeping `&self` off it is part of what lets the extract
+    /// loops borrow the template vector and the id map disjointly (#965).
+    ///
+    /// # 引数
+    ///
+    /// * `template` - The parsed template to apply.
+    /// * `features` - The entry's feature fields, indexed by `%F`/`%L`/`%R`.
+    /// * `cate_id` - The character category id substituted for `%t`.
+    /// * `ctx` - Surface and full-feature strings for `%w`/`%u`/`%l`/`%r`.
+    ///
+    /// # 戻り値
+    ///
+    /// The generated feature string, or `None` when a `?`-marked required
+    /// field is undefined (`*`, empty, or out of range), which means the
+    /// template does not apply to this entry.
     fn apply_parsed_template(
         template: &ParsedTemplate,
         features: &[String],

--- a/lindera-trainer/src/feature_extractor.rs
+++ b/lindera-trainer/src/feature_extractor.rs
@@ -267,7 +267,6 @@ impl FeatureExtractor {
 
     /// Apply a parsed template to generate feature string
     fn apply_parsed_template(
-        &self,
         template: &ParsedTemplate,
         features: &[String],
         cate_id: u32,
@@ -310,44 +309,50 @@ impl FeatureExtractor {
     }
 
     /// Get or create feature ID (with NonZeroU32)
-    fn get_or_create_unigram_feature_id(&mut self, feature_str: &str) -> NonZeroU32 {
-        if let Some(&id) = self.unigram_feature_ids.get(feature_str) {
-            id
-        } else {
-            let new_id = NonZeroU32::new(self.unigram_next_id).unwrap();
-            let feature_id = *self
-                .unigram_feature_ids
-                .entry(feature_str.to_string())
-                .or_insert(new_id);
-            if new_id == feature_id {
-                self.unigram_next_id += 1;
-            }
-            feature_id
+    /// Interns `feature_str` in `ids`, minting the next id from `next_id` on
+    /// a miss.
+    ///
+    /// Takes the map and the counter as separate arguments rather than
+    /// `&mut self` so the callers can hold a shared borrow of their template
+    /// vector at the same time; that disjointness is what lets the extract
+    /// loops iterate the templates in place instead of cloning them (#965).
+    ///
+    /// The `get` lookup on the hit path matters: the `entry` API needs an
+    /// owned key, so going straight to it allocated a `String` on *every*
+    /// call, and the ids are interned precisely because the same feature
+    /// strings recur across lexicon entries.
+    ///
+    /// # 引数
+    ///
+    /// * `ids` - The feature-string to id map to intern into.
+    /// * `next_id` - The counter for this id space; incremented on a miss.
+    /// * `feature_str` - The generated feature string to intern.
+    ///
+    /// # 戻り値
+    ///
+    /// The existing id, or the newly minted one.
+    fn intern_feature_id(
+        ids: &mut HashMap<String, NonZeroU32>,
+        next_id: &mut u32,
+        feature_str: &str,
+    ) -> NonZeroU32 {
+        if let Some(&id) = ids.get(feature_str) {
+            return id;
         }
-    }
-
-    fn get_or_create_left_feature_id(&mut self, feature_str: &str) -> Option<NonZeroU32> {
-        let new_id = NonZeroU32::new(self.left_next_id).unwrap();
-        let feature_id = *self
-            .left_feature_ids
-            .entry(feature_str.to_string())
-            .or_insert(new_id);
-        if new_id == feature_id {
-            self.left_next_id += 1;
-        }
-        Some(feature_id)
-    }
-
-    fn get_or_create_right_feature_id(&mut self, feature_str: &str) -> Option<NonZeroU32> {
-        let new_id = NonZeroU32::new(self.right_next_id).unwrap();
-        let feature_id = *self
-            .right_feature_ids
-            .entry(feature_str.to_string())
-            .or_insert(new_id);
-        if new_id == feature_id {
-            self.right_next_id += 1;
-        }
-        Some(feature_id)
+        // `from_templates` starts the counters at 1, but `new()` starts them
+        // at 0, where `NonZeroU32::new` yields `None`. The retired helpers
+        // called `.unwrap()` there and would have panicked; clamping to 1
+        // instead keeps the production path free of `unwrap()` per CLAUDE.md.
+        // Advancing from the id actually minted -- rather than from
+        // `*next_id` -- is what keeps ids distinct in that case, instead of
+        // handing out 1 twice. Unreachable today (the template vectors are
+        // private and only `from_templates` fills them, so a `new()`-built
+        // extractor has nothing to iterate), but the helper is correct for
+        // any starting value rather than relying on that.
+        let new_id = NonZeroU32::new(*next_id).unwrap_or(NonZeroU32::MIN);
+        ids.insert(feature_str.to_string(), new_id);
+        *next_id = new_id.get().saturating_add(1);
+        new_id
     }
 
     /// Extracts unigram feature IDs from features.
@@ -366,15 +371,29 @@ impl FeatureExtractor {
         cate_id: u32,
         ctx: &TemplateContext,
     ) -> Vec<NonZeroU32> {
-        let mut feature_ids = Vec::new();
+        // Destructured so the template borrow and the id-map borrow are
+        // disjoint; iterating `self.unigram_templates` directly while calling
+        // a `&mut self` method is what forced the per-call clone this
+        // replaces (#965).
+        let Self {
+            unigram_templates,
+            unigram_feature_ids,
+            unigram_next_id,
+            ..
+        } = self;
 
-        // Clone templates to avoid borrow conflicts
-        let templates = self.unigram_templates.clone();
-        for template in templates {
-            if let Some(feature_str) = self.apply_parsed_template(&template, features, cate_id, ctx)
+        let mut feature_ids = Vec::with_capacity(unigram_templates.len());
+        for template in unigram_templates.iter() {
+            // A template whose `%F?` field is undefined is skipped entirely,
+            // so the result is shorter than the template list. The left/right
+            // variants below deliberately differ.
+            if let Some(feature_str) = Self::apply_parsed_template(template, features, cate_id, ctx)
             {
-                let id = self.get_or_create_unigram_feature_id(&feature_str);
-                feature_ids.push(id);
+                feature_ids.push(Self::intern_feature_id(
+                    unigram_feature_ids,
+                    unigram_next_id,
+                    &feature_str,
+                ));
             }
         }
 
@@ -392,16 +411,28 @@ impl FeatureExtractor {
         features: &[String],
         ctx: &TemplateContext,
     ) -> Vec<Option<NonZeroU32>> {
-        let mut feature_ids = Vec::new();
+        // See `extract_unigram_feature_ids_with_ctx` for why this is
+        // destructured rather than iterating through `self` (#965).
+        let Self {
+            left_templates,
+            left_feature_ids,
+            left_next_id,
+            ..
+        } = self;
 
-        // Clone templates to avoid borrow conflicts
-        let templates = self.left_templates.clone();
-        for template in templates {
-            if let Some(feature_str) = self.apply_parsed_template(&template, features, 0, ctx) {
-                let id = self.get_or_create_left_feature_id(&feature_str);
-                feature_ids.push(id);
+        let mut feature_ids = Vec::with_capacity(left_templates.len());
+        for template in left_templates.iter() {
+            // Unlike unigram extraction, a skipped template pushes `None`
+            // rather than being dropped, so the result stays index-aligned
+            // with the template list. Callers depend on that alignment.
+            if let Some(feature_str) = Self::apply_parsed_template(template, features, 0, ctx) {
+                feature_ids.push(Some(Self::intern_feature_id(
+                    left_feature_ids,
+                    left_next_id,
+                    &feature_str,
+                )));
             } else {
-                feature_ids.push(None); // Handle undefined features
+                feature_ids.push(None);
             }
         }
 
@@ -419,16 +450,28 @@ impl FeatureExtractor {
         features: &[String],
         ctx: &TemplateContext,
     ) -> Vec<Option<NonZeroU32>> {
-        let mut feature_ids = Vec::new();
+        // See `extract_unigram_feature_ids_with_ctx` for why this is
+        // destructured rather than iterating through `self` (#965).
+        let Self {
+            right_templates,
+            right_feature_ids,
+            right_next_id,
+            ..
+        } = self;
 
-        // Clone templates to avoid borrow conflicts
-        let templates = self.right_templates.clone();
-        for template in templates {
-            if let Some(feature_str) = self.apply_parsed_template(&template, features, 0, ctx) {
-                let id = self.get_or_create_right_feature_id(&feature_str);
-                feature_ids.push(id);
+        let mut feature_ids = Vec::with_capacity(right_templates.len());
+        for template in right_templates.iter() {
+            // Unlike unigram extraction, a skipped template pushes `None`
+            // rather than being dropped, so the result stays index-aligned
+            // with the template list. Callers depend on that alignment.
+            if let Some(feature_str) = Self::apply_parsed_template(template, features, 0, ctx) {
+                feature_ids.push(Some(Self::intern_feature_id(
+                    right_feature_ids,
+                    right_next_id,
+                    &feature_str,
+                )));
             } else {
-                feature_ids.push(None); // Handle undefined features
+                feature_ids.push(None);
             }
         }
 


### PR DESCRIPTION
## Background

Closes #965. Phase 2 of two — #970 landed the tests that guard this change.

`FeatureExtractor`'s three `extract_*_with_ctx` entry points each began by deep-cloning
the whole template list, annotated `// Clone templates to avoid borrow conflicts`.
`ParsedTemplate` holds a `String` plus two `Vec`s, so each clone costs 2–3 heap
allocations, and mecab-ipadic's `feature.def` expands to 130 templates (20 unigram + 55
left + 55 right) walked once per lexicon entry.

### The comment misattributed the conflict

It is not `apply_parsed_template` — that function never reads `self`. The conflict is
between `self.get_or_create_*_feature_id(..)` (`&mut self`) and
`for template in &self.unigram_templates` (a shared borrow of `*self`) in the same loop
body. Making `apply_parsed_template` an associated function **alone still fails to
compile**; I verified that with a minimal reproduction under `rustc --edition 2024`:

| Variant | Result |
| --- | --- |
| Associated-fn `apply_parsed_template` only | `error[E0502]` |
| Field-splitting borrow | compiles |
| Index loop | compiles |

## Changes

**Split the borrows structurally.** The three `get_or_create_*_feature_id` methods
collapse into one associated `intern_feature_id(ids, next_id, feature_str)` taking the
map and the counter separately, and each extract fn destructures
`let Self { .. } = self;` so the template vector and the id map are borrowed disjointly.
The templates are then iterated in place. `apply_parsed_template` also loses its unused
`&self`.

Two further allocations go with it:

- `get_or_create_left/right_feature_id` went straight to
  `entry(feature_str.to_string())`, allocating a `String` on **every** call including
  hits. Since ids are interned, the vast majority of calls are hits.
  `intern_feature_id` does the `get` lookup first, as the unigram variant already did.
- The result vectors started from `Vec::new()`; they are now sized from the template
  count.

`ParsedTemplate`'s `Clone` derive is dropped, since nothing clones one any more.

**No public signature changes.** The `pub` id-map fields stay where they are, so
`Trainer::remove_unused_features` keeps working against them unchanged.

## Measurements

Deterministic global-allocator counter (hooking `alloc`, `alloc_zeroed` and `realloc`)
around the three extract calls, over 2000 entries against a template set shaped like
mecab-ipadic's `feature.def` — 130 templates with the same 12/20 and 41/55 ratio of
`?`-marked ones — in the steady state where ids are already interned:

| | Before | After |
| --- | ---: | ---: |
| allocations per lexicon entry | 882.00 | **404.00** (−54%) |

### Scope of the win, stated honestly

This runs once inside `Trainer::new` per `lindera train` invocation. **The win is
training-time startup and allocator churn, not tokenization speed.**
`apply_parsed_template` still allocates for its own work, so this removes roughly the
template-side half of the allocations in this loop, not an order of magnitude.

No wall-clock claim is made — the machine available for this work is too noisy to measure
on. Any timing figure must come from the interleaved min-of-N protocol in
`scripts/benchmarks/README.md` on an idle machine.

## Output preservation, verified end to end

Ran `lindera train` → `lindera export` on both sides with the `resources/training/`
fixtures (`-t 1 -i 20` for determinism). **All eight exported files are byte-identical:**
`left-id.def`, `right-id.def`, `lex.csv`, `matrix.def`, `unk.def`, `char.def`,
`feature.def`, `rewrite.def`.

`model.dat` itself differs — but an A/A control showed **the same code also fails to
reproduce its own `model.dat`**, so that is not attributable to this change.
`SerializableModel` serializes `HashMap` fields whose iteration order is randomly seeded
per process. Filed as #974.

Behavior is otherwise guarded by the nine tests from #970: template iteration order,
unigram's `None`-skip vs left/right's `None`-push, id sequence continuity across calls,
`%F?` skip semantics, and the independence of the three id spaces. All still green,
unmodified.

## Incidental fix: three `unwrap()`s removed from production code

The retired helpers each contained `NonZeroU32::new(next_id).unwrap()`, which CLAUDE.md
disallows in production code. They were safe only because `from_templates` starts the
counters at 1 — while `new()` starts them at **0**, where they would have panicked.

`intern_feature_id` clamps to 1 instead, and advances from the id actually minted rather
than from `*next_id`, so it hands out distinct ids for any starting value instead of
relying on an undocumented invariant. That path is unreachable today (the template
vectors are private and only `from_templates` fills them, so a `new()`-built extractor
has nothing to iterate), and the code says so.

## Follow-ups filed

Per this issue's last acceptance criterion, the section 4 items not included here are now
tracked:

- #974 — `model.dat` is not reproducible across runs (found while verifying this PR)
- #975 — `rewrite_cached` never hits for a real seed lexicon
- #976 — `extract_*` forces a `Vec<String>` per lexicon entry (needs a public API
  decision, which is why it is not bundled here)

## Verification

- `cargo test -p lindera-trainer` — 29 + 1 passed
- `cargo test -p lindera --features train --lib` — 6 passed
- `cargo build -p lindera-cli` (which enables `train` by default) — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p lindera-trainer --all-targets -- -D warnings` — clean

Closes #965
