### PR TITLE
perf(dictionary): yield token details without an intermediate Vec

### DIFF
--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -29,10 +29,160 @@ use crate::loader::connection_cost_matrix::ConnectionCostMatrixLoader;
 use crate::loader::metadata::MetadataLoader;
 use crate::loader::prefix_dictionary::PrefixDictionaryLoader;
 use crate::loader::unknown_dictionary::UnknownDictionaryLoader;
-use crate::util::{Data, detail_field_count};
+use crate::util::{Data, detail_field_count, joined_details_at, words_idx_offset};
 use crate::viterbi::WordEntry;
 
-pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec!["UNK"]);
+/// The single field the unknown-word sentinel consists of.
+///
+/// Kept as a constant so [`UNK`] and [`DetailFields::unk`] cannot drift apart.
+const UNK_FIELD: &str = "UNK";
+
+pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec![UNK_FIELD]);
+
+/// The detail fields of one dictionary entry, borrowed from the dictionary's
+/// own bytes.
+///
+/// Yielding borrows rather than a `Vec` is what lets a caller materialize an
+/// entry's details in a single allocation: the fields are handed out straight
+/// from the packed record, with no intermediate collection (#966). The
+/// iterator is [`ExactSizeIterator`], so a caller can size its buffer exactly
+/// before consuming anything.
+///
+/// Obtained from [`Dictionary::word_details_iter`],
+/// [`Dictionary::unknown_word_details_iter`],
+/// [`UserDictionary::word_details_iter`], or
+/// [`UnknownDictionary::word_details_iter`].
+pub struct DetailFields<'a> {
+    /// The remaining fields, split from the entry's NUL-joined blob.
+    inner: str::Split<'a, char>,
+    /// How many fields `inner` has yet to yield, for `ExactSizeIterator`.
+    remaining: usize,
+}
+
+impl<'a> DetailFields<'a> {
+    /// Builds the field list of a validated NUL-joined blob.
+    ///
+    /// # 引数
+    ///
+    /// * `joined` - The entry's joined fields, already UTF-8 validated.
+    ///
+    /// # 戻り値
+    ///
+    /// The fields in schema order; always at least one, since an empty blob
+    /// splits into a single empty field.
+    #[inline]
+    fn from_joined(joined: &'a str) -> Self {
+        Self {
+            inner: joined.split('\0'),
+            remaining: detail_field_count(joined.as_bytes()),
+        }
+    }
+
+    /// The unknown-word sentinel: a single `"UNK"` field.
+    ///
+    /// This is what every accessor falls back to for a malformed entry. It is
+    /// built by splitting the sentinel itself, so the fallback runs through
+    /// the same machinery as a real entry instead of needing its own variant.
+    ///
+    /// # 戻り値
+    ///
+    /// A one-field iterator yielding `"UNK"`.
+    //
+    // Returns `Self`, not `DetailFields<'static>`: `str::Split` makes this
+    // type invariant over `'a`, so a `'static` value would not coerce to a
+    // shorter lifetime. The `&'static str` constant coerces to `&'a str`
+    // before construction instead, which needs no variance.
+    #[inline]
+    pub fn unk() -> Self {
+        Self::from_joined(UNK_FIELD)
+    }
+
+    /// An entry with no fields at all.
+    ///
+    /// Distinct from [`DetailFields::unk`]: this is what
+    /// [`Dictionary::word_details_iter`] yields for an out-of-range word id,
+    /// where the allocating accessor has always returned an empty vector.
+    ///
+    /// # 戻り値
+    ///
+    /// An iterator that yields nothing.
+    //
+    // Returns `Self` for the same invariance reason as `unk`.
+    #[inline]
+    pub fn empty() -> Self {
+        Self {
+            inner: "".split('\0'),
+            remaining: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for DetailFields<'a> {
+    type Item = &'a str;
+
+    /// Yields the next detail field.
+    ///
+    /// # 戻り値
+    ///
+    /// The next field in schema order, or `None` once all are consumed.
+    #[inline]
+    fn next(&mut self) -> Option<&'a str> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
+        self.inner.next()
+    }
+
+    /// Reports the exact number of fields left, so collecting into a `Vec`
+    /// reserves in one shot.
+    ///
+    /// # 戻り値
+    ///
+    /// `(remaining, Some(remaining))`.
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for DetailFields<'_> {}
+
+/// Looks up one entry in a packed dictionary's detail records.
+///
+/// Shared by [`Dictionary`] and [`UserDictionary`], whose storage layout is
+/// identical and whose only behavioural difference is what a word id with no
+/// slot in the index yields.
+///
+/// # 引数
+///
+/// * `words_idx_data` - The word-id index table.
+/// * `words_data` - The packed detail records.
+/// * `word_id` - The word id to look up.
+/// * `missing` - Builds the fallback for a word id with no slot in the index.
+///
+/// # 戻り値
+///
+/// The entry's fields; `missing()` when the id has no slot, and
+/// [`DetailFields::unk`] when the entry itself is malformed.
+#[inline]
+fn packed_details_iter<'a>(
+    words_idx_data: &'a [u8],
+    words_data: &'a [u8],
+    word_id: usize,
+    missing: fn() -> DetailFields<'a>,
+) -> DetailFields<'a> {
+    let Some(offset) = words_idx_offset(words_idx_data, word_id) else {
+        return missing();
+    };
+    // A malformed entry always falls back to the sentinel in both
+    // dictionaries; only a word id with no slot at all is subject to
+    // `missing`.
+    match joined_details_at(words_data, offset) {
+        Some(joined) => DetailFields::from_joined(joined),
+        None => DetailFields::unk(),
+    }
+}
 
 /// `prefix_dictionary` and `connection_cost_matrix` are `Arc`-wrapped so that
 /// `Dictionary::clone()` is O(1) regardless of load method (embedded, mmap,
