### PR TITLE
feat(wasm)!: load user dictionaries from bytes; drop filesystem APIs

### DIFF
--- a/docs/ja/src/lindera-wasm/dictionary_management.md
+++ b/docs/ja/src/lindera-wasm/dictionary_management.md
@@ -115,19 +115,48 @@ console.log(dictionary.encoding); // "utf-8"
 
 ユーザー辞書を使用すると、システム辞書にないカスタム語彙を追加できます。
 
-### ユーザー辞書の読み込み
+WebAssembly にはファイルシステムが無いため、ユーザー辞書は JavaScript 側で
+取得した**バイト列**（`fetch`・`<input type="file">`・OPFS）から読み込みます。
+
+### CSV バイト列からのユーザー辞書の読み込み
+
+ユーザー辞書を組み合わせるシステム辞書のメタデータ（例:
+`dictionary.metadata`）を渡してください。CSV の内容は UTF-8 である必要が
+あります。
 
 ```javascript
-import { loadUserDictionary } from 'lindera-wasm-web';
+import { loadUserDictionaryFromBytes } from 'lindera-wasm-web';
 
-const metadata = dictionary.metadata;
-const userDict = loadUserDictionary("/path/to/user_dict.csv", metadata);
+const response = await fetch('/dictionaries/user_dict.csv');
+const csvBytes = new Uint8Array(await response.arrayBuffer());
+const userDict = loadUserDictionaryFromBytes(csvBytes, dictionary.metadata);
+```
+
+OPFS 上のファイルも同じ形で使えます：
+
+```javascript
+const root = await navigator.storage.getDirectory();
+const handle = await root.getFileHandle('user_dict.csv');
+const csvBytes = new Uint8Array(await (await handle.getFile()).arrayBuffer());
+const userDict = loadUserDictionaryFromBytes(csvBytes, dictionary.metadata);
+```
+
+### ビルド済みユーザー辞書（`.bin`）の読み込み
+
+`lindera build --user` でコンパイルしたユーザー辞書はそのまま読み込めます：
+
+```javascript
+import { loadUserDictionaryBinFromBytes } from 'lindera-wasm-web';
+
+const response = await fetch('/dictionaries/user_dict.bin');
+const binBytes = new Uint8Array(await response.arrayBuffer());
+const userDict = loadUserDictionaryBinFromBytes(binBytes);
 ```
 
 ### Tokenizer でのユーザー辞書の使用
 
 ```javascript
-import { loadDictionaryFromBytes, loadUserDictionary, Tokenizer } from 'lindera-wasm-web';
+import { loadDictionaryFromBytes, loadUserDictionaryFromBytes, Tokenizer } from 'lindera-wasm-web';
 import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
 
 const files = await loadDictionaryFiles("ipadic");
@@ -136,48 +165,33 @@ const dictionary = loadDictionaryFromBytes(
     files.dictWordsIdx, files.dictWords, files.matrixMtx, files.charDef,
     files.unk,
 );
-const userDict = loadUserDictionary("/path/to/user_dict.csv", dictionary.metadata);
+const response = await fetch('/dictionaries/user_dict.csv');
+const csvBytes = new Uint8Array(await response.arrayBuffer());
+const userDict = loadUserDictionaryFromBytes(csvBytes, dictionary.metadata);
 const tokenizer = new Tokenizer(dictionary, "normal", userDict);
 ```
 
 ### ユーザー辞書の CSV フォーマット
 
-ユーザー辞書の CSV は Lindera ユーザー辞書と同じフォーマットに準拠します：
+ユーザー辞書の CSV は Lindera ユーザー辞書と同じフォーマットに準拠します。
+IPADIC のシンプル形式は以下のとおりです：
 
 ```csv
 東京スカイツリー,カスタム名詞,トウキョウスカイツリー
 東武スカイツリーライン,カスタム名詞,トウブスカイツリーライン
 ```
 
-各行の構成: `surface,part_of_speech,reading`
+各行の構成: `surface,part_of_speech,reading`。辞書のフル形式
+（IPADIC では 13 フィールド以上）の行も併用できます。内容は UTF-8 で
+ある必要があります。
 
 ## 辞書のビルド
 
-JavaScript API を使用してソースファイルからコンパイル済み辞書をビルドできます。
-
-### システム辞書のビルド
-
-`metadata` はプレーンなオブジェクトリテラルではなく、実際の `Metadata` インスタンスである必要があります -- 生成されたバインディングは引数が `Metadata` であることをアサートしており、そうでない場合は例外を投げます。`Metadata.createDefault()` でインスタンスを作成し、必要なフィールドを設定してください。
-
-```javascript
-import { buildDictionary, Metadata } from 'lindera-wasm-web';
-
-const metadata = Metadata.createDefault();
-metadata.name = "custom-dict";
-metadata.encoding = "utf-8";
-
-buildDictionary("/path/to/source/dir", "/path/to/output/dir", metadata);
-```
-
-### ユーザー辞書のビルド
-
-```javascript
-import { buildUserDictionary } from 'lindera-wasm-web';
-
-buildUserDictionary("/path/to/user_dict.csv", "/path/to/output/dir");
-```
-
-`buildUserDictionary` の `metadata` パラメータは省略可能です。省略した場合はデフォルトのメタデータが使用されます。
+WebAssembly では辞書のビルドはできません。ビルドはソースディレクトリを
+読み出力ディレクトリへ書き込みますが、`wasm32-unknown-unknown` には
+ファイルシステムが無いためです。辞書は `lindera` CLI（またはネイティブ
+バインディング）でビルドし、結果をバイト列としてここに読み込んでください。
+ビルド済み辞書のダウンロードは [OPFS 辞書管理](opfs.md) を参照してください。
 
 ## Metadata
 

