### PR TITLE
perf(trainer)!: take feature fields as &[&str] in extract_*

### DIFF
--- a/docs/ja/src/migration_v5_to_v6.md
+++ b/docs/ja/src/migration_v5_to_v6.md
@@ -92,6 +92,10 @@ failed to deserialize model: ... re-run `lindera train` to regenerate it.
   キャッシュは素性文字列全体をキーにしており、実辞書では行ごとにほぼ一意で
   一度もヒットせず、メモリを保持するだけだったためです。代わりに `rewrite`
   を呼んでください（`&mut` も不要になりました）。
+- `FeatureExtractor::extract_*` 6 メソッドの `features` 引数を
+  `&[String]` から `&[&str]` に変更しました。呼び出し側がフィールドごとに
+  `String` を確保する必要がなくなります。`&[String]` を持っている場合は
+  `&v.iter().map(|s| s.as_str()).collect::<Vec<_>>()` で渡せます。
 - 固定分割の導入で加算順が変わったため、この変更**前**に学習した重みと
   変更後に学習した重みはバイト単位では一致しません（`--max-threads 1` を
   含むすべてのスレッド数で）。以後の成果物を比較可能にするには

--- a/docs/src/migration_v5_to_v6.md
+++ b/docs/src/migration_v5_to_v6.md
@@ -92,6 +92,10 @@ Two related notes:
   cache was keyed on the full feature string, which is unique per row in a
   real lexicon, so it never hit and only retained memory. Call `rewrite`
   instead — it no longer requires `&mut`.
+- The `features` parameter of the six `FeatureExtractor::extract_*` methods
+  changed from `&[String]` to `&[&str]`, so callers no longer have to
+  allocate one `String` per feature field. A caller holding a `&[String]`
+  can pass `&v.iter().map(|s| s.as_str()).collect::<Vec<_>>()`.
 - The fixed partition changed the summation order, so weights trained
   **before** this change are not byte-identical to weights trained after it —
   at any thread count, including `--max-threads 1`. Re-run `lindera train` if