@@ -50,46 +200,77 @@ pub struct Dictionary {
 
 impl Dictionary {
     /// Retrieve the detail fields (POS, etc.) for an unknown word entry.
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The unknown-word entry id.
+    ///
+    /// # 戻り値
+    ///
+    /// A freshly allocated vector of the entry's fields, or the [`UNK`]
+    /// sentinel when the id is out of range or the entry is malformed. Prefer
+    /// [`Dictionary::unknown_word_details_iter`] on per-token paths, which
+    /// yields the same fields without allocating.
     pub fn unknown_word_details(&self, word_id: usize) -> Vec<&str> {
-        match self.unknown_dictionary.word_details(word_id as u32) {
-            Some(details) => details,
-            None => UNK.to_vec(),
-        }
+        self.unknown_word_details_iter(word_id).collect()
     }
 
+    /// Yields the detail fields of an unknown-word entry, borrowed from the
+    /// dictionary's own bytes.
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The unknown-word entry id.
+    ///
+    /// # 戻り値
+    ///
+    /// The entry's fields, or the [`UNK`] sentinel when the id is out of
+    /// range or the entry is malformed -- the fallback
+    /// [`Dictionary::unknown_word_details`] has always applied.
+    #[inline]
+    pub fn unknown_word_details_iter<'a>(&'a self, word_id: usize) -> DetailFields<'a> {
+        self.unknown_dictionary
+            .word_details_iter(word_id as u32)
+            .unwrap_or_else(DetailFields::unk)
+    }
+
+    /// Retrieve the detail fields (POS, etc.) for a system dictionary entry.
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The system word id.
+    ///
+    /// # 戻り値
+    ///
+    /// A freshly allocated vector of the entry's fields; empty when `word_id`
+    /// is out of range, and the [`UNK`] sentinel when the entry is malformed.
+    /// Prefer [`Dictionary::word_details_iter`] on per-token paths, which
+    /// yields the same fields without allocating.
     pub fn word_details(&self, word_id: usize) -> Vec<&str> {
-        if 4 * word_id >= self.prefix_dictionary.words_idx_data.len() {
-            return vec![];
-        }
+        self.word_details_iter(word_id).collect()
+    }
 
-        let idx: usize = match LittleEndian::read_u32(
-            &self.prefix_dictionary.words_idx_data[4 * word_id..][..4],
+    /// Yields the detail fields of a system dictionary entry, borrowed from
+    /// the dictionary's own bytes.
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The system word id.
+    ///
+    /// # 戻り値
+    ///
+    /// The entry's fields; [`DetailFields::empty`] when `word_id` is out of
+    /// range, and [`DetailFields::unk`] when the entry is malformed. Those
+    /// two fallbacks differ, and both are what
+    /// [`Dictionary::word_details`] has always returned.
+    #[inline]
+    pub fn word_details_iter<'a>(&'a self, word_id: usize) -> DetailFields<'a> {
+        packed_details_iter(
+            &self.prefix_dictionary.words_idx_data,
+            &self.prefix_dictionary.words_data,
+            word_id,
+            DetailFields::empty,
         )
-        .try_into()
-        {
-            Ok(value) => value,
-            Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
-        };
-        let data = &self.prefix_dictionary.words_data[idx..];
-        let joined_details_len: usize = match LittleEndian::read_u32(data).try_into() {
-            Ok(value) => value,
-            Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
-        };
-        let joined_details_bytes: &[u8] =
-            &self.prefix_dictionary.words_data[idx + 4..idx + 4 + joined_details_len];
-
-        // Size the vector from the separator count so the pushes below never
-        // reallocate; growing from capacity zero cost two reallocations per
-        // token for a 9-field dictionary (#966).
-        let mut details = Vec::with_capacity(detail_field_count(joined_details_bytes));
-        for bytes in joined_details_bytes.split(|&b| b == 0) {
-            let detail = match str::from_utf8(bytes) {
-                Ok(s) => s,
-                Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
-            };
-            details.push(detail);
-        }
-        details
     }
 
     /// Load dictionary from a directory containing dictionary files.
@@ -247,31 +428,45 @@ impl UserDictionary {
         })
     }
 