--- a/docs/ja/src/lindera-wasm/tokenizer_api.md
+++ b/docs/ja/src/lindera-wasm/tokenizer_api.md
@@ -60,20 +60,9 @@ const dictionary = loadDictionaryFromBytes(
 builder.setDictionaryInstance(dictionary);
 ```
 
-#### `setUserDictionary(uri)`
-
-ユーザー定義辞書を設定します。
-
-- **パラメータ**: `uri` (string) -- ユーザー辞書のパスまたは URI
-- **戻り値**: void
-
-```javascript
-builder.setUserDictionary("file:///path/to/user_dict.csv");
-```
-
 #### `setUserDictionaryInstance(userDictionary)`
 
-読み込み済みのユーザー辞書インスタンスを設定します。URI の代わりにバイトデータから読み込んだユーザー辞書を使用する場合に使います。
+読み込み済みのユーザー辞書インスタンスを設定します。`loadUserDictionaryFromBytes()`（CSV）または `loadUserDictionaryBinFromBytes()`（ビルド済み `.bin`）でバイト列から読み込んでください。WebAssembly では URI ベースのユーザー辞書は使用できません。
 
 - **パラメータ**: `userDictionary` (UserDictionary) -- 読み込み済みのユーザー辞書オブジェクト
 - **戻り値**: void
@@ -239,34 +228,21 @@ import { loadDictionary } from 'lindera-wasm-web-ipadic';
 const dict = loadDictionary("embedded://ipadic");
 ```
 
-### `loadUserDictionary(uri, metadata)`
+### `loadUserDictionaryFromBytes(csv, metadata)`
 
-指定された URI からユーザー辞書を読み込みます。
+CSV バイト列（UTF-8）からユーザー辞書をビルドします。バイト列は `fetch`・ファイル入力・OPFS から取得します。
 
 - **パラメータ**:
-  - `uri` (string) -- ユーザー辞書ファイルのパスまたは URI
-  - `metadata` (Metadata) -- 辞書のメタデータオブジェクト
+  - `csv` (Uint8Array) -- ユーザー辞書 CSV の内容
+  - `metadata` (Metadata) -- 組み合わせるシステム辞書のメタデータ（例: `dictionary.metadata`）
 - **戻り値**: `UserDictionary`
 
-### `buildDictionary(inputDir, outputDir, metadata)`
+### `loadUserDictionaryBinFromBytes(bytes)`
 
-ソースファイルからコンパイル済み辞書をビルドします。
+ビルド済みユーザー辞書（`lindera build --user` の出力）をバイト列から読み込みます。
 
-- **パラメータ**:
-  - `inputDir` (string) -- 辞書ソースファイルを含むディレクトリのパス
-  - `outputDir` (string) -- 出力ディレクトリのパス
-  - `metadata` (Metadata) -- 辞書のメタデータオブジェクト
-- **戻り値**: void
-
-### `buildUserDictionary(inputFile, outputDir, metadata?)`
-
-CSV ファイルからコンパイル済みユーザー辞書をビルドします。
-
-- **パラメータ**:
-  - `inputFile` (string) -- ユーザー辞書 CSV ファイルのパス
-  - `outputDir` (string) -- 出力ディレクトリのパス
-  - `metadata` (Metadata, 省略可) -- 辞書のメタデータオブジェクト
-- **戻り値**: void
+- **パラメータ**: `bytes` (Uint8Array) -- `.bin` の内容
+- **戻り値**: `UserDictionary`
 
 ### `version()` / `getVersion()`
 
@@ -338,7 +314,6 @@ Python API との一貫性のため、すべてのメソッドは snake\_case �
 | `setMode()` | `set_mode()` |
 | `setDictionary()` | `set_dictionary()` |
 | `setDictionaryInstance()` | `set_dictionary_instance()` |
-| `setUserDictionary()` | `set_user_dictionary()` |
 | `setUserDictionaryInstance()` | `set_user_dictionary_instance()` |
 | `setKeepWhitespace()` | `set_keep_whitespace()` |
 | `appendCharacterFilter()` | `append_character_filter()` |
@@ -347,6 +322,5 @@ Python API との一貫性のため、すべてのメソッドは snake\_case �
 | `tokenizeNbest()` | `tokenize_nbest()` |
 | `loadDictionary()` | `load_dictionary()` |
 | `loadDictionaryFromBytes()` | `load_dictionary_from_bytes()` |
-| `loadUserDictionary()` | `load_user_dictionary()` |
-| `buildDictionary()` | `build_dictionary()` |
-| `buildUserDictionary()` | `build_user_dictionary()` |
+| `loadUserDictionaryFromBytes()` | `load_user_dictionary_from_bytes()` |
+| `loadUserDictionaryBinFromBytes()` | `load_user_dictionary_bin_from_bytes()` |

--- a/docs/ja/src/migration_v5_to_v6.md
+++ b/docs/ja/src/migration_v5_to_v6.md
@@ -96,6 +96,16 @@ failed to deserialize model: ... re-run `lindera train` to regenerate it.
   `&[String]` から `&[&str]` に変更しました。呼び出し側がフィールドごとに
   `String` を確保する必要がなくなります。`&[String]` を持っている場合は
   `&v.iter().map(|s| s.as_str()).collect::<Vec<_>>()` で渡せます。
+- `lindera-wasm` からファイルシステム依存のエクスポート
+  `loadUserDictionary` / `buildDictionary` / `buildUserDictionary` /
+  `TokenizerBuilder.setUserDictionary(uri)`（と snake_case エイリアス）を
+  削除しました。`wasm32-unknown-unknown` にはファイルシステムが無く、
+  これらは常に実行時に失敗していました。システム辞書は
+  `loadDictionaryFromBytes()`（または `embedded://`）で、ユーザー辞書は
+  新設の `loadUserDictionaryFromBytes()` /
+  `loadUserDictionaryBinFromBytes()` と `setUserDictionaryInstance()` で
+  読み込んでください。`loadDictionary()` はファイル URI・パスを
+  bytes API を案内するエラーで即座に拒否するようになりました。
 - 固定分割の導入で加算順が変わったため、この変更**前**に学習した重みと
   変更後に学習した重みはバイト単位では一致しません（`--max-threads 1` を
   含むすべてのスレッド数で）。以後の成果物を比較可能にするには

--- a/docs/src/lindera-wasm/dictionary_management.md
+++ b/docs/src/lindera-wasm/dictionary_management.md
@@ -115,19 +115,49 @@ console.log(dictionary.encoding); // "utf-8"
 
 User dictionaries allow you to add custom words that are not in the system dictionary.
 
-### Loading a User Dictionary
+There is no filesystem on WebAssembly, so user dictionaries are loaded from
+**bytes** obtained in JavaScript — from `fetch`, an `<input type="file">`
+element, or OPFS.
+
+### Loading a User Dictionary from CSV Bytes
+
+Pass the metadata of the system dictionary the user dictionary will be used
+with (e.g. `dictionary.metadata`), so the CSV is interpreted with the right
+schema. The CSV content must be UTF-8.
 
 ```javascript
-import { loadUserDictionary } from 'lindera-wasm-web';
+import { loadUserDictionaryFromBytes } from 'lindera-wasm-web';
 
-const metadata = dictionary.metadata;
-const userDict = loadUserDictionary("/path/to/user_dict.csv", metadata);
+const response = await fetch('/dictionaries/user_dict.csv');
+const csvBytes = new Uint8Array(await response.arrayBuffer());
+const userDict = loadUserDictionaryFromBytes(csvBytes, dictionary.metadata);
+```
+
+Bytes from OPFS work the same way:
+
+```javascript
+const root = await navigator.storage.getDirectory();
+const handle = await root.getFileHandle('user_dict.csv');
+const csvBytes = new Uint8Array(await (await handle.getFile()).arrayBuffer());
+const userDict = loadUserDictionaryFromBytes(csvBytes, dictionary.metadata);
+```
+
+### Loading a Prebuilt User Dictionary (`.bin`)
+
+A user dictionary compiled with `lindera build --user` loads directly:
+
+```javascript
+import { loadUserDictionaryBinFromBytes } from 'lindera-wasm-web';
+
+const response = await fetch('/dictionaries/user_dict.bin');
+const binBytes = new Uint8Array(await response.arrayBuffer());
+const userDict = loadUserDictionaryBinFromBytes(binBytes);
 ```
 
 ### Using a User Dictionary with Tokenizer
 
 ```javascript
-import { loadDictionaryFromBytes, loadUserDictionary, Tokenizer } from 'lindera-wasm-web';
+import { loadDictionaryFromBytes, loadUserDictionaryFromBytes, Tokenizer } from 'lindera-wasm-web';
 import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
 
 const files = await loadDictionaryFiles("ipadic");
@@ -135,48 +165,33 @@ const dictionary = loadDictionaryFromBytes(
     files.metadata, files.dictTrie, files.dictValsIdx, files.dictVals,
     files.dictWordsIdx, files.dictWords, files.matrixMtx, files.charDef, files.unk,
 );
-const userDict = loadUserDictionary("/path/to/user_dict.csv", dictionary.metadata);
+const response = await fetch('/dictionaries/user_dict.csv');
+const csvBytes = new Uint8Array(await response.arrayBuffer());
+const userDict = loadUserDictionaryFromBytes(csvBytes, dictionary.metadata);
 const tokenizer = new Tokenizer(dictionary, "normal", userDict);
 ```
 
 ### User Dictionary CSV Format
 
-The user dictionary CSV follows the same format as the Lindera user dictionary:
+The user dictionary CSV follows the same format as the Lindera user dictionary.
+For IPADIC the simple format is:
 
 ```csv
 東京スカイツリー,カスタム名詞,トウキョウスカイツリー
 東武スカイツリーライン,カスタム名詞,トウブスカイツリーライン
 ```
 
-Each line contains: `surface,part_of_speech,reading`
+Each line contains: `surface,part_of_speech,reading`. Rows in the full
+dictionary format (13+ fields for IPADIC) are also accepted. The content must
+be UTF-8.
 
 ## Building Dictionaries
 
-You can build compiled dictionaries from source files using the JavaScript API.
-
-### Building a System Dictionary
-
-`metadata` must be an actual `Metadata` instance, not a plain object literal -- the generated binding asserts the argument is a `Metadata` and throws otherwise. Create one with `Metadata.createDefault()` and set the fields you need:
-
-```javascript
-import { buildDictionary, Metadata } from 'lindera-wasm-web';
-
-const metadata = Metadata.createDefault();
-metadata.name = "custom-dict";
-metadata.encoding = "utf-8";
-
-buildDictionary("/path/to/source/dir", "/path/to/output/dir", metadata);
-```
-
-### Building a User Dictionary
-
-```javascript
-import { buildUserDictionary } from 'lindera-wasm-web';
-
-buildUserDictionary("/path/to/user_dict.csv", "/path/to/output/dir");
-```
-
-The `metadata` parameter is optional for `buildUserDictionary`. If omitted, default metadata is used.
+Dictionaries cannot be built in WebAssembly: building reads a source directory
+and writes an output directory, and there is no filesystem on
+`wasm32-unknown-unknown`. Build dictionaries with the `lindera` CLI (or a
+native binding) and load the result here as bytes — see
+[OPFS Dictionary Management](opfs.md) for downloading prebuilt dictionaries.
 
 ## Metadata
 

--- a/docs/src/lindera-wasm/tokenizer_api.md
+++ b/docs/src/lindera-wasm/tokenizer_api.md
@@ -59,20 +59,9 @@ const dictionary = loadDictionaryFromBytes(
 builder.setDictionaryInstance(dictionary);
 ```
 
-#### `setUserDictionary(uri)`
-
-Sets a user-defined dictionary by URI.
-
-- **Parameters**: `uri` (string) -- Path or URI to the user dictionary
-- **Returns**: void
-
-```javascript
-builder.setUserDictionary("file:///path/to/user_dict.csv");
-```
-
 #### `setUserDictionaryInstance(userDictionary)`
 
-Sets a pre-loaded user dictionary instance. Use this when the user dictionary has been loaded from bytes instead of from a URI.
+Sets a pre-loaded user dictionary instance. Load one from bytes with `loadUserDictionaryFromBytes()` (CSV) or `loadUserDictionaryBinFromBytes()` (prebuilt `.bin`); URI-based user dictionaries are not available on WebAssembly.
 
 - **Parameters**: `userDictionary` (UserDictionary) -- A loaded user dictionary object
 - **Returns**: void
@@ -238,34 +227,21 @@ import { loadDictionary } from 'lindera-wasm-web-ipadic';
 const dict = loadDictionary("embedded://ipadic");
 ```
 
-### `loadUserDictionary(uri, metadata)`
+### `loadUserDictionaryFromBytes(csv, metadata)`
 
-Loads a user dictionary from the specified URI.
+Builds a user dictionary from CSV bytes (UTF-8), obtained via `fetch`, a file input, or OPFS.
 
 - **Parameters**:
-  - `uri` (string) -- Path or URI to the user dictionary file
-  - `metadata` (Metadata) -- Dictionary metadata object
+  - `csv` (Uint8Array) -- The user dictionary CSV content
+  - `metadata` (Metadata) -- Metadata of the system dictionary the user dictionary will be used with (e.g. `dictionary.metadata`)
 - **Returns**: `UserDictionary`
 
-### `buildDictionary(inputDir, outputDir, metadata)`
+### `loadUserDictionaryBinFromBytes(bytes)`
 
-Builds a compiled dictionary from source files.
+Loads a prebuilt user dictionary (the output of `lindera build --user`) from bytes.
 
-- **Parameters**:
-  - `inputDir` (string) -- Path to the directory containing source dictionary files
-  - `outputDir` (string) -- Path to the output directory
-  - `metadata` (Metadata) -- Dictionary metadata object
-- **Returns**: void
-
-### `buildUserDictionary(inputFile, outputDir, metadata?)`
-
-Builds a compiled user dictionary from a CSV file.
-
-- **Parameters**:
-  - `inputFile` (string) -- Path to the user dictionary CSV file
-  - `outputDir` (string) -- Path to the output directory
-  - `metadata` (Metadata, optional) -- Dictionary metadata object
-- **Returns**: void
+- **Parameters**: `bytes` (Uint8Array) -- The `.bin` content
+- **Returns**: `UserDictionary`
 
 ### `version()` / `getVersion()`
 
@@ -337,7 +313,6 @@ For consistency with the Python API, all methods are also available in snake\_ca
 | `setMode()` | `set_mode()` |
 | `setDictionary()` | `set_dictionary()` |
 | `setDictionaryInstance()` | `set_dictionary_instance()` |
-| `setUserDictionary()` | `set_user_dictionary()` |
 | `setUserDictionaryInstance()` | `set_user_dictionary_instance()` |
 | `setKeepWhitespace()` | `set_keep_whitespace()` |
 | `appendCharacterFilter()` | `append_character_filter()` |
@@ -346,6 +321,5 @@ For consistency with the Python API, all methods are also available in snake\_ca
 | `tokenizeNbest()` | `tokenize_nbest()` |
 | `loadDictionary()` | `load_dictionary()` |
 | `loadDictionaryFromBytes()` | `load_dictionary_from_bytes()` |
-| `loadUserDictionary()` | `load_user_dictionary()` |
-| `buildDictionary()` | `build_dictionary()` |
-| `buildUserDictionary()` | `build_user_dictionary()` |
+| `loadUserDictionaryFromBytes()` | `load_user_dictionary_from_bytes()` |
+| `loadUserDictionaryBinFromBytes()` | `load_user_dictionary_bin_from_bytes()` |

--- a/docs/src/migration_v5_to_v6.md
+++ b/docs/src/migration_v5_to_v6.md
@@ -96,6 +96,15 @@ Two related notes:
   changed from `&[String]` to `&[&str]`, so callers no longer have to
   allocate one `String` per feature field. A caller holding a `&[String]`
   can pass `&v.iter().map(|s| s.as_str()).collect::<Vec<_>>()`.
+- `lindera-wasm` removed the filesystem-based exports `loadUserDictionary`,
+  `buildDictionary`, `buildUserDictionary`, and
+  `TokenizerBuilder.setUserDictionary(uri)` (plus their snake_case aliases):
+  there is no filesystem on `wasm32-unknown-unknown`, so they always failed
+  at runtime. Load system dictionaries with `loadDictionaryFromBytes()` (or
+  `embedded://`), and user dictionaries with the new
+  `loadUserDictionaryFromBytes()` / `loadUserDictionaryBinFromBytes()` +
+  `setUserDictionaryInstance()`. `loadDictionary()` now rejects file URIs
+  and bare paths up front with an error naming the bytes API.
 - The fixed partition changed the summation order, so weights trained
   **before** this change are not byte-identical to weights trained after it —
   at any thread count, including `--max-threads 1`. Re-run `lindera train` if

--- a/lindera-dictionary/src/builder.rs
+++ b/lindera-dictionary/src/builder.rs
@@ -18,7 +18,9 @@ use self::context_id_remap::compute_context_id_remap;
 use self::metadata::MetadataBuilder;
 use self::prefix_dictionary::PrefixDictionaryBuilderOptions;
 use self::unknown_dictionary::UnknownDictionaryBuilderOptions;
-use self::user_dictionary::{UserDictionaryBuilderOptions, build_user_dictionary};
+use self::user_dictionary::{
+    UserDictionaryBuilder, UserDictionaryBuilderOptions, build_user_dictionary,
+};
 use crate::LinderaResult;
 use crate::dictionary::UserDictionary;
 use crate::dictionary::character_definition::CharacterDefinition;
@@ -278,6 +280,37 @@ impl DictionaryBuilder {
     }
 
     pub fn build_user_dict(&self, input_file: &Path) -> LinderaResult<UserDictionary> {
+        self.user_dictionary_builder().build(input_file)
+    }
+
+    /// Builds a user dictionary from CSV content supplied by a reader.
+    ///
+    /// The filesystem-free counterpart of [`Self::build_user_dict`], added so
+    /// WebAssembly callers can build a user dictionary from bytes (#972).
+    /// The content must be UTF-8.
+    ///
+    /// # 引数
+    ///
+    /// * `reader` - Read source of the user dictionary CSV content.
+    ///
+    /// # 戻り値
+    ///
+    /// The built user dictionary.
+    pub fn build_user_dict_from_reader<R: std::io::Read>(
+        &self,
+        reader: R,
+    ) -> LinderaResult<UserDictionary> {
+        self.user_dictionary_builder().build_from_reader(reader)
+    }
+
+    /// Composes the user-dictionary builder from this builder's metadata,
+    /// including the handler that maps simple rows onto the dictionary
+    /// schema's custom fields.
+    ///
+    /// # 戻り値
+    ///
+    /// The configured builder, shared by the path and reader entry points.
+    fn user_dictionary_builder(&self) -> UserDictionaryBuilder {
         let userdic_schema = self.metadata.user_dictionary_schema.clone();
         let dict_schema = self.metadata.dictionary_schema.clone();
         let default_field_value = self.metadata.default_field_value.clone();
@@ -311,6 +344,5 @@ impl DictionaryBuilder {
                 Ok(result)
             })))
             .builder()
