### PR TITLE
perf(trainer)!: drop the rewrite cache that never hits

### DIFF
--- a/docs/ja/src/lindera-trainer/architecture.md
+++ b/docs/ja/src/lindera-trainer/architecture.md
@@ -28,7 +28,7 @@ MeCab互換の素性テンプレートを解析し、生成された素性文字
 
 ### DictionaryRewriter
 
-MeCabの3セクション形式`rewrite.def`（`[unigram rewrite]`、`[left rewrite]`、`[right rewrite]`）を実装します。各セクションは`pattern<TAB>replacement`形式のルールの並びを持ち、内部の`FeatureRewriterBuilder`によって`FeatureRewriter`というprefix trie（前方一致木）に構築されます。`DictionaryRewriter::from_reader`は3セクションすべてをパースしますが、セクションヘッダのないファイルは後方互換性のため（右文脈書き換えのみのレガシー形式として）扱います。`rewrite()`は素性文字列に3つの書き換え器すべてを適用し、`(ufeature, lfeature, rfeature)`を返します。マッチするルールがないセクションは入力をそのまま通過させます。`rewrite_cached()`は入力の素性文字列ごとに結果をメモ化します（MeCabの`rewrite2`に相当）。
+MeCabの3セクション形式`rewrite.def`（`[unigram rewrite]`、`[left rewrite]`、`[right rewrite]`）を実装します。各セクションは`pattern<TAB>replacement`形式のルールの並びを持ち、内部の`FeatureRewriterBuilder`によって`FeatureRewriter`というprefix trie（前方一致木）に構築されます。`DictionaryRewriter::from_reader`は3セクションすべてをパースしますが、セクションヘッダのないファイルは後方互換性のため（右文脈書き換えのみのレガシー形式として）扱います。`rewrite()`は素性文字列に3つの書き換え器すべてを適用し、`(ufeature, lfeature, rfeature)`を返します。マッチするルールがないセクションは入力をそのまま通過させます。（かつての`rewrite_cached()`は素性文字列全体をキーにメモ化していましたが、実辞書の素性は行ごとにほぼ一意でキャッシュが一度もヒットしないため削除されました — #975。）
 
 ### Model / SerializableModel
 

--- a/docs/ja/src/migration_v5_to_v6.md
+++ b/docs/ja/src/migration_v5_to_v6.md
@@ -88,6 +88,10 @@ failed to deserialize model: ... re-run `lindera train` to regenerate it.
   順序でエントリを書き出します。これに伴い Rust API から
   `ModelInfo.updated_at` フィールドを削除しました（`lindera-dictionary`）。
   このキーを含む既存の `metadata.json` は引き続き読み込めます。
+- `DictionaryRewriter::rewrite_cached` と `clear_cache` を削除しました。
+  キャッシュは素性文字列全体をキーにしており、実辞書では行ごとにほぼ一意で
+  一度もヒットせず、メモリを保持するだけだったためです。代わりに `rewrite`
+  を呼んでください（`&mut` も不要になりました）。
 - 固定分割の導入で加算順が変わったため、この変更**前**に学習した重みと
   変更後に学習した重みはバイト単位では一致しません（`--max-threads 1` を
   含むすべてのスレッド数で）。以後の成果物を比較可能にするには

--- a/docs/src/lindera-trainer/architecture.md
+++ b/docs/src/lindera-trainer/architecture.md
@@ -28,7 +28,7 @@ Parses MeCab-compatible feature templates and manages the mapping from generated
 
 ### DictionaryRewriter
 