+    /// Retrieve the detail fields (POS, etc.) for a user dictionary entry.
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The user-dictionary word id.
+    ///
+    /// # 戻り値
+    ///
+    /// A freshly allocated vector of the entry's fields, or the [`UNK`]
+    /// sentinel when the id is out of range or the entry is malformed --
+    /// note this differs from [`Dictionary::word_details`], which returns an
+    /// empty vector for an out-of-range id. Prefer
+    /// [`UserDictionary::word_details_iter`] on per-token paths, which yields
+    /// the same fields without allocating.
     pub fn word_details(&self, word_id: usize) -> Vec<&str> {
-        if 4 * word_id >= self.dict.words_idx_data.len() {
-            return UNK.to_vec(); // fall back to the UNK sentinel for an out-of-range word id
-        }
-        let idx = LittleEndian::read_u32(&self.dict.words_idx_data[4 * word_id..][..4]);
-        let data = &self.dict.words_data[idx as usize..];
+        self.word_details_iter(word_id).collect()
+    }
 
-        // Parse the data in the same format as main Dictionary
-        let joined_details_len: usize = match LittleEndian::read_u32(data).try_into() {
-            Ok(value) => value,
-            Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
-        };
-        let joined_details_bytes: &[u8] =
-            &self.dict.words_data[idx as usize + 4..idx as usize + 4 + joined_details_len];
-
-        // Presized from the separator count; see `Dictionary::word_details` (#966).
-        let mut details = Vec::with_capacity(detail_field_count(joined_details_bytes));
-        for bytes in joined_details_bytes.split(|&b| b == 0) {
-            let detail = match str::from_utf8(bytes) {
-                Ok(s) => s,
-                Err(_) => return UNK.to_vec(), // fall back to the UNK sentinel if conversion fails
-            };
-            details.push(detail);
-        }
-        details
+    /// Yields the detail fields of a user dictionary entry, borrowed from the
+    /// dictionary's own bytes.
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The user-dictionary word id.
+    ///
+    /// # 戻り値
+    ///
+    /// The entry's fields, or [`DetailFields::unk`] when the id is out of
+    /// range or the entry is malformed. Unlike
+    /// [`Dictionary::word_details_iter`], an out-of-range id yields the
+    /// sentinel rather than nothing; that divergence is pre-existing.
+    #[inline]
+    pub fn word_details_iter<'a>(&'a self, word_id: usize) -> DetailFields<'a> {
+        packed_details_iter(
+            &self.dict.words_idx_data,
+            &self.dict.words_data,
+            word_id,
+            DetailFields::unk,
+        )
     }
 }
 