-            .build(input_file)
     }
 }

--- a/lindera-dictionary/src/builder/user_dictionary.rs
+++ b/lindera-dictionary/src/builder/user_dictionary.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::fs::File;
 use std::io;
+use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 
@@ -92,20 +93,47 @@ impl UserDictionaryBuilderOptions {
 }
 
 impl UserDictionaryBuilder {
+    /// Builds a user dictionary from a CSV file on disk.
+    ///
+    /// # 引数
+    ///
+    /// * `input_file` - Path of the user dictionary CSV file.
+    ///
+    /// # 戻り値
+    ///
+    /// The built user dictionary.
     pub fn build(&self, input_file: &Path) -> LinderaResult<UserDictionary> {
         debug!("reading {input_file:?}");
 
+        let file = File::open(input_file).map_err(|err| {
+            LinderaErrorKind::Io
+                .with_error(anyhow::anyhow!(err))
+                .add_context(format!(
+                    "Failed to open user dictionary CSV file: {input_file:?}"
+                ))
+        })?;
+        self.build_from_reader(file)
+    }
+
+    /// Builds a user dictionary from CSV content supplied by a reader.
+    ///
+    /// This is the filesystem-free entry point: WebAssembly callers feed it
+    /// bytes obtained in JavaScript (fetch, file inputs, OPFS), and
+    /// [`Self::build`] delegates here after opening its file (#972).
+    /// The content must be UTF-8.
+    ///
+    /// # 引数
+    ///
+    /// * `reader` - Read source of the user dictionary CSV content.
+    ///
+    /// # 戻り値
+    ///
+    /// The built user dictionary.
+    pub fn build_from_reader<R: Read>(&self, reader: R) -> LinderaResult<UserDictionary> {
         let mut rdr = csv::ReaderBuilder::new()
             .has_headers(false)
             .flexible(self.flexible_csv)
-            .from_path(input_file)
-            .map_err(|err| {
-                LinderaErrorKind::Io
-                    .with_error(anyhow::anyhow!(err))
-                    .add_context(format!(
-                        "Failed to open user dictionary CSV file: {input_file:?}"
-                    ))
-            })?;
+            .from_reader(reader);
 
         let mut rows: Vec<StringRecord> = vec![];
         for (line_num, result) in rdr.records().enumerate() {
@@ -113,13 +141,38 @@ impl UserDictionaryBuilder {
                 LinderaErrorKind::Content
                     .with_error(anyhow::anyhow!(err))
                     .add_context(format!(
-                        "Failed to parse CSV record at line {} in file: {:?}",
+                        "Failed to parse CSV record at line {}",
                         line_num + 1,
-                        input_file
                     ))
             })?;
             rows.push(record);
         }
+
+        // Classify row arity before anything indexes into a row: with
+        // `flexible` CSV parsing a 1- or 2-field row would otherwise reach
+        // the cost/context-id column accesses below and panic out of bounds
+        // -- and a panic aborts the module on wasm32, where this builder is
+        // fed untrusted browser input (#972). Runs before the sort so the
+        // reported row number matches the input order.
+        for (row_id, row) in rows.iter().enumerate() {
+            if row.len() != self.user_dictionary_fields_num
+                && row.len() < self.dictionary_fields_num
+            {
+                return Err(LinderaErrorKind::Content
+                    .with_error(anyhow::anyhow!(
+                        "user dictionary should be a CSV with {} or {}+ fields",
+                        self.user_dictionary_fields_num,
+                        self.dictionary_fields_num
+                    ))
+                    .add_context(format!(
+                        "Row {} has {} fields (surface: '{}')",
+                        row_id + 1,
+                        row.len(),
+                        row.get(0).unwrap_or("<empty>")
+                    )));
+            }
+        }
+
         // The cached variant computes the allocating surface key once per row
         // instead of once per comparison.
         rows.sort_by_cached_key(|row| row[0].to_string());
@@ -182,7 +235,7 @@ impl UserDictionaryBuilder {
 
         let mut words_data = Vec::<u8>::new();
         let mut words_idx_data = Vec::<u8>::new();
-        for row in rows.iter() {
+        for (row_id, row) in rows.iter().enumerate() {
             let word_detail = if row.len() == self.user_dictionary_fields_num {
                 if let Some(handler) = &self.user_dictionary_handler {
                     handler(row)?
@@ -207,7 +260,7 @@ impl UserDictionaryBuilder {
                     ))
                     .add_context(format!(
                         "Row {} has {} fields (surface: '{}')",
-                        rows.iter().position(|r| std::ptr::eq(r, row)).unwrap_or(0) + 1,
+                        row_id + 1,
                         row.len(),
                         row.get(0).unwrap_or("<empty>")
                     )));
@@ -343,4 +396,91 @@ pub fn build_user_dictionary(user_dict: UserDictionary, output_file: &Path) -> L
     })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::builder::DictionaryBuilder;
+    use crate::dictionary::metadata::Metadata;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../resources/user_dict")
+            .join(name)
+    }
+
+    fn flexible_builder() -> DictionaryBuilder {
+        let metadata = Metadata {
+            flexible_csv: true,
+            ..Metadata::default()
+        };
+        DictionaryBuilder::new(metadata)
+    }
+
+    /// The reader-based build must produce a byte-identical dictionary to the
+    /// path-based build over the same CSV (#972).
+    #[test]
+    fn reader_and_path_builds_are_identical() {
+        let path = fixture_path("ipadic_simple_userdic.csv");
+        let builder = flexible_builder();
+
+        let from_path = match builder.build_user_dict(&path) {
+            Ok(dict) => dict,
+            Err(err) => panic!("path build failed: {err}"),
+        };
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(err) => panic!("failed to read fixture: {err}"),
+        };
+        let from_reader = match builder.build_user_dict_from_reader(bytes.as_slice()) {
+            Ok(dict) => dict,
+            Err(err) => panic!("reader build failed: {err}"),
+        };
+
+        let path_bytes = match rkyv::to_bytes::<rkyv::rancor::Error>(&from_path) {
+            Ok(bytes) => bytes,
+            Err(err) => panic!("serialization failed: {err}"),
+        };
+        let reader_bytes = match rkyv::to_bytes::<rkyv::rancor::Error>(&from_reader) {
+            Ok(bytes) => bytes,
+            Err(err) => panic!("serialization failed: {err}"),
+        };
+        assert_eq!(path_bytes.as_slice(), reader_bytes.as_slice());
+    }
+
+    /// A CSV mixing simple (3-field) and detailed (13-field) rows builds
+    /// under flexible parsing. First test to exercise the mixed fixture.
+    #[test]
+    fn mixed_simple_and_detailed_rows_build() {
+        let bytes = match std::fs::read(fixture_path("ipadic_mixed_userdic.csv")) {
+            Ok(bytes) => bytes,
+            Err(err) => panic!("failed to read fixture: {err}"),
+        };
+        let dict = match flexible_builder().build_user_dict_from_reader(bytes.as_slice()) {
+            Ok(dict) => dict,
+            Err(err) => panic!("mixed build failed: {err}"),
+        };
+        assert!(!dict.dict.vals_data.is_empty());
+    }
+
+    /// Rows shorter than the simple format must produce an error, not an
+    /// out-of-bounds panic: with flexible CSV parsing such rows previously
+    /// reached the cost-column access before any arity check, and on wasm32
+    /// a panic aborts the module (#972).
+    #[test]
+    fn short_rows_error_instead_of_panicking() {
+        for csv in ["東京\n", "東京,1288\n"] {
+            let result = flexible_builder().build_user_dict_from_reader(csv.as_bytes());
+            let err = match result {
+                Ok(_) => panic!("{csv:?} must not build"),
+                Err(err) => format!("{err:?}"),
+            };
+            assert!(
+                err.contains("user dictionary should be a CSV with 3 or 13+ fields"),
+                "unexpected error for {csv:?}: {err}"
+            );
+        }
+    }
 }