--- a/lindera-trainer/src/feature_extractor.rs
+++ b/lindera-trainer/src/feature_extractor.rs
@@ -285,7 +285,7 @@ impl FeatureExtractor {
     /// template does not apply to this entry.
     fn apply_parsed_template(
         template: &ParsedTemplate,
-        features: &[String],
+        features: &[&str],
         cate_id: u32,
         ctx: &TemplateContext,
     ) -> Option<String> {
@@ -294,7 +294,7 @@ impl FeatureExtractor {
             if required_idx >= features.len() {
                 return None; // Index out of bounds
             }
-            let feature_val = &features[required_idx];
+            let feature_val = features[required_idx];
             if feature_val == "*" || feature_val.is_empty() {
                 return None; // Skip if required feature is undefined
             }
@@ -309,7 +309,7 @@ impl FeatureExtractor {
                     if *idx >= features.len() {
                         "*".to_string() // Default for out of bounds
                     } else {
-                        features[*idx].clone()
+                        features[*idx].to_string()
                     }
                 }
                 FeatureType::CharacterType => cate_id.to_string(),
@@ -373,18 +373,39 @@ impl FeatureExtractor {
     }
 
     /// Extracts unigram feature IDs from features.
+    ///
+    /// # 引数
+    ///
+    /// * `features` - Rewritten unigram feature fields, one slice element per
+    ///   comma-separated field.
+    /// * `cate_id` - Character category id for the `%t` placeholder.
+    ///
+    /// # 戻り値
+    ///
+    /// The interned feature ids; templates whose `%F?` field is undefined are
+    /// skipped, so the result may be shorter than the template list.
     pub fn extract_unigram_feature_ids(
         &mut self,
-        features: &[String],
+        features: &[&str],
         cate_id: u32,
     ) -> Vec<NonZeroU32> {
         self.extract_unigram_feature_ids_with_ctx(features, cate_id, &TemplateContext::default())
     }
 
     /// Extracts unigram feature IDs from features with template context.
+    ///
+    /// # 引数
+    ///
+    /// * `features` - Rewritten unigram feature fields.
+    /// * `cate_id` - Character category id for the `%t` placeholder.
+    /// * `ctx` - Values for the `%w` / `%u` / `%l` / `%r` placeholders.
+    ///
+    /// # 戻り値
+    ///
+    /// The interned feature ids; skipped templates are dropped.
     pub fn extract_unigram_feature_ids_with_ctx(
         &mut self,
-        features: &[String],
+        features: &[&str],
         cate_id: u32,
         ctx: &TemplateContext,
     ) -> Vec<NonZeroU32> {
@@ -418,14 +439,32 @@ impl FeatureExtractor {
     }
 
     /// Extracts left context feature IDs from features (with Optional).
-    pub fn extract_left_feature_ids(&mut self, features: &[String]) -> Vec<Option<NonZeroU32>> {
+    ///
+    /// # 引数
+    ///
+    /// * `features` - Rewritten left-context feature fields.
+    ///
+    /// # 戻り値
+    ///
+    /// One entry per template, `None` where the template was skipped, so the
+    /// result stays index-aligned with the template list.
+    pub fn extract_left_feature_ids(&mut self, features: &[&str]) -> Vec<Option<NonZeroU32>> {
         self.extract_left_feature_ids_with_ctx(features, &TemplateContext::default())
     }
 
     /// Extracts left context feature IDs from features with template context.
+    ///
+    /// # 引数
+    ///
+    /// * `features` - Rewritten left-context feature fields.
+    /// * `ctx` - Values for the `%w` / `%u` / `%l` / `%r` placeholders.
+    ///
+    /// # 戻り値
+    ///
+    /// One entry per template, `None` where the template was skipped.
     pub fn extract_left_feature_ids_with_ctx(
         &mut self,
-        features: &[String],
+        features: &[&str],
         ctx: &TemplateContext,
     ) -> Vec<Option<NonZeroU32>> {
         // See `extract_unigram_feature_ids_with_ctx` for why this is
@@ -457,14 +496,32 @@ impl FeatureExtractor {
     }
 
     /// Extracts right context feature IDs from features (with Optional).
-    pub fn extract_right_feature_ids(&mut self, features: &[String]) -> Vec<Option<NonZeroU32>> {
+    ///
+    /// # 引数
+    ///
+    /// * `features` - Rewritten right-context feature fields.
+    ///
+    /// # 戻り値
+    ///
+    /// One entry per template, `None` where the template was skipped, so the
+    /// result stays index-aligned with the template list.
+    pub fn extract_right_feature_ids(&mut self, features: &[&str]) -> Vec<Option<NonZeroU32>> {
         self.extract_right_feature_ids_with_ctx(features, &TemplateContext::default())
     }
 
     /// Extracts right context feature IDs from features with template context.
+    ///
+    /// # 引数
+    ///
+    /// * `features` - Rewritten right-context feature fields.
+    /// * `ctx` - Values for the `%w` / `%u` / `%l` / `%r` placeholders.
+    ///
+    /// # 戻り値
+    ///
+    /// One entry per template, `None` where the template was skipped.
     pub fn extract_right_feature_ids_with_ctx(
         &mut self,
-        features: &[String],
+        features: &[&str],
         ctx: &TemplateContext,
     ) -> Vec<Option<NonZeroU32>> {
         // See `extract_unigram_feature_ids_with_ctx` for why this is
@@ -513,8 +570,8 @@ mod tests {
         FeatureExtractor::from_templates(unigram, bigram)
     }
 
-    fn features(fields: &[&str]) -> Vec<String> {
-        fields.iter().map(|f| f.to_string()).collect()
+    fn features<'a>(fields: &[&'a str]) -> Vec<&'a str> {
+        fields.to_vec()
     }
 
     /// The ids an extractor hands out are 1-based and assigned in template

--- a/lindera-trainer/src/lib.rs
+++ b/lindera-trainer/src/lib.rs
@@ -146,9 +146,9 @@ impl Trainer {
             // Uncached on purpose: real feature strings are unique per row,
             // so a cache keyed on them never hits (#975).
             let (ufeature, lfeature, rfeature) = config.dictionary_rewriter.rewrite(feature_str);
-            let u_vec: Vec<String> = ufeature.split(',').map(|s| s.to_string()).collect();
-            let l_vec: Vec<String> = lfeature.split(',').map(|s| s.to_string()).collect();
-            let r_vec: Vec<String> = rfeature.split(',').map(|s| s.to_string()).collect();
+            let u_vec: Vec<&str> = ufeature.split(',').collect();
+            let l_vec: Vec<&str> = lfeature.split(',').collect();
+            let r_vec: Vec<&str> = rfeature.split(',').collect();
 
             // Compute character category ID from the first character of the surface
             let cate_id = if let Some(first_char) = surface.chars().next() {
@@ -207,9 +207,9 @@ impl Trainer {
             // Apply dictionary rewriter to get ufeature, lfeature, rfeature.
             // Uncached on purpose: see the seed loop above (#975).
             let (ufeature, lfeature, rfeature) = config.dictionary_rewriter.rewrite(unk_feature);
-            let u_vec: Vec<String> = ufeature.split(',').map(|s| s.to_string()).collect();
-            let l_vec: Vec<String> = lfeature.split(',').map(|s| s.to_string()).collect();
-            let r_vec: Vec<String> = rfeature.split(',').map(|s| s.to_string()).collect();
+            let u_vec: Vec<&str> = ufeature.split(',').collect();
+            let l_vec: Vec<&str> = lfeature.split(',').collect();
+            let r_vec: Vec<&str> = rfeature.split(',').collect();
 
             // Create feature set for unknown word category
             let feature_extractor = &mut config.feature_extractor;

--- a/lindera-trainer/src/model.rs
+++ b/lindera-trainer/src/model.rs
@@ -217,9 +217,9 @@ impl Model {
                 // Apply dictionary rewriter to get ufeature, lfeature, rfeature
                 let (ufeature, lfeature, rfeature) =
                     self.config.dictionary_rewriter.rewrite(&features);
-                let u_vec: Vec<String> = ufeature.split(',').map(|s| s.to_string()).collect();
-                let l_vec: Vec<String> = lfeature.split(',').map(|s| s.to_string()).collect();
-                let r_vec: Vec<String> = rfeature.split(',').map(|s| s.to_string()).collect();
+                let u_vec: Vec<&str> = ufeature.split(',').collect();
+                let l_vec: Vec<&str> = lfeature.split(',').collect();
+                let r_vec: Vec<&str> = rfeature.split(',').collect();
 
                 let unigram_features = self
                     .config


### PR DESCRIPTION
## Background

Closes #976. Last item of the 2026-08 performance campaign, split out of #965.

Three sites built a `Vec<String>` — one `String` per feature field — purely because
`FeatureExtractor::extract_*` demanded `&[String]`: the seed loop and the unk loop in
`Trainer::new`, and `Model::read_user_lexicon`. The values are read-only and outlive
nothing; at mecab-ipadic scale that is 3 vectors × 9 fields = 27 String allocations per
row over 392,126 rows, existing solely to satisfy the parameter type.

Investigation ([report](https://github.com/lindera/lindera/issues/976#issuecomment-5392191164),
[plan](https://github.com/lindera/lindera/issues/976#issuecomment-5392231418)) found the
blast radius even smaller than the issue assumed: the six methods have exactly three
production call sites and one test helper in the whole workspace, and no binding or other
crate touches them. Of the issue's three options, the maintainer chose **option 1 — the
breaking change to `&[&str]`** (decision recorded in the issue, per its acceptance
criteria), matching the v6 window's four consecutive trainer `!` commits.

## Changes

- The six `extract_{unigram,left,right}_feature_ids{,_with_ctx}` methods and the private
  `apply_parsed_template` take `features: &[&str]`. Internal changes are two lines: the
  `%F?` required-field check copies the `&str` instead of referencing a `String`, and
  field substitution becomes `to_string()`. Doc comments gain the house
  `# 引数` / `# 戻り値` sections.
- The three call sites become `let u_vec: Vec<&str> = ufeature.split(',').collect();` —
  the 27 per-row Strings are gone; the three `Vec` allocations remain in both worlds.
- The test helper `features()` returns `Vec<&str>`; every test in the file — including
  the #970 regression guards that pin id numbering and generated feature strings —
  passes **unmodified**, which is exactly what they are for.
- Migration-guide entries (en/ja) with the mechanical fix for external callers holding
  `&[String]`.

## Verification

- **End to end, byte-for-byte**: `lindera train` + `lindera export` on
  `resources/training`, before vs after — `model.dat` and all nine export files are
  **identical**. The change moves no value.
- **Allocations** (`Trainer::new`, 48-row wide fixture, deterministic `GlobalAlloc`
  counter): 3541 → **2139** (−1402, **−39.6%**, −29.2 per row; ≈11.5M fewer allocations
  at mecab-ipadic scale). No wall-clock claims.
- **Revert resistance**: the signature change cannot be silently reverted — the call
  sites stop compiling; behavioral regressions are held by the unmodified #970 tests.
- **Gates**: `cargo fmt --check`; `cargo clippy --all-targets --all-features -D
  warnings` clean; `cargo test -p lindera-trainer` 41 + 1 green; `cargo build
  --features train`; `markdownlint-cli2` clean over both doc trees.

## Breaking change (v6, documented in the migration guide)

The `features` parameter of the six public `FeatureExtractor::extract_*` methods changes
from `&[String]` to `&[&str]` (reachable via `lindera::dictionary::trainer`). A caller
holding `&[String]` migrates with
`&v.iter().map(|s| s.as_str()).collect::<Vec<_>>()`.

Closes #976