-Implements MeCab's 3-section `rewrite.def` format: `[unigram rewrite]`, `[left rewrite]`, and `[right rewrite]` sections, each holding an ordered list of `pattern<TAB>replacement` rules built into a `FeatureRewriter` prefix trie (via the internal `FeatureRewriterBuilder`). `DictionaryRewriter::from_reader` parses all three sections (falling back to treating an unsectioned file as legacy right-rewrite-only content, for backward compatibility with older Lindera `rewrite.def` files). `rewrite()` applies all three rewriters to a feature string and returns `(ufeature, lfeature, rfeature)`, passing a section through unchanged when no rule matches; `rewrite_cached()` memoizes results per input feature string (MeCab's `rewrite2` equivalent).
+Implements MeCab's 3-section `rewrite.def` format: `[unigram rewrite]`, `[left rewrite]`, and `[right rewrite]` sections, each holding an ordered list of `pattern<TAB>replacement` rules built into a `FeatureRewriter` prefix trie (via the internal `FeatureRewriterBuilder`). `DictionaryRewriter::from_reader` parses all three sections (falling back to treating an unsectioned file as legacy right-rewrite-only content, for backward compatibility with older Lindera `rewrite.def` files). `rewrite()` applies all three rewriters to a feature string and returns `(ufeature, lfeature, rfeature)`, passing a section through unchanged when no rule matches. (An earlier `rewrite_cached()` memoized per full feature string, but real lexicon features are unique per row, so the cache never hit and was removed — #975.)
 
 ### Model / SerializableModel
 

--- a/docs/src/migration_v5_to_v6.md
+++ b/docs/src/migration_v5_to_v6.md
@@ -88,6 +88,10 @@ Two related notes:
   a deterministic order. Accordingly, the `ModelInfo.updated_at` field was
   removed from the Rust API (`lindera-dictionary`); old `metadata.json` files
   that still contain the key keep parsing.
+- `DictionaryRewriter::rewrite_cached` and `clear_cache` were removed: the
+  cache was keyed on the full feature string, which is unique per row in a
+  real lexicon, so it never hit and only retained memory. Call `rewrite`
+  instead — it no longer requires `&mut`.
 - The fixed partition changed the summation order, so weights trained
   **before** this change are not byte-identical to weights trained after it —
   at any thread count, including `--max-threads 1`. Re-run `lindera train` if

--- a/lindera-trainer/src/feature_rewriter.rs
+++ b/lindera-trainer/src/feature_rewriter.rs
@@ -1,5 +1,5 @@
 use regex::Regex;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Pattern {
@@ -52,8 +52,13 @@ impl FeatureRewriterBuilder {
     }
 
     /// Adds the rewrite rule associated with the pattern.
-    /// If the pattern is shorter than the rewrite rule,
-    /// the remainings are automatically padded with "*".
+    ///
+    /// # 引数
+    ///
+    /// * `pattern` - Field patterns matched positionally from field 0; `*`
+    ///   matches any single field, `A|B` any of the listed values.
+    /// * `rewrite` - Replacement fields; `$N` (1-based) copies input field
+    ///   `N`, anything else is literal text.
     pub fn add_rule<S>(&mut self, pattern: &[S], rewrite: &[S])
     where
         S: AsRef<str>,
@@ -91,13 +96,19 @@ impl FeatureRewriterBuilder {
         let mut parsed_rewrite = vec![];
         for p in rewrite {
             let p = p.as_ref();
-            parsed_rewrite.push(self.ref_pattern.captures(p).map_or_else(
-                || Rewrite::Text(p.to_string()),
-                |cap| {
-                    let idx = cap.get(1).unwrap().as_str().parse::<usize>().unwrap() - 1;
-                    Rewrite::Reference(idx)
-                },
-            ));
+            // `$N` is 1-based (MeCab convention). `$0`, or a digit string
+            // too long for usize, is out-of-spec input and falls back to
+            // literal text rather than panicking (#975).
+            let reference = self
+                .ref_pattern
+                .captures(p)
+                .and_then(|cap| cap.get(1))
+                .and_then(|digits| digits.as_str().parse::<usize>().ok())
+                .and_then(|n| n.checked_sub(1));
+            parsed_rewrite.push(match reference {
+                Some(idx) => Rewrite::Reference(idx),
+                None => Rewrite::Text(p.to_string()),
+            });
         }
         self.nodes[cursor]
             .actions
@@ -232,7 +243,6 @@ pub struct DictionaryRewriter {
     unigram_rewriter: FeatureRewriter,
     left_rewriter: FeatureRewriter,
     right_rewriter: FeatureRewriter,
-    cache: HashMap<String, (String, String, String)>,
 }
 
 impl Default for DictionaryRewriter {
@@ -248,7 +258,6 @@ impl DictionaryRewriter {
             unigram_rewriter: FeatureRewriter::new(),
             left_rewriter: FeatureRewriter::new(),
             right_rewriter: FeatureRewriter::new(),
-            cache: HashMap::new(),
         }
     }
 
@@ -328,7 +337,6 @@ impl DictionaryRewriter {
             unigram_rewriter: FeatureRewriter::from(unigram_builder),
             left_rewriter: FeatureRewriter::from(left_builder),
             right_rewriter: FeatureRewriter::from(right_builder),
-            cache: HashMap::new(),
         })
     }
 