--- a/lindera-wasm/src/dictionary.rs
+++ b/lindera-wasm/src/dictionary.rs
@@ -1,11 +1,9 @@
-use std::path::Path;
 use std::sync::Arc;
 
 use wasm_bindgen::prelude::*;
 
 use lindera::dictionary::{
     Dictionary, DictionaryBuilder, UserDictionary, load_dictionary as lindera_load_dictionary,
-    load_user_dictionary as lindera_load_user_dictionary,
 };
 use lindera_dictionary::dictionary::character_definition::CharacterDefinition;
 use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix;
@@ -54,34 +52,21 @@ impl JsUserDictionary {
 }
 
 /// Loads a dictionary from the specified URI.
+///
+/// On WebAssembly only `embedded://` dictionaries can be loaded by URI:
+/// there is no filesystem on `wasm32-unknown-unknown`, so file URIs and
+/// bare paths are rejected up front with a pointer at the bytes API (#971).
 #[wasm_bindgen(js_name = "loadDictionary")]
 pub fn load_dictionary(uri: &str) -> Result<JsDictionary, JsValue> {
+    if !uri.starts_with("embedded://") {
+        return Err(JsValue::from_str(
+            "filesystem dictionaries are not available in WebAssembly; \
+             use loadDictionaryFromBytes() with bytes obtained in JavaScript \
+             (see the OPFS helper in js/opfs.js), or an embedded:// dictionary",
+        ));
+    }
     let dict = lindera_load_dictionary(uri).map_err(|e| JsValue::from_str(&e.to_string()))?;
     Ok(JsDictionary { inner: dict })
-}
-
-/// Loads a user dictionary from the specified URI.
-#[wasm_bindgen(js_name = "loadUserDictionary")]
-pub fn load_user_dictionary(uri: &str, metadata: JsMetadata) -> Result<JsUserDictionary, JsValue> {
-    let meta: Metadata = metadata.into();
-    let dict =
-        lindera_load_user_dictionary(uri, &meta).map_err(|e| JsValue::from_str(&e.to_string()))?;
-    Ok(JsUserDictionary { inner: dict })
-}
-
-/// Builds a dictionary from source files.
-#[wasm_bindgen(js_name = "buildDictionary")]
-pub fn build_dictionary(
-    input_dir: &str,
-    output_dir: &str,
-    metadata: JsMetadata,
-) -> Result<(), JsValue> {
-    let meta: Metadata = metadata.into();
-    let builder = DictionaryBuilder::new(meta);
-    builder
-        .build_dictionary(Path::new(input_dir), Path::new(output_dir))
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
-    Ok(())
 }
 
 /// Loads a dictionary from raw byte arrays.