@@ -279,7 +474,7 @@ impl UserDictionary {
 mod tests {
     use daachorse::DoubleArrayAhoCorasickBuilder;
 
-    use super::{UNK, UserDictionary};
+    use super::{DetailFields, UNK, UserDictionary};
     use crate::dictionary::prefix_dictionary::UserPrefixDictionary;
 
     /// Builds a user dictionary whose words blob holds `entries`, each
@@ -353,5 +548,75 @@ mod tests {
         bytes[last] = 0xff;
         dict.dict.words_data = bytes.into();
         assert_eq!(dict.word_details(0), UNK.to_vec());
+    }
+
+    /// The iterator and the allocating accessor must agree field for field --
+    /// the latter is now implemented as `collect()` over the former, so this
+    /// pins that the delegation did not change what callers see.
+    #[test]
+    fn user_word_details_iter_matches_word_details() {
+        let dict = user_dictionary(&[
+            &["カスタム名詞", "*", "リンデラ"],
+            &["動詞", "自立", "*"],
+            &["ONLY"],
+        ]);
+
+        for word_id in 0..3 {
+            let via_iter: Vec<&str> = dict.word_details_iter(word_id).collect();
+            assert_eq!(via_iter, dict.word_details(word_id), "word_id {word_id}");
+        }
+    }
+
+    /// `DetailFields` reports its length before anything is consumed, which
+    /// is what lets a caller size its buffer in one shot. If this stopped
+    /// being exact, `Token::ensure_details` would silently start
+    /// reallocating.
+    #[test]
+    fn user_word_details_iter_reports_an_exact_length() {
+        let dict = user_dictionary(&[&["a", "b", "c"], &["only"]]);
+
+        let mut fields = dict.word_details_iter(0);
+        assert_eq!(fields.len(), 3);
+        assert_eq!(fields.next(), Some("a"));
+        assert_eq!(fields.len(), 2, "len must track consumption");
+        assert_eq!(fields.count(), 2);
+
+        assert_eq!(dict.word_details_iter(1).len(), 1);
+        // The out-of-range sentinel is one field, not zero.
+        assert_eq!(dict.word_details_iter(99).len(), 1);
+    }
+
+    /// A word id whose index entry points past `words_data` used to panic on
+    /// an unchecked slice. It now falls back to the sentinel, matching what
+    /// `UnknownDictionary` has always done and the repo's no-panic rule.
+    #[test]
+    fn user_word_details_corrupt_offset_falls_back_instead_of_panicking() {
+        let mut dict = user_dictionary(&[&["名詞", "一般"]]);
+
+        // Point word id 0's index entry far past the end of `words_data`.
+        let idx: &[u8] = &dict.dict.words_idx_data;
+        let mut idx_bytes = idx.to_vec();
+        let words_len: &[u8] = &dict.dict.words_data;
+        let past_end = (words_len.len() as u32) + 1_000;
+        idx_bytes[0..4].copy_from_slice(&past_end.to_le_bytes());
+        dict.dict.words_idx_data = idx_bytes.into();
+
+        assert_eq!(dict.word_details(0), UNK.to_vec());
+        assert_eq!(dict.word_details_iter(0).collect::<Vec<_>>(), vec!["UNK"]);
+    }
+
+    /// `DetailFields::empty` yields nothing and `DetailFields::unk` yields
+    /// exactly the sentinel, and the two are distinct -- `Dictionary` uses
+    /// the first for an out-of-range id where `UserDictionary` uses the
+    /// second.
+    #[test]
+    fn detail_fields_constructors() {
+        assert_eq!(
+            DetailFields::empty().collect::<Vec<_>>(),
+            Vec::<&str>::new()
+        );
+        assert_eq!(DetailFields::empty().len(), 0);
+        assert_eq!(DetailFields::unk().collect::<Vec<_>>(), UNK.to_vec());
+        assert_eq!(DetailFields::unk().len(), 1);
     }
 }

--- a/lindera-dictionary/src/dictionary/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/unknown_dictionary.rs
@@ -5,9 +5,10 @@ use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::LinderaResult;
+use crate::dictionary::DetailFields;
 use crate::dictionary::character_definition::CategoryId;
 use crate::error::LinderaErrorKind;
-use crate::util::detail_field_count;
+use crate::util::joined_details_at;
 use crate::viterbi::WordEntry;
 
 #[derive(Serialize, Deserialize, Clone, Archive, RkyvSerialize, RkyvDeserialize)]
@@ -40,26 +41,44 @@ impl UnknownDictionary {
     }
 
     /// Retrieve the detail fields (POS, etc.) for an unknown word entry.
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The unknown-word entry id.
+    ///
+    /// # 戻り値
+    ///
+    /// A freshly allocated vector of the entry's fields, or `None` when the
+    /// id is out of range or the entry is malformed. Prefer
+    /// [`UnknownDictionary::word_details_iter`] on per-token paths, which
+    /// yields the same fields without allocating.
     pub fn word_details(&self, word_id: u32) -> Option<Vec<&str>> {
-        let idx = word_id as usize;
-        if idx >= self.words_idx_data.len() {
-            return None;
-        }
-        let offset = self.words_idx_data[idx] as usize;
-        if offset + 4 > self.words_data.len() {
-            return None;
-        }
-        let len = u32::from_le_bytes(self.words_data[offset..offset + 4].try_into().ok()?) as usize;
-        if offset + 4 + len > self.words_data.len() {
-            return None;
-        }
-        let text = std::str::from_utf8(&self.words_data[offset + 4..offset + 4 + len]).ok()?;
-        // `str::Split` reports a `(0, None)` size hint, so `collect()` would
-        // grow this vector from capacity zero. Size it from the separator
-        // count instead (#966).
-        let mut details = Vec::with_capacity(detail_field_count(text.as_bytes()));
-        details.extend(text.split('\0'));
-        Some(details)
+        self.word_details_iter(word_id).map(Iterator::collect)
+    }
+
+    /// Yields the detail fields of an unknown-word entry, borrowed from this
+    /// dictionary's own bytes.
+    ///
+    /// Unlike the packed dictionaries, this one distinguishes "no such entry"
+    /// from "an entry with no fields", so the absence stays in the return
+    /// type rather than collapsing into a sentinel; the caller decides what
+    /// to substitute (see [`Dictionary::unknown_word_details_iter`]).
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The unknown-word entry id.
+    ///
+    /// # 戻り値
+    ///
+    /// The entry's fields, or `None` when the id is out of range or the entry
+    /// is malformed.
+    #[inline]
+    pub fn word_details_iter<'a>(&'a self, word_id: u32) -> Option<DetailFields<'a>> {
+        // `words_idx_data` here is a `Vec<u32>`, not a packed byte table, so
+        // the index lookup cannot share `util::words_idx_offset`; the blob
+        // decode below is shared.
+        let offset = *self.words_idx_data.get(word_id as usize)? as usize;
+        joined_details_at(&self.words_data, offset).map(DetailFields::from_joined)
     }
 
     /// Unknown word generation with callback system

--- a/lindera-dictionary/src/util.rs
+++ b/lindera-dictionary/src/util.rs
@@ -36,6 +36,61 @@ pub(crate) fn detail_field_count(joined_details: &[u8]) -> usize {
     memchr::memchr_iter(0, joined_details).count() + 1
 }
 