@@ -359,22 +367,6 @@ impl DictionaryRewriter {
             .unwrap_or_else(|| feature.to_string());
 
         (ufeature, lfeature, rfeature)
-    }
-
-    /// Rewrites input features with caching (MeCab's rewrite2 equivalent).
-    pub fn rewrite_cached(&mut self, feature: &str) -> (String, String, String) {
-        if let Some(cached) = self.cache.get(feature) {
-            return cached.clone();
-        }
-
-        let result = self.rewrite(feature);
-        self.cache.insert(feature.to_string(), result.clone());
-        result
-    }
-
-    /// Clears the rewrite cache.
-    pub fn clear_cache(&mut self) {
-        self.cache.clear();
     }
 
     /// Returns the unigram rewriter (for direct access when needed).
@@ -419,24 +411,61 @@ mod tests {
         assert_eq!(r, "名詞,一般,*");
     }
 
+    /// Pins `rewrite` over an ipadic-shaped rewrite.def: three sections,
+    /// depth-7/8 patterns, `$N` references, and a passthrough path.
+    ///
+    /// This replaces the removed `test_dictionary_rewriter_cached`, which
+    /// passed even with the cache logic deleted (#975).
     #[test]
-    fn test_dictionary_rewriter_cached() {
+    fn test_dictionary_rewriter_ipadic_shape() {
         let rewrite_def = "\
 [unigram rewrite]
-*\t$1
+*,*,*,*,*,*,*,*\t$1,$2,$3,$4,$5,$6,$7,$8
 
 [left rewrite]
-*\t$1
+名詞,一般,*,*,*,*,*\t$1,$2,$3,$4,$5,$6,NOUN
 
 [right rewrite]
-*\t$1
+名詞,一般,*,*,*,*,*\t$1,$2,$3,$4,$5,$6,$7
 ";
-        let mut rewriter =
+        let rewriter =
             DictionaryRewriter::from_reader(Cursor::new(rewrite_def.as_bytes())).unwrap();
 
-        let result1 = rewriter.rewrite_cached("名詞");
-        let result2 = rewriter.rewrite_cached("名詞");
-        assert_eq!(result1, result2);
+        // All three sections match: unigram keeps 8 fields, left replaces
+        // field 7 with a literal, right keeps 7 fields (dropping 8..).
+        let (u, l, r) = rewriter.rewrite("名詞,一般,*,*,*,*,外食,ガイショク,ガイショク");
+        assert_eq!(u, "名詞,一般,*,*,*,*,外食,ガイショク");
+        assert_eq!(l, "名詞,一般,*,*,*,*,NOUN");
+        assert_eq!(r, "名詞,一般,*,*,*,*,外食");
+
+        // Two entries differing only after the matched prefix must still
+        // differ in the sections that reference those fields -- the reason a
+        // prefix cache key was rejected in #975.
+        let (u2, _, r2) = rewriter.rewrite("名詞,一般,*,*,*,*,会見,カイケン,カイケン");
+        assert_ne!(u, u2);
+        assert_ne!(r, r2);
+
+        // Passthrough: a feature no left/right rule matches comes back whole.
+        let (u3, l3, r3) = rewriter.rewrite("動詞,自立,*,*,*,*,動く,ウゴク,ウゴク");
+        assert_eq!(u3, "動詞,自立,*,*,*,*,動く,ウゴク");
+        assert_eq!(l3, "動詞,自立,*,*,*,*,動く,ウゴク,ウゴク");
+        assert_eq!(r3, "動詞,自立,*,*,*,*,動く,ウゴク,ウゴク");
+    }
+
+    /// A `$0` reference is out-of-spec (`$N` is 1-based, per MeCab) and must
+    /// be treated as literal text rather than panicking (#975; the previous
+    /// parser underflowed on the `- 1`).
+    #[test]
+    fn test_dollar_zero_is_literal_text() {
+        let rewrite_def = "\
+[right rewrite]
+名詞\t$0,$1
+";
+        let rewriter =
+            DictionaryRewriter::from_reader(Cursor::new(rewrite_def.as_bytes())).unwrap();
+
+        let (_, _, r) = rewriter.rewrite("名詞,一般");
+        assert_eq!(r, "$0,名詞");
     }
 
     #[test]

--- a/lindera-trainer/src/lib.rs
+++ b/lindera-trainer/src/lib.rs
@@ -123,7 +123,7 @@ impl Trainer {
     /// Creates a new [`Trainer`] using the specified configuration.
     pub fn new(mut config: TrainerConfig) -> Result<Self> {
         let mut provider = lindera_crf::FeatureProvider::default();
-        let mut label_id_map = HashMap::new();
+        let mut label_id_map: HashMap<String, HashMap<char, NonZeroU32>> = HashMap::new();
 
         // Build label mapping from surfaces and add feature sets to provider
         // Generate default features based on dictionary schema
@@ -136,15 +136,16 @@ impl Trainer {
 
         for (i, surface) in config.surfaces.iter().enumerate() {
             // Get feature string from config.features (parallel to surfaces)
-            let feature_str = if i < config.features.len() {
-                config.features[i].clone()
+            let feature_str: &str = if i < config.features.len() {
+                &config.features[i]
             } else {
-                default_features.clone()
+                &default_features
             };
 
-            // Apply dictionary rewriter to get ufeature, lfeature, rfeature
-            let (ufeature, lfeature, rfeature) =
-                config.dictionary_rewriter.rewrite_cached(&feature_str);
+            // Apply dictionary rewriter to get ufeature, lfeature, rfeature.
+            // Uncached on purpose: real feature strings are unique per row,
+            // so a cache keyed on them never hits (#975).
+            let (ufeature, lfeature, rfeature) = config.dictionary_rewriter.rewrite(feature_str);
             let u_vec: Vec<String> = ufeature.split(',').map(|s| s.to_string()).collect();
             let l_vec: Vec<String> = lfeature.split(',').map(|s| s.to_string()).collect();
             let r_vec: Vec<String> = rfeature.split(',').map(|s| s.to_string()).collect();
@@ -184,14 +185,9 @@ impl Trainer {
             let label_id = provider.add_feature_set(feature_set)?;
 
             // Map feature string to label ID using first character classification
-            label_id_map
-                .entry(feature_str.to_string())
-                .or_insert_with(HashMap::new);
+            let char_map = label_id_map.entry(feature_str.to_string()).or_default();
             if let Some(first_char) = surface.chars().next() {
-                label_id_map
-                    .get_mut(&feature_str)
-                    .unwrap()
-                    .insert(first_char, label_id);
+                char_map.insert(first_char, label_id);
             }
         }
 
@@ -202,15 +198,15 @@ impl Trainer {
 
         for (i, category) in unk_category_names.iter().enumerate() {
             // Get unknown word feature string from unk_categories
-            let unk_feature = config
+            let unk_feature: &str = config
                 .unk_categories
                 .get(category)
-                .cloned()
-                .unwrap_or_else(|| default_features.clone());
+                .map(|s| s.as_str())
+                .unwrap_or(&default_features);
 
-            // Apply dictionary rewriter to get ufeature, lfeature, rfeature
-            let (ufeature, lfeature, rfeature) =
-                config.dictionary_rewriter.rewrite_cached(&unk_feature);
+            // Apply dictionary rewriter to get ufeature, lfeature, rfeature.
+            // Uncached on purpose: see the seed loop above (#975).
+            let (ufeature, lfeature, rfeature) = config.dictionary_rewriter.rewrite(unk_feature);
             let u_vec: Vec<String> = ufeature.split(',').map(|s| s.to_string()).collect();
             let l_vec: Vec<String> = lfeature.split(',').map(|s| s.to_string()).collect();
             let r_vec: Vec<String> = rfeature.split(',').map(|s| s.to_string()).collect();


### PR DESCRIPTION
## Background

Closes #975.

`DictionaryRewriter::rewrite_cached` memoized rewrite results keyed on the full feature
string. On a real lexicon that key is unique per row — 392,126 distinct of 392,126 for
mecab-ipadic, byte-exact — so the cache **never hit**: ~1.57M allocations and ~150 MB
retained for the `Model`'s lifetime, for nothing.

The issue's primary proposal (key on the prefix the rules discriminate on) was refuted
during investigation and the issue body corrected: it is **unsound** — `rewrite()` falls
back to the entire feature string when a section has no matching rule, so rows sharing a
prefix but differing later must produce different results — and **worthless where
sound** — real ipadic rules discriminate on the base form (sound key length K = 8, hit
rate 0.04%; jumandic: zero hits at K = 8). There is also no call pattern for any cache to
exploit: MeCab's `rewrite2` (the ported original) runs per lattice path per iteration
where features recur; Lindera's ran once per lexicon row in `Trainer::new`, where every
key is fresh by construction. Full working in the
[investigation](https://github.com/lindera/lindera/issues/975#issuecomment-5390367112)
and [plan](https://github.com/lindera/lindera/issues/975#issuecomment-5390473424)
comments.

## Changes

- **Remove the cache**: the `cache` field, `rewrite_cached`, and `clear_cache` (zero
  callers in the workspace) are gone; `Trainer::new`'s two loops call `rewrite`, which
  needs only `&self`.
- **Fix the `$0` panic path** in the `$N` replacement parser: an out-of-spec reference
  (`$0` — `$N` is 1-based per MeCab — or an over-long digit string) is now literal text
  instead of a debug panic / release wrap to `usize::MAX`. Removes two production
  `unwrap()`s.
- **Fix `add_rule`'s stale doc**, which described `*`-padding the code never performed
  (vibrato leftover).
- **Drop the adjacent per-row allocations** in the same loops: `feature_str` and
  `unk_feature` become borrows, and the `label_id_map` update uses the entry API — which
  also removes a third production `unwrap()` and a redundant re-owning `to_string()`.
- **Replace the inert test**: `test_dictionary_rewriter_cached` passed even with the
  cache logic deleted (it compared two calls on the same input). In its place: an
  ipadic-shaped three-section test (depth 7–8 patterns, `$1..$8` references, a
  passthrough path, and an assertion that rows differing only after the matched prefix
  produce different results — the exact reason the prefix key was rejected), plus a `$0`
  fallback test.

## Verification

- **End to end, byte-for-byte**: `lindera train` + `lindera export` on
  `resources/training`, before vs after — `model.dat` and all nine export files are
  **identical**. The removal changes no value.
- **Allocations** (`Trainer::new`, 48-row wide fixture, deterministic `GlobalAlloc`
  counter): 3774 → **3541** (−4.85 per row; ≈1.9M fewer allocations at mecab-ipadic
  scale, and the ~150 MB retained table is gone). No wall-clock claims.
- **Revert checks**: the `$0` test panics on the reverted parser (observed); the cache
  removal cannot be silently reverted — the call sites stop compiling.
- **Gates**: `cargo fmt --check`; `cargo clippy --all-targets --all-features -D
  warnings` clean; `cargo test -p lindera-trainer` 41 + 1 green;
  `cargo build --features train`; `markdownlint-cli2` clean over both doc trees.

## Breaking change (v6, documented in the migration guide)

`DictionaryRewriter::rewrite_cached` and `clear_cache` are removed (both `pub`,
reachable via `lindera::dictionary::trainer`). Migration: call `rewrite` — no `&mut`
needed. Also a behavior change for out-of-spec input: `$0` in a `rewrite.def` becomes
literal text instead of a debug panic.

Closes #975