@@ -158,19 +143,39 @@ pub fn load_dictionary_from_bytes(
     Ok(JsDictionary { inner: dict })
 }
 
-/// Builds a user dictionary from a CSV file.
-#[wasm_bindgen(js_name = "buildUserDictionary")]
-pub fn build_user_dictionary(
-    input_file: &str,
-    output_dir: &str,
-    metadata: Option<JsMetadata>,
-) -> Result<(), JsValue> {
-    let meta: Metadata = metadata.map(Into::into).unwrap_or_default();
+/// Builds a user dictionary from CSV bytes.
+///
+/// The bytes typically come from `fetch`, an `<input type="file">` element,
+/// or OPFS. The content must be UTF-8. Rows follow either the simple format
+/// defined by the metadata's user dictionary schema (for IPADIC:
+/// `surface,part_of_speech,reading`) or the full dictionary format; pass the
+/// metadata of the system dictionary the user dictionary will be used with
+/// (e.g. `dictionary.metadata`).
+///
+/// The result feeds `Tokenizer`'s user-dictionary argument or
+/// `TokenizerBuilder.setUserDictionaryInstance()`.
+#[wasm_bindgen(js_name = "loadUserDictionaryFromBytes")]
+pub fn load_user_dictionary_from_bytes(
+    csv: &[u8],
+    metadata: JsMetadata,
+) -> Result<JsUserDictionary, JsValue> {
+    let meta: Metadata = metadata.into();
     let builder = DictionaryBuilder::new(meta);
-    builder
-        .build_user_dictionary(Path::new(input_file), Path::new(output_dir))
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
-    Ok(())
+    let dict = builder
+        .build_user_dict_from_reader(csv)
+        .map_err(|e| JsValue::from_str(&format!("user_dict csv: {e:?}")))?;
+    Ok(JsUserDictionary { inner: dict })
+}
+
+/// Loads a prebuilt user dictionary (`.bin`) from bytes.
+///
+/// The bytes are the output of `lindera build --user` (a serialized user
+/// dictionary), obtained in JavaScript via `fetch`, a file input, or OPFS.
+#[wasm_bindgen(js_name = "loadUserDictionaryBinFromBytes")]
+pub fn load_user_dictionary_bin_from_bytes(bytes: &[u8]) -> Result<JsUserDictionary, JsValue> {
+    let dict = UserDictionary::load(bytes)
+        .map_err(|e| JsValue::from_str(&format!("user_dict bin: {e}")))?;
+    Ok(JsUserDictionary { inner: dict })
 }
 
 #[cfg(test)]
@@ -217,6 +222,83 @@ mod tests {
             err.contains("metadata"),
             "error should mention metadata: {err}"
         );
+    }
+
+    /// Filesystem URIs and bare paths must fail fast with a pointer at the
+    /// bytes API, not with an opaque platform error (#971).
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_load_dictionary_fs_uri_fails_fast() {
+        use super::load_dictionary;
+
+        for uri in ["file:///path/to/dict", "/path/to/dict", "./relative/dict"] {
+            let err = match load_dictionary(uri) {
+                Ok(_) => panic!("{uri} must not load on wasm32"),
+                Err(err) => err.as_string().unwrap_or_default(),
+            };
+            assert!(
+                err.contains("loadDictionaryFromBytes"),
+                "error for {uri} must name the bytes API: {err}"
+            );
+        }
+    }
+
+    /// A user dictionary built from CSV bytes must change tokenization:
+    /// `東京スカイツリー` splits under bare IPADIC and becomes a single token
+    /// with the user dictionary (#972).
+    #[cfg(all(target_arch = "wasm32", feature = "embed-ipadic"))]
+    #[wasm_bindgen_test]
+    fn test_user_dictionary_from_csv_bytes_changes_tokenization() {
+        use super::{load_dictionary, load_user_dictionary_from_bytes};
+        use crate::tokenizer::Tokenizer;
+
+        let dict = load_dictionary("embedded://ipadic").unwrap();
+        let csv = include_bytes!("../../resources/user_dict/ipadic_simple_userdic.csv");
+
+        let without = Tokenizer::new(dict.clone(), None, None).unwrap();
+        let baseline = without.tokenize_surfaces("東京スカイツリー").unwrap();
+        assert!(
+            baseline.len() > 1,
+            "fixture assumption: 東京スカイツリー must split under bare IPADIC: {baseline:?}"
+        );
+
+        let user_dict = load_user_dictionary_from_bytes(csv, dict.metadata()).unwrap();
+        let with = Tokenizer::new(dict, None, Some(user_dict)).unwrap();
+        let surfaces = with.tokenize_surfaces("東京スカイツリー").unwrap();
+        assert_eq!(
+            surfaces,
+            vec!["東京スカイツリー".to_string()],
+            "the user dictionary must take effect"
+        );
+    }
+
+    /// A prebuilt `.bin` user dictionary loaded from bytes must work the
+    /// same way (#972).
+    #[cfg(all(target_arch = "wasm32", feature = "embed-ipadic"))]
+    #[wasm_bindgen_test]
+    fn test_user_dictionary_bin_from_bytes_changes_tokenization() {
+        use super::{load_dictionary, load_user_dictionary_bin_from_bytes};
+        use crate::tokenizer::Tokenizer;
+
+        let dict = load_dictionary("embedded://ipadic").unwrap();
+        let bin = include_bytes!("../../resources/user_dict/ipadic_simple_userdic.bin");
+
+        let user_dict = load_user_dictionary_bin_from_bytes(bin).unwrap();
+        let tokenizer = Tokenizer::new(dict, None, Some(user_dict)).unwrap();
+        let surfaces = tokenizer.tokenize_surfaces("東京スカイツリー").unwrap();
+        assert_eq!(surfaces, vec!["東京スカイツリー".to_string()]);
+    }
+
+    /// Malformed CSV (rows shorter than the simple format) must return an
+    /// error rather than panic — a panic aborts the module on wasm32 (#972).
+    #[cfg(all(target_arch = "wasm32", feature = "embed-ipadic"))]
+    #[wasm_bindgen_test]
+    fn test_user_dictionary_malformed_csv_returns_error() {
+        use super::{load_dictionary, load_user_dictionary_from_bytes};
+
+        let dict = load_dictionary("embedded://ipadic").unwrap();
+        let result = load_user_dictionary_from_bytes("東京,1288\n".as_bytes(), dict.metadata());
+        assert!(result.is_err(), "a 2-field row must be rejected, not panic");
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/lindera-wasm/src/lib.rs
+++ b/lindera-wasm/src/lib.rs
@@ -11,7 +11,7 @@
 //! - **Flexible tokenization modes**: Normal and decompose modes
 //! - **Character filters**: Unicode normalization and more
 //! - **Token filters**: Lowercase, compound word handling, number normalization
-//! - **Custom user dictionaries**: Support for user-defined dictionaries
+//! - **Custom user dictionaries**: Built from CSV or prebuilt bytes via `loadUserDictionaryFromBytes()` / `loadUserDictionaryBinFromBytes()`
 //!
 //! ## Usage
 //!
@@ -85,27 +85,17 @@ pub fn py_load_dictionary_from_bytes(
     )
 }
 