+/// Reads the `words_data` byte offset a word id maps to.
+///
+/// Both packed dictionaries store `words_idx_data` as one little-endian `u32`
+/// per word id. Every step is bounds-checked, so a corrupt archive or an
+/// absurd id ends in `None` instead of a panic -- the accessors used to slice
+/// this unchecked (#966).
+///
+/// # 引数
+///
+/// * `words_idx_data` - The word-id index table.
+/// * `word_id` - The word id to look up.
+///
+/// # 戻り値
+///
+/// The entry's byte offset into `words_data`, or `None` when the id has no
+/// slot in the table. Callers map `None` onto their own missing-entry
+/// fallback, which differs per dictionary.
+#[inline]
+pub(crate) fn words_idx_offset(words_idx_data: &[u8], word_id: usize) -> Option<usize> {
+    let start = word_id.checked_mul(4)?;
+    let bytes = words_idx_data.get(start..start.checked_add(4)?)?;
+    let offset: [u8; 4] = bytes.try_into().ok()?;
+    Some(u32::from_le_bytes(offset) as usize)
+}
+
+/// Locates and validates one entry's NUL-joined detail blob.
+///
+/// Each entry is a 4-byte little-endian length followed by that many bytes of
+/// NUL-joined fields. The whole blob is validated once rather than field by
+/// field: NUL is ASCII and therefore never occurs inside a multi-byte UTF-8
+/// sequence, so "the blob is valid UTF-8" and "every field is valid UTF-8"
+/// are the same statement. One `from_utf8` call replaces one per field, and
+/// the resulting `&str` can be split without re-validating.
+///
+/// # 引数
+///
+/// * `words_data` - The packed detail records.
+/// * `offset` - The entry's byte offset inside `words_data`.
+///
+/// # 戻り値
+///
+/// The entry's joined fields, or `None` when the offset, the declared length
+/// or the payload's encoding is invalid.
+#[inline]
+pub(crate) fn joined_details_at(words_data: &[u8], offset: usize) -> Option<&str> {
+    let header: [u8; 4] = words_data
+        .get(offset..offset.checked_add(4)?)?
+        .try_into()
+        .ok()?;
+    let start = offset + 4;
+    let len = u32::from_le_bytes(header) as usize;
+    let bytes = words_data.get(start..start.checked_add(len)?)?;
+    str::from_utf8(bytes).ok()
+}
+
 /// Write data directly to the writer.
 pub fn write_data<W: Write>(buffer: &[u8], writer: &mut W) -> LinderaResult<()> {
     writer.write_all(buffer).map_err(|err| {
@@ -193,7 +248,7 @@ impl<'de> Deserialize<'de> for Data {
 
 #[cfg(test)]
 mod tests {
-    use super::detail_field_count;
+    use super::{detail_field_count, joined_details_at, words_idx_offset};
 
     /// The count must match what `slice::split` actually yields, which is the
     /// invariant the presized detail vectors rely on.
@@ -229,5 +284,77 @@ mod tests {
     fn detail_field_count_ipadic_shape() {
         let blob = b"\xe5\x90\x8d\xe8\xa9\x9e\0*\0*\0*\0*\0*\0a\0b\0c";
         assert_eq!(detail_field_count(blob), 9);
+    }
+
+    /// Builds a `words_data` blob holding `entries`, each encoded as a 4-byte
+    /// LE length followed by its NUL-joined fields, and returns it with each
+    /// entry's offset.
+    fn packed(entries: &[&[&str]]) -> (Vec<u8>, Vec<usize>) {
+        let mut data = Vec::new();
+        let mut offsets = Vec::new();
+        for fields in entries {
+            offsets.push(data.len());
+            let joined = fields.join("\0");
+            data.extend_from_slice(&(joined.len() as u32).to_le_bytes());
+            data.extend_from_slice(joined.as_bytes());
+        }
+        (data, offsets)
+    }
+
+    /// Each entry decodes to its own blob, not to the tail of the buffer.
+    #[test]
+    fn joined_details_at_reads_the_declared_length() {
+        let (data, offsets) = packed(&[&["名詞", "一般"], &["動詞", "自立", "*"]]);
+
+        assert_eq!(joined_details_at(&data, offsets[0]), Some("名詞\0一般"));
+        assert_eq!(joined_details_at(&data, offsets[1]), Some("動詞\0自立\0*"));
+    }
+
+    /// A truncated header, an offset past the end, and a declared length that
+    /// runs past the buffer all yield `None` rather than panicking. The
+    /// accessors used to slice this unchecked.
+    #[test]
+    fn joined_details_at_rejects_out_of_range_offsets_and_lengths() {
+        let (mut data, offsets) = packed(&[&["名詞", "一般"]]);
+
+        // Offset past the end, and an offset whose 4-byte header straddles it.
+        assert_eq!(joined_details_at(&data, data.len()), None);
+        assert_eq!(joined_details_at(&data, data.len() - 2), None);
+        // An offset so large that `offset + 4` would overflow.
+        assert_eq!(joined_details_at(&data, usize::MAX), None);
+
+        // Declared length running past the buffer.
+        let past_end = (data.len() + 1) as u32;
+        data[offsets[0]..offsets[0] + 4].copy_from_slice(&past_end.to_le_bytes());
+        assert_eq!(joined_details_at(&data, offsets[0]), None);
+
+        // A length so large that `start + len` would overflow.
+        data[offsets[0]..offsets[0] + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert_eq!(joined_details_at(&data, offsets[0]), None);
+    }
+
+    /// Invalid UTF-8 anywhere in the blob rejects the whole entry, which is
+    /// what per-field validation did too.
+    #[test]
+    fn joined_details_at_rejects_invalid_utf8() {
+        let (mut data, offsets) = packed(&[&["ok", "fields"]]);
+        let last = data.len() - 1;
+        data[last] = 0xff;
+
+        assert_eq!(joined_details_at(&data, offsets[0]), None);
+    }
+
+    /// Word ids index a table of little-endian `u32`s; out-of-range and
+    /// overflowing ids yield `None`.
+    #[test]
+    fn words_idx_offset_reads_and_bounds_checks() {
+        let table: Vec<u8> = [7u32, 42u32].iter().flat_map(|v| v.to_le_bytes()).collect();
+
+        assert_eq!(words_idx_offset(&table, 0), Some(7));
+        assert_eq!(words_idx_offset(&table, 1), Some(42));
+        assert_eq!(words_idx_offset(&table, 2), None);
+        // `word_id * 4` overflows.
+        assert_eq!(words_idx_offset(&table, usize::MAX), None);
+        assert_eq!(words_idx_offset(&table, usize::MAX / 4), None);
     }
 }

--- a/lindera/src/token.rs
+++ b/lindera/src/token.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use lindera_dictionary::dictionary::UNK;
+use lindera_dictionary::dictionary::{DetailFields, UNK};
 use serde_json::{Value, json};
 
 use crate::dictionary::{Dictionary, UserDictionary, WordId};
@@ -155,43 +155,55 @@ impl<'a> Token<'a> {
             .map(|c| c.as_ref())
     }
 
-    /// Helper method to ensure details are loaded without returning them
+    /// Loads and caches this token's detail fields.
+    ///
+    /// The fields are borrowed straight out of the dictionary's own bytes and
+    /// written into the cache vector, which is sized exactly once, so
+    /// materializing a token's details costs a single allocation: the cache
+    /// itself. Going through an intermediate `Vec<&str>` cost one more
+    /// (#966).
     fn ensure_details(&mut self) {
-        if self.details.is_none() {
-            let tmp = if self.word_id.is_unknown() {
-                self.dictionary
-                    .unknown_word_details(self.word_id.id() as usize)
-            } else if self.word_id.is_system() {
-                self.dictionary.word_details(self.word_id.id() as usize)
-            } else {
-                match self.user_dictionary {
-                    Some(user_dictionary) => {
-                        user_dictionary.word_details(self.word_id.id() as usize)
-                    }
-                    None => UNK.to_vec(),
-                }
-            };
-
-            // Pad details to match the dictionary schema's custom field count so that
-            // token filters can safely access any field by index.
-            let expected_len = self
-                .dictionary
-                .metadata
-                .dictionary_schema
-                .get_custom_fields()
-                .len();
-
-            // Reserve for the padded length up front: collecting first and
-            // resizing afterwards allocated twice whenever the entry carried
-            // fewer fields than the schema (#966).
-            let mut details: Vec<Cow<'a, str>> = Vec::with_capacity(tmp.len().max(expected_len));
-            details.extend(tmp.into_iter().map(Cow::Borrowed));
-            if details.len() < expected_len {
-                details.resize(expected_len, Cow::Borrowed("*"));
-            }
-
-            self.details = Some(details);
+        if self.details.is_some() {
+            return;
         }
+
+        // Copied out of `self` before the borrow below so the fields borrow
+        // for `'a` rather than for this `&mut self`; the dictionary accessors
+        // take `&'a self`.
+        let dictionary: &'a Dictionary = self.dictionary;
+        let user_dictionary: Option<&'a UserDictionary> = self.user_dictionary;
+        let word_id = self.word_id.id() as usize;
+
+        let fields = if self.word_id.is_unknown() {
+            dictionary.unknown_word_details_iter(word_id)
+        } else if self.word_id.is_system() {
+            dictionary.word_details_iter(word_id)
+        } else {
+            match user_dictionary {
+                Some(user_dictionary) => user_dictionary.word_details_iter(word_id),
+                None => DetailFields::unk(),
+            }
+        };
+
+        // Details are padded to the dictionary schema's custom field count so
+        // that token filters can safely access any field by index.
+        let expected_len = dictionary
+            .metadata
+            .dictionary_schema
+            .get_custom_fields()
+            .len();
+
+        // `DetailFields` is an `ExactSizeIterator`, so the padded width is
+        // known before anything is materialized and this is the only
+        // allocation on the path -- neither the extend nor the pad below can
+        // reallocate.
+        let mut details: Vec<Cow<'a, str>> = Vec::with_capacity(fields.len().max(expected_len));
+        details.extend(fields.map(Cow::Borrowed));
+        if details.len() < expected_len {
+            details.resize(expected_len, Cow::Borrowed("*"));
+        }
+
+        self.details = Some(details);
     }
 
     /// Retrieves the token's detail at the specified index, if available.
@@ -505,5 +517,102 @@ mod tests {
             assert_eq!(expected, actual, "surface {:?}", token.surface);
             assert!(!actual.is_empty());
         }
+    }
+
+    /// The detail cache must be allocated exactly once: `DetailFields` is an
+    /// `ExactSizeIterator`, so `ensure_details` can size the vector before
+    /// materializing anything and neither the extend nor the schema padding
+    /// reallocates. A capacity larger than the padded width means something
+    /// grew, which is precisely the regression #966 step (b) removed -- and
+    /// it is observable without an allocator hook.
+    #[test]
+    fn test_details_cache_is_allocated_exactly_once() {
+        let dictionary = match load_dictionary("embedded://ipadic") {
+            Ok(dictionary) => dictionary,
+            Err(err) => panic!("failed to load embedded IPADIC: {err}"),
+        };
+        let expected_len = dictionary
+            .metadata
+            .dictionary_schema
+            .get_custom_fields()
+            .len();
+
+        let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+        // Mixed input: system entries plus a Latin run that becomes an
+        // unknown word, so both dictionary paths are covered.
+        let tokens = match segmenter.segment(Cow::Borrowed("東京都でsupercalifragilisticを買う"))
+        {
+            Ok(tokens) => tokens,
+            Err(err) => panic!("segment failed: {err}"),
+        };
+        assert!(!tokens.is_empty());
+
+        let mut saw_unknown = false;
+        for mut token in tokens {
+            saw_unknown |= token.word_id.is_unknown();
+            let _ = token.details_iter().count();
+            let details = match token.details.as_ref() {
+                Some(details) => details,
+                None => panic!("details must be cached after details_iter"),
+            };
+            assert_eq!(details.len(), expected_len, "surface {:?}", token.surface);
+            assert_eq!(
+                details.capacity(),
+                expected_len,
+                "the cache reallocated for surface {:?}",
+                token.surface
+            );
+        }
+        assert!(saw_unknown, "expected at least one unknown-word token");
+    }
+
+    /// The same, on the user-dictionary path, which reaches a third accessor.
+    #[test]
+    fn test_user_dictionary_details_cache_is_allocated_exactly_once() {
+        use std::path::PathBuf;
+
+        let userdic_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../resources")
+            .join("user_dict")
+            .join("ipadic_simple_userdic.csv");
+
+        let config = serde_json::json!({
+            "dictionary": "embedded://ipadic",
+            "user_dictionary": userdic_file.to_str().unwrap(),
+            "mode": "normal"
+        });
+
+        let segmenter = match Segmenter::from_config(&config) {
+            Ok(segmenter) => segmenter,
+            Err(err) => panic!("failed to build segmenter: {err}"),
+        };
+        let expected_len = segmenter
+            .dictionary
+            .metadata
+            .dictionary_schema
+            .get_custom_fields()
+            .len();
+
+        let tokens = match segmenter.segment(Cow::Borrowed("東京スカイツリーの近く")) {
+            Ok(tokens) => tokens,
+            Err(err) => panic!("segment failed: {err}"),
+        };
+
+        let mut saw_user_token = false;
+        for mut token in tokens {
+            if !token.word_id.is_system() && !token.word_id.is_unknown() {
+                saw_user_token = true;
+            }
+            let _ = token.details_iter().count();
+            let details = match token.details.as_ref() {
+                Some(details) => details,
+                None => panic!("details must be cached after details_iter"),
+            };
+            assert_eq!(details.capacity(), expected_len);
+        }
+        assert!(
+            saw_user_token,
+            "expected at least one user-dictionary token"
+        );
     }
 }


### PR DESCRIPTION
## Background

Closes #966 — this is **step (b)**, the second half of that issue. Step (a) landed in #968.

Materializing a token's details still went through a throwaway `Vec<&str>`:
`word_details` collected the fields, and `Token::ensure_details` immediately re-collected
them into the `Vec<Cow>` it caches. Step (a) presized both; this removes the first one
entirely.

The investigation and plan comments on #966 have the full working; the short version is
that `Token::ensure_details` is the **only** production consumer of these accessors — no
binding crate, CLI command, analysis filter, example or bench calls them directly — so
fixing it reaches every consumer at once.

## Why an iterator, not an out-parameter

`Lattice::tokens_offset_into` (`lindera-dictionary/src/viterbi.rs:1541`) is the only
out-parameter precedent in the tree, and the obvious move was to copy it:
`word_details_into(&'a self, id, out: &mut Vec<Cow<'a, str>>)`.

**That precedent does not transfer.** `tokens_offset_into` is an out-parameter so that
*one* buffer can be reused across *many* sentences — `SegmentWorker` holds it. Details are
cached per token and live exactly as long as the token, so there is no reuse to enable.
Copying the shape without the reason would be cargo-culting.

Three further reasons:

1. **`Cow` is not the storage layer's vocabulary.** What the dictionary has is a sequence
   of fields borrowed from its own bytes; it owns no strings and never will. `Cow` exists
   because `Token` lets filters write owned strings over borrowed ones via `set_detail`.
   Test: *if `Token` did not exist, what would this API look like?* An iterator of `&str`.
2. **`ExactSizeIterator` reports the count before anything is materialized**, so the cache
   vector is sized exactly — including for an entry wider than the schema. An
   out-parameter must commit to a capacity before it knows the count; that is not an
   implementation wrinkle but the consequence of inverting the information flow.
3. **The type system keeps what it currently encodes.** `Vec` vs `Option<Vec>` today means
   "only this one can report absence". `DetailFields` vs `Option<DetailFields>` keeps it
   checkable rather than demoting it to prose.

## Changes

`DetailFields<'a>` is a new public `ExactSizeIterator` yielding `&'a str` borrowed straight
out of the packed record. The `UNK` sentinel is expressed as `"UNK".split('\0')`, which
yields exactly one item — the fallback reuses the normal machinery instead of adding an
enum variant.

New accessors, and the fallbacks they preserve exactly:

| Method | Out of range | Malformed |
| --- | --- | --- |
| `Dictionary::word_details_iter` | empty | `UNK` |
| `Dictionary::unknown_word_details_iter` | `UNK` | `UNK` |
| `UserDictionary::word_details_iter` | `UNK` | `UNK` |
| `UnknownDictionary::word_details_iter` | `None` | `None` |

The four allocating accessors **keep their signatures** and become `collect()` delegates,
cross-linked in their doc comments the way `tokens_offset` points at `tokens_offset_into`.
`Dictionary` and `UserDictionary` share `packed_details_iter`, since their storage is
identical and only the out-of-range behaviour differs.

Two new `pub(crate)` byte helpers in `util.rs` (`words_idx_offset`, `joined_details_at`)
carry the shared, fully bounds-checked decode.

## Measurements

Deterministic global-allocator counter hooking `alloc`, `alloc_zeroed` and `realloc`, same
probe on both sides; baseline built from `git show main:<file>`.

| Dictionary | Workload | Before | After |
| --- | --- | ---: | ---: |
| IPADIC (9 custom fields) | `segment()` only | 1.00 | 1.00 |
| IPADIC | `+ details_iter()` | 3.00 | **2.00** |
| IPADIC | `+ details()` | 4.00 | **3.00** |
| ko-dic (8 custom fields) | `segment()` only | 3.50 | 3.50 |
| ko-dic | `+ details_iter()` | 5.50 | **4.50** |
| ko-dic | `+ details()` | 6.50 | **5.50** |

This beats the 3.10 / 2.10 targets in the issue. **2.00 is the floor** for
`details_iter()`: `Token::details` is a public `Option<Vec<Cow<'a, str>>>`, so the cache
vector is mandatory. Together with step (a), the path is down from 5.00 — a 60% reduction.

**No wall-clock claim.** Any timing figure must come from the interleaved min-of-N protocol
in `scripts/benchmarks/README.md` on an idle machine.

## Deliberate behaviour change

`Dictionary::word_details` and `UserDictionary::word_details` sliced `words_data`
unchecked and **panicked** on a corrupt offset or length. Routing them through the shared
bounds-checked helper turns that into the `UNK` fallback — matching `UnknownDictionary`,
which has always bounds-checked, and CLAUDE.md's no-panic-in-production rule. Covered by
`user_word_details_corrupt_offset_falls_back_instead_of_panicking`.

## Implementation notes worth recording

- **`str::Split` makes `DetailFields<'a>` invariant over `'a`.** Writing `unk()` and
  `empty()` as returning `DetailFields<'static>` does not compile, because `'static` will
  not coerce to a shorter lifetime under invariance. They return `Self` instead and let
  the `&'static str` constant coerce *before* construction, which needs no variance. The
  reasoning is in a code comment so nobody "simplifies" it back.
- **The blob is UTF-8 validated once, not field by field.** NUL is ASCII and never occurs
  inside a multi-byte sequence, so "the blob is valid" and "every field is valid" are the
  same statement, and the failure behaviour is unchanged. `UnknownDictionary` already
  worked this way; this makes all three consistent.

## Tests

Ten new tests:

- `util.rs` (4): declared-length reads, out-of-range and overflowing offsets/lengths,
  invalid UTF-8, index-table bounds.
- `dictionary.rs` (4): iterator/accessor agreement, `ExactSizeIterator` exactness including
  after partial consumption, the corrupt-offset fallback, and the two constructors.
- `token.rs` (2): **capacity assertions** — `details.capacity() == expected_len` across the
  system, unknown-word and user-dictionary paths. That equality only holds if nothing
  reallocated, so it pins this optimization without an allocator hook.

**The capacity assertions are not inert.** Mutating `ensure_details`'s
`Vec::with_capacity(...)` back to `Vec::new()` makes
`test_details_cache_is_allocated_exactly_once` fail, as it should.

## Verification

- `cargo test -p lindera-dictionary` — 108 + 5 + 1 passed
- `cargo test -p lindera --features embed-ipadic` — 45 passed plus integration tests,
  including the four IPADIC golden snapshots (normal / decompose / nbest / user dictionary)
- `cargo test -p lindera-analysis --features embed-ipadic` — 115 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p lindera-dictionary --all-targets -- -D warnings` and the same for
  `lindera --features embed-ipadic` — clean

`docs/` has no mention of `word_details`, so no documentation changes were needed.

Closes #966