-#[wasm_bindgen(js_name = "load_user_dictionary")]
-pub fn py_load_user_dictionary(uri: &str, metadata: Metadata) -> Result<UserDictionary, JsValue> {
-    crate::dictionary::load_user_dictionary(uri, metadata)
-}
-
-#[wasm_bindgen(js_name = "build_dictionary")]
-pub fn py_build_dictionary(
-    input_dir: &str,
-    output_dir: &str,
+#[wasm_bindgen(js_name = "load_user_dictionary_from_bytes")]
+pub fn py_load_user_dictionary_from_bytes(
+    csv: &[u8],
     metadata: Metadata,
-) -> Result<(), JsValue> {
-    crate::dictionary::build_dictionary(input_dir, output_dir, metadata)
+) -> Result<UserDictionary, JsValue> {
+    crate::dictionary::load_user_dictionary_from_bytes(csv, metadata)
 }
 
-#[wasm_bindgen(js_name = "build_user_dictionary")]
-pub fn py_build_user_dictionary(
-    input_file: &str,
-    output_dir: &str,
-    metadata: Option<Metadata>,
-) -> Result<(), JsValue> {
-    crate::dictionary::build_user_dictionary(input_file, output_dir, metadata)
+#[wasm_bindgen(js_name = "load_user_dictionary_bin_from_bytes")]
+pub fn py_load_user_dictionary_bin_from_bytes(bytes: &[u8]) -> Result<UserDictionary, JsValue> {
+    crate::dictionary::load_user_dictionary_bin_from_bytes(bytes)
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lindera-wasm/src/tokenizer.rs
+++ b/lindera-wasm/src/tokenizer.rs
@@ -103,19 +103,11 @@ impl TokenizerBuilder {
         self.dictionary_instance = Some(dictionary);
     }
 
-    /// Sets a user-defined dictionary by URI.
-    #[wasm_bindgen(js_name = "setUserDictionary")]
-    pub fn set_user_dictionary(&mut self, uri: &str) -> Result<(), JsValue> {
-        self.inner.set_user_dictionary(uri);
-        self.user_dictionary_instance = None;
-
-        Ok(())
-    }
-
     /// Sets a pre-loaded user dictionary instance.
     ///
-    /// Use this method when the user dictionary has been loaded from bytes
-    /// instead of from a URI.
+    /// Use this method with a user dictionary loaded from bytes via
+    /// `loadUserDictionaryFromBytes()` or `loadUserDictionaryBinFromBytes()`;
+    /// URI-based user dictionaries are not available on WebAssembly (#972).
     #[wasm_bindgen(js_name = "setUserDictionaryInstance")]
     pub fn set_user_dictionary_instance(&mut self, user_dictionary: JsUserDictionary) {
         self.user_dictionary_instance = Some(user_dictionary);
@@ -161,11 +153,6 @@ impl TokenizerBuilder {
     #[wasm_bindgen(js_name = "set_dictionary_instance")]
     pub fn py_set_dictionary_instance(&mut self, dictionary: JsDictionary) {
         self.set_dictionary_instance(dictionary)
-    }
-
-    #[wasm_bindgen(js_name = "set_user_dictionary")]
-    pub fn py_set_user_dictionary(&mut self, uri: &str) -> Result<(), JsValue> {
-        self.set_user_dictionary(uri)
     }
 
     #[wasm_bindgen(js_name = "set_user_dictionary_instance")]


### PR DESCRIPTION
## Background

Closes #971. Closes #972.

`lindera-wasm` builds only for `wasm32-unknown-unknown`, where `std::fs` is
unconditionally unsupported — yet several exports went through the filesystem, failing at
runtime with an opaque "operation not supported on this platform" (#971), and user
dictionaries were entirely unusable: every entry point was filesystem-based, and
`setUserDictionaryInstance()` was unreachable because nothing could construct its
argument from JavaScript (#972). The docs actively recommended the broken forms.

The investigation (posted to both issues:
[#971](https://github.com/lindera/lindera/issues/971#issuecomment-5394982208),
[#972](https://github.com/lindera/lindera/issues/972#issuecomment-5394982449)) added
three facts: five snake_case duplicate exports must move in lockstep; **nothing in-repo
uses the filesystem APIs** (the Pages demo, memcheck and READMEs all use the bytes path);
and an adjacent panic — with flexible CSV parsing, a 1–2-field row reaches the cost
column before any arity check and panics out of bounds, which **aborts the module** on
wasm32. Decisions recorded there: the filesystem APIs are **removed** (they have never
worked on this target), and both issues ship in this one PR.

## Changes

**Upstream (`lindera-dictionary`)** — additive only:

- `UserDictionaryBuilder::build_from_reader<R: Read>` — the CSV build body moves behind a
  reader; `build(path)` becomes a `File::open` + delegate wrapper. The only filesystem
  touch in the whole path was the `csv::ReaderBuilder::from_path` call.
- `DictionaryBuilder::build_user_dict_from_reader<R: Read>`, sharing the options/handler
  composition with the path variant via a private helper.
- **Panic fix**: row arity is classified before any indexed column access, so malformed
  rows return a `Content` error (same pinned message) instead of panicking. Also removes
  a `ptr::eq` O(n) row-index recovery. The two error strings pinned by `lindera`'s
  `should_panic` tests are preserved.
- Three new unit tests in a previously test-free file: path/reader rkyv byte-identity,
  the mixed simple+detailed fixture (first test to use it), and short rows returning
  `Err` (fails by panic on the pre-fix code — revert-checked).

**`lindera-wasm`**:

- New: `loadUserDictionaryFromBytes(csv, metadata)` and
  `loadUserDictionaryBinFromBytes(bytes)` (+ snake_case aliases). They feed the existing
  `setUserDictionaryInstance()` / `Tokenizer` constructor — no tokenizer changes. Bytes
  come from `fetch`, `<input type="file">`, or OPFS; CSV must be UTF-8.
- Removed (breaking, migration guide): `loadUserDictionary`, `buildDictionary`,
  `buildUserDictionary`, `TokenizerBuilder.setUserDictionary(uri)`, and their snake_case
  aliases — APIs that have never succeeded at runtime on this target. This also removes
  the silent no-op where a stored user-dictionary URI was ignored whenever
  `setDictionaryInstance` was used.
- `loadDictionary()` now rejects anything but `embedded://` up front:
  "filesystem dictionaries are not available in WebAssembly; use
  loadDictionaryFromBytes() … (see the OPFS helper in js/opfs.js)".

**Docs (en/ja)**: `dictionary_management.md` rewritten to the bytes flow (fetch / file
input / OPFS examples, UTF-8 constraint, the ipadic simple schema); `tokenizer_api.md`
sections and both reference/alias tables updated; the crate doc's user-dictionary claim
made accurate; migration-guide entries with the replacements.

## Verification

- `make test-lindera-wasm`: 24 native + **33 wasm tests green**, including four new
  ones — a user dictionary built from CSV bytes makes `東京スカイツリー` tokenize as a
  single token (it splits under bare embedded IPADIC — the "demonstrably changes
  tokenization" criterion), the prebuilt `.bin` loader, a malformed 2-field CSV returning
  `Err` (a panic would abort the test), and the `loadDictionary` fast-fail naming the
  bytes API.
- `cargo test -p lindera-dictionary` (113) and `cargo test -p lindera --features
  embed-ipadic --lib` (45, including the two pinned `should_panic` tests) — green.
- **Revert checks**: reverting the arity fix makes the new short-row test fail by index
  panic (observed); reverting the reader API breaks wasm compilation.
- `make build-lindera-wasm-example` builds — the Pages demo never used the removed APIs.
- `cargo clippy -p lindera-wasm --target wasm32-unknown-unknown -- -D warnings` (as CI)
  and `--all-targets` clippy clean; `cargo fmt --check`; `markdownlint-cli2` clean over
  both doc trees.

## Breaking change (v6, documented in the migration guide)

The four filesystem-based wasm exports and their snake_case aliases are removed;
`loadDictionary` fails fast for non-`embedded://` URIs. Native bindings and all existing
`lindera-dictionary` signatures are unchanged (additions only).

Closes #971
Closes #972
