### PR TITLE
feat!: rename published packages to the bare-name convention

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
       # placeholders in the repository; the release workflow rewrites
       # them to the actual version at publish time. They must never be
       # bumped in-repo.
-      - dependency-name: lindera-nodejs-*
+      - dependency-name: lindera-*
 
   # Python binding (Poetry via the pip ecosystem).
   - package-ecosystem: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -697,17 +697,10 @@ jobs:
           tag_name: ${{ github.ref_name }}
 
   build-wasm:
-    name: Build WASM (${{ matrix.target.name }})
+    name: Build WASM
     needs: [create-release]
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    strategy:
-      matrix:
-        target:
-          - value: "web"
-            name: "web"
-          - value: "bundler"
-            name: "bundler"
     steps:
       - name: Run checkout
         uses: actions/checkout@v7
@@ -730,7 +723,7 @@ jobs:
         shell: bash
         run: |
           cd lindera-wasm
-          wasm-pack build --release --target ${{ matrix.target.value }}
+          wasm-pack build --release --target web
 
       - name: Copy JS helpers to pkg
         shell: bash
@@ -743,8 +736,6 @@ jobs:
         run: |
           cd lindera-wasm/pkg
           jq '
-            .name = "lindera-wasm-${{ matrix.target.name }}" |
-            .description = "Lindera WASM (${{ matrix.target.name }} target)" |
             .files += ["opfs.js", "opfs.d.ts"] |
             .exports = {
               ".": {
@@ -762,7 +753,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: wasm-pkg-lindera-wasm-${{ matrix.target.name }}
+          name: wasm-pkg-lindera-wasm
           path: lindera-wasm/pkg
 
   build-lindera-nodejs:
@@ -832,7 +823,10 @@ jobs:
 
       - name: Publish crates
         run: |
-          for crate in lindera-crf lindera-dictionary lindera-trainer lindera-cc-cedict lindera-jieba lindera-ipadic lindera-ipadic-neologd lindera-ko-dic lindera-unidic lindera lindera-analysis lindera-binding-core lindera-python lindera-nodejs lindera-ruby lindera-cli lindera-wasm; do
+          # Binding crates (lindera-python, lindera-nodejs, lindera-ruby,
+          # lindera-wasm, lindera-php) are not published to crates.io; they are
+          # distributed through their own registries (PyPI, npm, RubyGems).
+          for crate in lindera-crf lindera-dictionary lindera-trainer lindera-cc-cedict lindera-jieba lindera-ipadic lindera-ipadic-neologd lindera-ko-dic lindera-unidic lindera lindera-analysis lindera-binding-core lindera-cli; do
             VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r ".packages[] | select(.name==\"$crate\") | .version")
             PUBLISHED_VERSIONS=$(curl -s -A "lindera-release-workflow (https://github.com/lindera/lindera)" "https://crates.io/api/v1/crates/$crate" | jq -r 'select(.versions != null) | .versions[].num')
             if echo "${PUBLISHED_VERSIONS}" | grep -Fx "${VERSION}" >/dev/null; then
@@ -872,17 +866,10 @@ jobs:
           args: --non-interactive --skip-existing dist/*
 
   publish-wasm-npm:
-    name: Publish WASM to npm (${{ matrix.target.name }})
+    name: Publish WASM to npm
     needs: [build-wasm]
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    strategy:
-      matrix:
-        target:
-          - value: "web"
-            name: "web"
-          - value: "bundler"
-            name: "bundler"
     steps:
       - name: Run checkout
         uses: actions/checkout@v7
@@ -890,7 +877,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: wasm-pkg-lindera-wasm-${{ matrix.target.name }}
+          name: wasm-pkg-lindera-wasm
           path: lindera-wasm/pkg
 
       - name: Setup Node.js

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Lindera tokenizes Japanese text (IPADIC) at roughly 10-20 MB/s single-threaded, 
 Lindera also provides Python bindings. You can install it via pip:
 
 ```bash
-pip install lindera-python
+pip install lindera
 ```
 
 For more details, see the [lindera-python](lindera-python/) directory.
@@ -42,7 +42,7 @@ For more details, see the [lindera-python](lindera-python/) directory.
 Lindera also provides Node.js bindings. You can install it via npm:
 
 ```bash
-npm install lindera-nodejs
+npm install lindera
 ```
 
 For more details, see the [lindera-nodejs](lindera-nodejs/) directory.
@@ -60,9 +60,11 @@ Lindera also provides PHP bindings. They are not yet published to Packagist — 
 Lindera also provides WebAssembly bindings. You can install it via npm:
 
 ```bash
-npm install lindera-wasm-web      # browser (native ES modules)
-npm install lindera-wasm-bundler  # bundlers (Webpack, Rollup, etc.)
+npm install lindera-wasm
 ```
+
+The package is built with wasm-pack's `web` target and works in browsers
+natively as well as with modern bundlers (Vite, Webpack 5).
 
 For more details and a demo application, see the [lindera-wasm](lindera-wasm/) directory.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -26,7 +26,7 @@ lindera = "5"
 Lindera は Python バインディングも提供しています。pip でインストールできます:
 
 ```bash
-pip install lindera-python
+pip install lindera
 ```
 
 詳細は [lindera-python](lindera-python/) ディレクトリを参照してください。
@@ -36,7 +36,7 @@ pip install lindera-python
 Lindera は Node.js バインディングも提供しています。npm でインストールできます:
 
 ```bash
-npm install lindera-nodejs
+npm install lindera
 ```
 
 詳細は [lindera-nodejs](lindera-nodejs/) ディレクトリを参照してください。
@@ -54,9 +54,10 @@ Lindera は PHP バインディングも提供していますが、Packagist に
 Lindera は WebAssembly バインディングも提供しています。npm でインストールできます:
 
 ```bash
-npm install lindera-wasm-web      # ブラウザ向け（ネイティブ ES モジュール）
-npm install lindera-wasm-bundler  # バンドラー向け（Webpack、Rollup など）
+npm install lindera-wasm
 ```
+
+パッケージは `web` ターゲットでビルドされており、ブラウザからネイティブ ES モジュールとして直接利用できるほか、モダンなバンドラー（Vite、Webpack 5 など）からも利用できます。
 
 詳細とデモアプリケーションは [lindera-wasm](lindera-wasm/) ディレクトリを参照してください。
 

--- a/docs/ja/src/lindera-nodejs/dictionary_management.md
+++ b/docs/ja/src/lindera-nodejs/dictionary_management.md
@@ -9,7 +9,7 @@ Lindera Node.js は、形態素解析で使用する辞書の読み込み、ビ�
 `loadDictionary(uri)` を使用してシステム辞書を読み込みます。[GitHub Releases](https://github.com/lindera/lindera/releases) からビルド済み辞書をダウンロードし、展開したディレクトリのパスを指定してください：
 
 ```javascript
-const { loadDictionary } = require("lindera-nodejs");
+const { loadDictionary } = require("lindera");
 
 const dictionary = loadDictionary("/path/to/ipadic");
 ```
@@ -35,7 +35,7 @@ console.log(metadata.defaultWordCost);
 ユーザー辞書はシステム辞書にカスタム語彙を追加します。
 
 ```javascript
-const { loadUserDictionary, Metadata } = require("lindera-nodejs");
+const { loadUserDictionary, Metadata } = require("lindera");
 
 const metadata = new Metadata();
 const userDict = loadUserDictionary("/path/to/user_dictionary", metadata);
@@ -44,7 +44,7 @@ const userDict = loadUserDictionary("/path/to/user_dictionary", metadata);
 トークナイザーのビルド時にユーザー辞書を渡します：
 
 ```javascript
-const { Tokenizer, loadDictionary, loadUserDictionary, Metadata } = require("lindera-nodejs");
+const { Tokenizer, loadDictionary, loadUserDictionary, Metadata } = require("lindera");
 
 const dictionary = loadDictionary("/path/to/ipadic");
 const metadata = new Metadata();
@@ -56,7 +56,7 @@ const tokenizer = new Tokenizer(dictionary, "normal", userDict);
 または、ビルダー経由で設定します：
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setDictionary("/path/to/ipadic")
@@ -71,7 +71,7 @@ const tokenizer = new TokenizerBuilder()
 ソースファイルからシステム辞書をビルドします：
 
 ```javascript
-const { buildDictionary, Metadata } = require("lindera-nodejs");
+const { buildDictionary, Metadata } = require("lindera");
 
 const metadata = new Metadata({ name: "custom", encoding: "UTF-8" });
 buildDictionary("/path/to/input_dir", "/path/to/output_dir", metadata);
@@ -84,7 +84,7 @@ buildDictionary("/path/to/input_dir", "/path/to/output_dir", metadata);
 CSV ファイルからユーザー辞書をビルドします：
 
 ```javascript
-const { buildUserDictionary, Metadata } = require("lindera-nodejs");
+const { buildUserDictionary, Metadata } = require("lindera");
 
 const metadata = new Metadata();
 buildUserDictionary("ipadic", "user_words.csv", "/path/to/output_dir", metadata);
@@ -107,7 +107,7 @@ buildUserDictionary("ipadic", "user_words.csv", "/path/to/output_dir");
 ### Metadata の作成
 
 ```javascript
-const { Metadata } = require("lindera-nodejs");
+const { Metadata } = require("lindera");
 
 // デフォルトのメタデータ
 const metadata = new Metadata();
@@ -170,7 +170,7 @@ console.log(metadata.toObject());
 ### Schema の作成
 
 ```javascript
-const { Schema } = require("lindera-nodejs");
+const { Schema } = require("lindera");
 
 // デフォルトの IPADIC 互換スキーマ
 const schema = Schema.createDefault();

--- a/docs/ja/src/lindera-nodejs/installation.md
+++ b/docs/ja/src/lindera-nodejs/installation.md
@@ -5,7 +5,7 @@
 ビルド済みパッケージが npm で公開予定です：
 
 ```bash
-npm install lindera-nodejs
+npm install lindera
 ```
 
 > [!NOTE]
@@ -97,14 +97,14 @@ npm run build -- --features "train,embed-ipadic,embed-ko-dic"
 インストール後、Node.js で lindera が利用可能であることを確認します：
 
 ```javascript
-const lindera = require("lindera-nodejs");
+const lindera = require("lindera");
 
 console.log(lindera.version());
 ```
 
 > [!NOTE]
-> `lindera-nodejs` の `package.json` は現状、`exports` マップに `require` 条件のみを定義しており
-> （`import` 条件はありません）、そのため `import { version } from "lindera-nodejs";` は
+> npm パッケージ `lindera` の `package.json` は現状、`exports` マップに `require` 条件のみを定義しており
+> （`import` 条件はありません）、そのため `import { version } from "lindera";` は
 > `ERR_PACKAGE_PATH_NOT_EXPORTED` で失敗します。ES modules から利用する場合は、Node.js の
 > `createRequire` を使用してください：
 
@@ -112,7 +112,7 @@ console.log(lindera.version());
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const lindera = require("lindera-nodejs");
+const lindera = require("lindera");
 
 console.log(lindera.version());
 ```

--- a/docs/ja/src/lindera-nodejs/quickstart.md
+++ b/docs/ja/src/lindera-nodejs/quickstart.md
@@ -7,7 +7,7 @@
 トークナイザーの作成には `TokenizerBuilder` の使用を推奨します：
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const builder = new TokenizerBuilder();
 builder.setMode("normal");
@@ -35,7 +35,7 @@ for (const token of tokens) {
 `TokenizerBuilder` は簡潔な設定のためにメソッドチェーンをサポートしています：
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setMode("normal")
@@ -53,7 +53,7 @@ for (const token of tokens) {
 各トークンは以下のプロパティを公開しています：
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setDictionary("/path/to/ipadic")
@@ -76,7 +76,7 @@ for (const token of tokens) {
 コスト順にランク付けされた複数のトークナイズ候補を取得します：
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setDictionary("/path/to/ipadic")
@@ -94,14 +94,14 @@ for (const { tokens, cost } of results) {
 Lindera Node.js には TypeScript の型定義が含まれています。すべてのクラスと関数に完全な型が付いています：
 
 ```typescript
-import type { Token } from "lindera-nodejs";
+import type { Token } from "lindera";
 import { createRequire } from "node:module";
 
-// lindera-nodejs は CommonJS の require エントリポイントのみを公開しているため
+// npm パッケージ lindera は CommonJS の require エントリポイントのみを公開しているため
 // （「インストール」を参照）、ESM プロジェクトでは createRequire で実行時の値を
 // 読み込みつつ、import type で型情報を取得します。
 const require = createRequire(import.meta.url);
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setMode("normal")

--- a/docs/ja/src/lindera-nodejs/text_processing_pipeline.md
+++ b/docs/ja/src/lindera-nodejs/text_processing_pipeline.md
@@ -24,7 +24,7 @@ Input Text
 入力テキストに Unicode 正規化を適用します。
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setDictionary("embedded://ipadic")
@@ -121,7 +121,7 @@ const tokenizer = new TokenizerBuilder()
 以下の例では、複数の文字フィルタとトークンフィルタを1つのパイプラインに組み合わせています：
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setMode("normal")

--- a/docs/ja/src/lindera-nodejs/tokenizer_api.md
+++ b/docs/ja/src/lindera-nodejs/tokenizer_api.md
@@ -11,7 +11,7 @@
 デフォルト設定で新しいビルダーを作成します。
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const builder = new TokenizerBuilder();
 ```
@@ -108,7 +108,7 @@ const tokenizer = builder.build();
 読み込み済みの辞書から直接トークナイザーを作成します。
 
 ```javascript
-const { Tokenizer, loadDictionary } = require("lindera-nodejs");
+const { Tokenizer, loadDictionary } = require("lindera");
 
 const dictionary = loadDictionary("embedded://ipadic");
 const tokenizer = new Tokenizer(dictionary, "normal");
@@ -210,7 +210,7 @@ const reading = token.details[7];  // 例: "トウキョウ"
 
 ## Mode と Penalty
 
-`Mode` と `Penalty` は `lindera-nodejs` からエクスポートされていますが、**現状どの公開 API
+`Mode` と `Penalty` は npm パッケージ `lindera` からエクスポートされていますが、**現状どの公開 API
 にも接続されていません**： `TokenizerBuilder.setMode()` / `Tokenizer` のコンストラクタは
 単純なモード文字列（`"normal"` または `"decompose"`）のみを受け取り、decompose モードは
 内部的に常にデフォルトのペナルティ設定を使用します。これらの型は完全性のためにここで

--- a/docs/ja/src/lindera-nodejs/training.md
+++ b/docs/ja/src/lindera-nodejs/training.md
@@ -22,7 +22,7 @@ npm run build -- --features train
 `train()` を使用して、種辞書とアノテーション付きコーパスから CRF モデルを学習します：
 
 ```javascript
-const { train } = require("lindera-nodejs");
+const { train } = require("lindera");
 
 train({
   seed: "resources/training/seed.csv",
@@ -58,7 +58,7 @@ train({
 学習後、`exportModel()` を使用してモデルを辞書ソースファイルにエクスポートします：
 
 ```javascript
-const { exportModel } = require("lindera-nodejs");
+const { exportModel } = require("lindera");
 
 exportModel({
   model: "/tmp/model.dat",
@@ -94,7 +94,7 @@ const {
   buildDictionary,
   Metadata,
   TokenizerBuilder,
-} = require("lindera-nodejs");
+} = require("lindera");
 
 // Step 1: Train the CRF model
 train({

--- a/docs/ja/src/lindera-python/installation.md
+++ b/docs/ja/src/lindera-python/installation.md
@@ -2,10 +2,10 @@
 
 ## PyPI からのインストール
 
-ビルド済みホイールが [PyPI](https://pypi.org/project/lindera-python/) で公開されています：
+ビルド済みホイールが [PyPI](https://pypi.org/project/lindera/) で公開されています：
 
 ```bash
-pip install lindera-python
+pip install lindera
 ```
 
 > [!NOTE]

--- a/docs/ja/src/lindera-wasm/browser_usage.md
+++ b/docs/ja/src/lindera-wasm/browser_usage.md
@@ -7,8 +7,8 @@
 推奨される方法は、辞書を WASM バイナリに埋め込むのではなく、OPFS から読み込むことです：
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm/opfs';
 
 async function main() {
     // WASM モジュールを初期化する（いずれかの API を使用する前に一度だけ呼び出す必要がある）
@@ -49,10 +49,10 @@ main();
 `embed-*` feature フラグ付きでビルドした場合、OPFS の代わりに埋め込み辞書を使用できます：
 
 > [!NOTE]
-> ここでの `lindera-wasm-web-ipadic` は説明用のパッケージ名であり、npm に公開されているものではありません。実際に公開されているのは `lindera-wasm-web` と `lindera-wasm-bundler` のみです。このようなパッケージを自分でビルド・命名する方法は [npm パッケージの命名規則](./installation.md#npm-パッケージの命名規則) を参照してください。
+> ここでの `lindera-wasm-ipadic` は説明用のパッケージ名であり、npm に公開されているものではありません。実際に公開されているのは `lindera-wasm` のみです。このようなパッケージを自分でビルド・命名する方法は [npm パッケージの命名規則](./installation.md#npm-パッケージの命名規則) を参照してください。
 
 ```javascript
-import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-web-ipadic';
+import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-ipadic';
 
 async function main() {
     await __wbg_init();
@@ -159,11 +159,14 @@ module.exports = {
 };
 ```
 
-次に、bundler ターゲットビルドを使用してインポートします：
+次に、`lindera-wasm` パッケージをインポートします。`web` ターゲットのビルドでは、使用前にデフォルトエクスポートの `__wbg_init()` を呼び出す必要があります：
 
 ```javascript
-import { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-bundler';
-import { loadDictionaryFiles } from 'lindera-wasm-bundler/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
+
+// WASM モジュールを初期化
+await __wbg_init();
 
 // OPFS から辞書を読み込み（セットアップは OPFS 辞書ストレージを参照）
 const files = await loadDictionaryFiles("ipadic");
@@ -179,30 +182,32 @@ builder.setMode("normal");
 const tokenizer = builder.build();
 ```
 
-bundler ターゲットでは、`__wbg_init()` はバンドラーによって自動的に呼び出されます。
-
 ## Vite / Rollup のセットアップ
 
-Vite は web ターゲットでの WASM をそのままサポートしています。ビルド済みの `pkg/` ディレクトリをプロジェクトに配置し、直接インポートします：
+Vite は `web` ターゲットの WASM をそのままサポートしています。npm からインストールした `lindera-wasm` を直接インポートできます：
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from './pkg/lindera_wasm.js';
-import { loadDictionaryFiles } from './pkg/opfs.js';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 await __wbg_init();
 // OPFS から辞書を読み込み、上記のように TokenizerBuilder を使用
 ```
 
-bundler ターゲットで Vite を使用する場合は、[vite-plugin-wasm](https://github.com/nicolo-ribaudo/vite-plugin-wasm) プラグインが必要になることがあります：
+Vite では `optimizeDeps` でこのパッケージを除外してください：
 
 ```javascript
 // vite.config.js
-import wasm from 'vite-plugin-wasm';
+import { defineConfig } from 'vite';
 
-export default {
-    plugins: [wasm()],
-};
+export default defineConfig({
+    optimizeDeps: {
+        exclude: ["lindera-wasm"],
+    },
+});
 ```
+
+ローカルでビルドした場合は、生成された `pkg/` ディレクトリをプロジェクトに配置し、`./pkg/lindera_wasm.js` を直接インポートすることもできます。
 
 ## Chrome 拡張機能に関する注意事項
 

--- a/docs/ja/src/lindera-wasm/dictionary_management.md
+++ b/docs/ja/src/lindera-wasm/dictionary_management.md
@@ -23,8 +23,8 @@ OPFS やその他のブラウザストレージに保存された辞書を `load
 - **戻り値**: `Dictionary`
 
 ```javascript
-import { loadDictionaryFromBytes, TokenizerBuilder } from 'lindera-wasm-web';
-import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import { loadDictionaryFromBytes, TokenizerBuilder } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 // OPFS から辞書ファイルを読み込む
 const files = await loadDictionaryFiles("ipadic");
@@ -56,12 +56,12 @@ const tokenizer = builder.build();
 `embed-*` feature フラグ付きでビルドした場合、`embedded://` URI スキームで埋め込み辞書を読み込めます。WASM バイナリのサイズが大幅に増加します。
 
 > [!NOTE]
-> 以下の例の `lindera-wasm-web-ipadic` は `embed-ipadic` feature でローカルビルドした場合の説明用パッケージ名であり、npm に公開されているものではありません。実際に公開されているのは `lindera-wasm-web` と `lindera-wasm-bundler` のみです。詳細は [npm パッケージの命名規則](./installation.md#npm-パッケージの命名規則) を参照してください。
+> 以下の例の `lindera-wasm-ipadic` は `embed-ipadic` feature でローカルビルドした場合の説明用パッケージ名であり、npm に公開されているものではありません。実際に公開されているのは `lindera-wasm` のみです。詳細は [npm パッケージの命名規則](./installation.md#npm-パッケージの命名規則) を参照してください。
 
 ### 埋め込み辞書の読み込み
 
 ```javascript
-import { loadDictionary } from 'lindera-wasm-web-ipadic';
+import { loadDictionary } from 'lindera-wasm-ipadic';
 
 const dictionary = loadDictionary("embedded://ipadic");
 ```
@@ -88,7 +88,7 @@ const tokenizer = builder.build();
 ### Tokenizer コンストラクタでの使用
 
 ```javascript
-import { loadDictionary, Tokenizer } from 'lindera-wasm-web-ipadic';
+import { loadDictionary, Tokenizer } from 'lindera-wasm-ipadic';
 
 const dictionary = loadDictionary("embedded://ipadic");
 const tokenizer = new Tokenizer(dictionary, "normal");
@@ -125,7 +125,7 @@ WebAssembly にはファイルシステムが無いため、ユーザー辞書�
 あります。
 
 ```javascript
-import { loadUserDictionaryFromBytes } from 'lindera-wasm-web';
+import { loadUserDictionaryFromBytes } from 'lindera-wasm';
 
 const response = await fetch('/dictionaries/user_dict.csv');
 const csvBytes = new Uint8Array(await response.arrayBuffer());
@@ -146,7 +146,7 @@ const userDict = loadUserDictionaryFromBytes(csvBytes, dictionary.metadata);
 `lindera build --user` でコンパイルしたユーザー辞書はそのまま読み込めます：
 
 ```javascript
-import { loadUserDictionaryBinFromBytes } from 'lindera-wasm-web';
+import { loadUserDictionaryBinFromBytes } from 'lindera-wasm';
 
 const response = await fetch('/dictionaries/user_dict.bin');
 const binBytes = new Uint8Array(await response.arrayBuffer());
@@ -156,8 +156,8 @@ const userDict = loadUserDictionaryBinFromBytes(binBytes);
 ### Tokenizer でのユーザー辞書の使用
 
 ```javascript
-import { loadDictionaryFromBytes, loadUserDictionaryFromBytes, Tokenizer } from 'lindera-wasm-web';
-import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import { loadDictionaryFromBytes, loadUserDictionaryFromBytes, Tokenizer } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 const files = await loadDictionaryFiles("ipadic");
 const dictionary = loadDictionaryFromBytes(

--- a/docs/ja/src/lindera-wasm/installation.md
+++ b/docs/ja/src/lindera-wasm/installation.md
@@ -14,7 +14,7 @@ Lindera WASM はデフォルトで辞書を同梱しません。ブラウザ環�
 ビルド済み辞書は [GitHub Releases](https://github.com/lindera/lindera/releases) ページから入手できます。ブラウザ環境では、OPFS ヘルパーを使用して辞書をダウンロードしてキャッシュします：
 
 ```javascript
-import { downloadDictionary, hasDictionary } from 'lindera-wasm-web/opfs';
+import { downloadDictionary, hasDictionary } from 'lindera-wasm/opfs';
 
 if (!await hasDictionary("ipadic")) {
     await downloadDictionary(
@@ -28,21 +28,15 @@ if (!await hasDictionary("ipadic")) {
 
 ## wasm-pack によるビルド
 
-ターゲット環境に合わせて WASM パッケージをビルドします：
-
-### Web（ブラウザ向け ES Modules）
+公開されている npm パッケージと同じ構成でビルドするには、`web` ターゲットを使用します：
 
 ```bash
 wasm-pack build --target web
 ```
 
-### バンドラー（Webpack、Vite、Rollup）
-
-```bash
-wasm-pack build --target bundler
-```
-
 出力は `lindera-wasm` クレート内の `pkg/` ディレクトリに書き込まれます。
+
+`web` ターゲットのビルドは、ブラウザからネイティブ ES モジュールとして直接利用できるほか、モダンなバンドラー（Vite、Webpack 5 の `asyncWebAssembly` など）からもそのまま利用できます。バンドラー専用のビルドを別途用意する必要はありません。
 
 ## 利用可能な Feature フラグ（上級者向け）
 
@@ -65,37 +59,37 @@ wasm-pack build --target web --features embed-ipadic,embed-ko-dic
 
 ## npm パッケージの命名規則
 
-npm に公開する際の推奨命名規則は以下の通りです：
+辞書を埋め込んだパッケージを自分で公開する際の推奨命名規則は以下の通りです：
 
 ```text
-lindera-wasm-{target}
-lindera-wasm-{target}-{dict}
+lindera-wasm
+lindera-wasm-{dict}
 ```
 
 例：
 
-- `lindera-wasm-web`
-- `lindera-wasm-web-ipadic`
-- `lindera-wasm-bundler-unidic`
-- `lindera-wasm-web-cjk`
+- `lindera-wasm`
+- `lindera-wasm-ipadic`
+- `lindera-wasm-unidic`
+- `lindera-wasm-cjk`
 
 公開前にパッケージ名を設定するには、生成された `pkg/package.json` の `name` フィールドを編集します。
 
 > [!NOTE]
-> 本プロジェクトのリリースワークフロー（`.github/workflows/release.yml`）が実際にビルドして npm に公開しているのは、`embed-*` feature を一切使わずにビルドした `lindera-wasm-web` と `lindera-wasm-bundler` という 2 つの汎用パッケージのみです。`lindera-wasm-web-ipadic` のような辞書名付きのパッケージ名はどこにも公開されていません。これは、対応する `embed-*` feature（上記の[利用可能な Feature フラグ](#利用可能な-feature-フラグ上級者向け)を参照）でローカルビルドし、自分でパッケージ名をリネームした場合に得られる名前の例に過ぎません。
+> 本プロジェクトのリリースワークフロー（`.github/workflows/release.yml`）が実際にビルドして npm に公開しているのは、`embed-*` feature を一切使わずに `web` ターゲットでビルドした `lindera-wasm` という汎用パッケージのみです。`lindera-wasm-ipadic` のような辞書名付きのパッケージ名はどこにも公開されていません。これは、対応する `embed-*` feature（上記の[利用可能な Feature フラグ](#利用可能な-feature-フラグ上級者向け)を参照）でローカルビルドし、自分でパッケージ名をリネームした場合に得られる名前の例に過ぎません。
 
 ## npm からのインストール
 
 ビルド済みパッケージが npm で公開されています：
 
 ```bash
-npm install lindera-wasm-web
+npm install lindera-wasm
 ```
 
 または yarn で：
 
 ```bash
-yarn add lindera-wasm-web
+yarn add lindera-wasm
 ```
 
 > [!NOTE]

--- a/docs/ja/src/lindera-wasm/opfs.md
+++ b/docs/ja/src/lindera-wasm/opfs.md
@@ -12,7 +12,7 @@ OPFS ヘルパーは、WASM パッケージとともに別の JavaScript モジ�
 
 ```javascript
 import { downloadDictionary, loadDictionaryFiles, removeDictionary,
-         listDictionaries, hasDictionary } from 'lindera-wasm-web/opfs';
+         listDictionaries, hasDictionary } from 'lindera-wasm/opfs';
 ```
 
 ## 関数
@@ -133,8 +133,8 @@ if (await hasDictionary("ipadic")) {
 OPFS ベースの辞書を使用する一般的なワークフロー:
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm/opfs';
 
 async function main() {
     await __wbg_init();

--- a/docs/ja/src/lindera-wasm/quickstart.md
+++ b/docs/ja/src/lindera-wasm/quickstart.md
@@ -5,8 +5,8 @@
 推奨される方法は、OPFS ヘルパーを使用して辞書を実行時にダウンロードすることです：
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm/opfs';
 
 async function main() {
     await __wbg_init();
@@ -57,10 +57,10 @@ main();
 `embed-*` feature フラグ付きでビルドした場合、埋め込み辞書を使用できます：
 
 > [!NOTE]
-> ここでの `lindera-wasm-web-ipadic` は説明用のパッケージ名であり、npm に公開されているものではありません。実際に公開されているのは `lindera-wasm-web` と `lindera-wasm-bundler` のみです。このようなパッケージを自分でビルド・命名する方法は [npm パッケージの命名規則](./installation.md#npm-パッケージの命名規則) を参照してください。
+> ここでの `lindera-wasm-ipadic` は説明用のパッケージ名であり、npm に公開されているものではありません。実際に公開されているのは `lindera-wasm` のみです。このようなパッケージを自分でビルド・命名する方法は [npm パッケージの命名規則](./installation.md#npm-パッケージの命名規則) を参照してください。
 
 ```javascript
-import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-web-ipadic';
+import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-ipadic';
 
 async function main() {
     await __wbg_init();
@@ -84,8 +84,8 @@ main();
 トークナイズパイプラインに文字フィルタやトークンフィルタを追加できます：
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 async function main() {
     await __wbg_init();

--- a/docs/ja/src/lindera-wasm/tokenizer_api.md
+++ b/docs/ja/src/lindera-wasm/tokenizer_api.md
@@ -47,8 +47,8 @@ URI の代わりにバイトデータから読み込んだ辞書（例: `loadDic
 - **戻り値**: void
 
 ```javascript
-import { loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import { loadDictionaryFromBytes } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 const files = await loadDictionaryFiles("ipadic");
 const dictionary = loadDictionaryFromBytes(
@@ -213,7 +213,7 @@ console.log(JSON.stringify(token, null, 2));
 ## ヘルパー関数
 
 > [!NOTE]
-> 以下の例は `lindera-wasm-web-ipadic` からインポートしていますが、これは `embed-ipadic` feature を使ってローカルビルドした場合の説明用パッケージ名であり、npm に公開されているものではありません。実際に公開されているのは `lindera-wasm-web` と `lindera-wasm-bundler` のみです。詳細は [npm パッケージの命名規則](./installation.md#npm-パッケージの命名規則) を参照してください。
+> 以下の例は `lindera-wasm-ipadic` からインポートしていますが、これは `embed-ipadic` feature を使ってローカルビルドした場合の説明用パッケージ名であり、npm に公開されているものではありません。実際に公開されているのは `lindera-wasm` のみです。詳細は [npm パッケージの命名規則](./installation.md#npm-パッケージの命名規則) を参照してください。
 
 ### `loadDictionary(uri)`
 
@@ -223,7 +223,7 @@ console.log(JSON.stringify(token, null, 2));
 - **戻り値**: `Dictionary`
 
 ```javascript
-import { loadDictionary } from 'lindera-wasm-web-ipadic';
+import { loadDictionary } from 'lindera-wasm-ipadic';
 
 const dict = loadDictionary("embedded://ipadic");
 ```
@@ -251,7 +251,7 @@ lindera-wasm パッケージのバージョン文字列を返します。
 - **戻り値**: `string`
 
 ```javascript
-import { version } from 'lindera-wasm-web-ipadic';
+import { version } from 'lindera-wasm-ipadic';
 
 console.log(version()); // 例: "5.3.0"
 ```

--- a/docs/ja/src/migration_v5_to_v6.md
+++ b/docs/ja/src/migration_v5_to_v6.md
@@ -23,10 +23,109 @@ Lindera v6.0.0 では、ビルド済みユーザー辞書の再ビルドが必�
 | 未知語の候補ラダー（length ladder）がデフォルトで有効に | 辞書外テキストに対する Normal・Decompose 両モードの出力 | v5 と同一の出力が必要な場合は `unknown_word_ladder(false)` / `--disable-unknown-word-ladder` を設定 |
 | `max_grouping_len` オプションの新設（`--max-grouping-len`、config キー、builder/worker setter） | MeCab の `max-grouping-size` 相当の上限を使いたいユーザー | 対応不要（デフォルトは従来どおり無制限） |
 | JS バインディングがプレーンオブジェクトを返すようになり `Token` クラスが廃止 | Node.js・WASM ユーザー | `token.getDetail(i)` を `token.details[i]` に置換。WASM ユーザーはフィールド名の camelCase 化にも対応 |
+| **npm・PyPI のパッケージ名が変更**（`lindera-nodejs` → `lindera`、`lindera-python` → `lindera`、WASM は `lindera-wasm` に統合） | npm・PyPI からバインディングをインストールしているユーザー | 依存関係と import のパッケージ名を更新（[下記](#npmpypicratesio-のパッケージ名変更)参照） |
 | `lindera_dictionary::viterbi`/`mode` の一部項目が改名・削除、`Lattice::set_text`/`set_text_nbest` に引数 2 つ追加 | `Lattice`/`Edge`/`Penalty`/`Mode` を直接利用するコード（`lindera` クレートの `Segmenter`/`Tokenizer`/`Worker` API 利用者は対象外） | 下記の表に従い呼び出し箇所を更新 |
 | ビルド済み辞書フォーマットがバージョン 2（`dict.da` → `dict.trie` + `dict.valsidx`）— **v5.3.0 でリリース済み** | **v5.2 以前**で作成した自前ビルドのシステム辞書 | `lindera build` で再ビルド、または `lindera download` で再取得 |
 | `loadDictionaryFromBytes()` が 9 引数 — **v5.3.0 でリリース済み** | **v5.2 以前**からアップグレードする、バイトデータから辞書を読み込む WASM ユーザー | `dictDa` の代わりに `dictTrie` と `dictValsIdx` を渡す |
 | OPFS の `DictionaryFiles` が `dictDa` を `dictTrie` + `dictValsIdx` に置き換え — **v5.3.0 でリリース済み** | **v5.2 以前**からアップグレードする、`opfs` ヘルパーを使う WASM ユーザー | OPFS にキャッシュ済みの辞書を再ダウンロード |
+
+## npm・PyPI・crates.io のパッケージ名変更
+
+v6.0.0 から、公開パッケージ名がサフィックス付きの名前から素の名前
+（bare name）に統一されます:
+
+| レジストリ | 旧パッケージ名 | 新パッケージ名 |
+| --- | --- | --- |
+| npm（Node.js 本体） | `lindera-nodejs` | `lindera` |
+| npm（プラットフォーム別） | `lindera-nodejs-<platform>`（例: `lindera-nodejs-darwin-arm64`） | `lindera-<platform>`（例: `lindera-darwin-arm64`） |
+| npm（WASM） | `lindera-wasm-web` / `lindera-wasm-bundler` | `lindera-wasm`（単一パッケージ） |
+| PyPI | `lindera-python` | `lindera` |
+
+RubyGems の `lindera` と、crates.io のコアクレート（`lindera`・
+`lindera-dictionary` など）は変更ありません。
+
+### Node.js（npm）
+
+`package.json` の依存関係と `require`/`import` のパッケージ名を更新してください:
+
+```javascript
+// v5
+const { TokenizerBuilder } = require("lindera-nodejs");
+
+// v6
+const { TokenizerBuilder } = require("lindera");
+```
+
+プラットフォーム別パッケージ（`optionalDependencies` 経由で自動的に
+解決されます）も `lindera-nodejs-<platform>` から `lindera-<platform>` に
+変わりますが、通常は明示的に依存指定していないため対応は不要です。
+
+旧 `lindera-nodejs` 系パッケージは npm 上で deprecated としてマークされます。
+公開済みの旧バージョンはそのまま残ります。
+
+### Python（PyPI）
+
+インストールコマンドと依存関係を更新してください:
+
+```bash
+# v5
+pip install lindera-python
+
+# v6
+pip install lindera
+```
+
+**Python の import 名は変わりません** — 以前から `import lindera` であり、
+コードの変更は不要です。変わるのは PyPI 上の配布名だけです。
+
+移行を助けるため、`lindera-python` の最終リリースとして、新しい `lindera`
+パッケージに依存するだけの移行スタブ（transition stub）が PyPI に公開されます。
+`pip install lindera-python` は当面動作しますが、依存関係は `lindera` に
+切り替えてください。
+
+### WASM（npm）
+
+`lindera-wasm-web` と `lindera-wasm-bundler` の 2 パッケージは、
+`wasm-pack --target web` でビルドされた単一の `lindera-wasm` パッケージに
+統合されます。
+
+`lindera-wasm-web` を使っていた場合は、パッケージ名の置き換えのみです:
+
+```javascript
+// v5
+import __wbg_init, { TokenizerBuilder } from "lindera-wasm-web";
+await __wbg_init();
+
+// v6
+import init, { TokenizerBuilder } from "lindera-wasm";
+await init();
+```
+
+`lindera-wasm-bundler` を使っていた場合も、同じ `lindera-wasm` パッケージを
+インストールします。ただし `web` ターゲットのビルドでは初期化が自動では
+行われないため、使用前にデフォルトエクスポートの非同期初期化関数を必ず
+呼び出してください:
+
+```javascript
+// v5（bundler ターゲット: 初期化はバンドラーが処理）
+import { TokenizerBuilder } from "lindera-wasm-bundler";
+
+// v6（web ターゲット: 明示的な初期化が必要）
+import init, { TokenizerBuilder } from "lindera-wasm";
+await init();
+```
+
+モダンなバンドラー（Vite、Webpack 5 の `asyncWebAssembly` など）は
+`web` ターゲットのビルドをそのまま扱えます。設定例は
+[ブラウザでの使用](./lindera-wasm/browser_usage.md) を参照してください。
+
+### crates.io
+
+バインディングクレート（`lindera-python`・`lindera-nodejs`・`lindera-ruby`・
+`lindera-wasm`）は crates.io への公開を終了します。公開済みの 5.3.0 までの
+バージョンはそのまま残ります。これらは各言語のレジストリ（PyPI・npm・
+RubyGems）経由で利用するものであり、Rust クレートとして依存する用途は
+想定されていません。コアクレートは引き続き crates.io に公開されます。
 
 ## ビルド済みユーザー辞書の再ビルドが必要
 
@@ -303,7 +402,7 @@ const tokens = tokenizer.tokenize(text);
 
 どちらもクラスではなくなったため、パッケージから export されなくなりました。
 `Token`・`JsToken`・`NbestResult`・`JsNbestResult` はすべて `index.js` から
-削除され、`require("lindera-nodejs").Token` は `undefined` になります。
+削除され、`require("lindera").Token` は `undefined` になります。
 `instanceof` による判定もできません:
 
 ```javascript
@@ -382,6 +481,12 @@ WASM の `tokenizeNbest` は v5 の時点で既にプレーンオブジェクト
 
 JavaScript（Node.js・WASM）:
 
+- Node.js: `package.json` の依存を `lindera-nodejs` から `lindera` に変更し、
+  `require`/`import` のパッケージ名を更新する。
+- WASM: 依存を `lindera-wasm-web` / `lindera-wasm-bundler` から `lindera-wasm`
+  に変更する。`lindera-wasm-bundler` を使っていた場合は、使用前に
+  デフォルトエクスポートの初期化関数（`await init()`）を呼び出すコードを
+  追加する。
 - `token.getDetail(i)` を `token.details[i]` に置き換える。
 - Node.js: `tokenizeObjects(text)` を `tokenize(text)` に置き換え、
   `Token`/`NbestResult` の import をやめる（export されなくなったため）。
@@ -389,6 +494,11 @@ JavaScript（Node.js・WASM）:
 - WASM: トークンのフィールド参照を camelCase に変更し（`byteStart`・
   `byteEnd`・`wordId`・`isUnknown`）、`toJSON()` の呼び出しを削除し、
   `Token` の import をやめる。
+
+Python:
+
+- 依存を `lindera-python` から `lindera` に変更する（`pip install lindera`）。
+  `import lindera` はそのままで、コードの変更は不要。
 
 `lindera_dictionary` を直接利用している場合:
 

--- a/docs/src/lindera-nodejs/dictionary_management.md
+++ b/docs/src/lindera-nodejs/dictionary_management.md
@@ -9,7 +9,7 @@ Lindera Node.js provides functions for loading, building, and managing dictionar
 Use `loadDictionary(uri)` to load a system dictionary. Download a pre-built dictionary from [GitHub Releases](https://github.com/lindera/lindera/releases) and specify the path to the extracted directory:
 
 ```javascript
-const { loadDictionary } = require("lindera-nodejs");
+const { loadDictionary } = require("lindera");
 
 const dictionary = loadDictionary("/path/to/ipadic");
 ```
@@ -35,7 +35,7 @@ console.log(metadata.defaultWordCost);
 User dictionaries add custom vocabulary on top of a system dictionary.
 
 ```javascript
-const { loadUserDictionary, Metadata } = require("lindera-nodejs");
+const { loadUserDictionary, Metadata } = require("lindera");
 
 const metadata = new Metadata();
 const userDict = loadUserDictionary("/path/to/user_dictionary", metadata);
@@ -44,7 +44,7 @@ const userDict = loadUserDictionary("/path/to/user_dictionary", metadata);
 Pass the user dictionary when building a tokenizer:
 
 ```javascript
-const { Tokenizer, loadDictionary, loadUserDictionary, Metadata } = require("lindera-nodejs");
+const { Tokenizer, loadDictionary, loadUserDictionary, Metadata } = require("lindera");
 
 const dictionary = loadDictionary("/path/to/ipadic");
 const metadata = new Metadata();
@@ -56,7 +56,7 @@ const tokenizer = new Tokenizer(dictionary, "normal", userDict);
 Or via the builder:
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setDictionary("/path/to/ipadic")
@@ -71,7 +71,7 @@ const tokenizer = new TokenizerBuilder()
 Build a system dictionary from source files:
 
 ```javascript
-const { buildDictionary, Metadata } = require("lindera-nodejs");
+const { buildDictionary, Metadata } = require("lindera");
 
 const metadata = new Metadata({ name: "custom", encoding: "UTF-8" });
 buildDictionary("/path/to/input_dir", "/path/to/output_dir", metadata);
@@ -84,7 +84,7 @@ The input directory should contain the dictionary source files (CSV lexicon, mat
 Build a user dictionary from a CSV file:
 
 ```javascript
-const { buildUserDictionary, Metadata } = require("lindera-nodejs");
+const { buildUserDictionary, Metadata } = require("lindera");
 
 const metadata = new Metadata();
 buildUserDictionary("ipadic", "user_words.csv", "/path/to/output_dir", metadata);
@@ -107,7 +107,7 @@ The `Metadata` class configures dictionary parameters.
 ### Creating Metadata
 
 ```javascript
-const { Metadata } = require("lindera-nodejs");
+const { Metadata } = require("lindera");
 
 // Default metadata
 const metadata = new Metadata();
@@ -170,7 +170,7 @@ The `Schema` class defines the field structure of dictionary entries.
 ### Creating a Schema
 
 ```javascript
-const { Schema } = require("lindera-nodejs");
+const { Schema } = require("lindera");
 
 // Default IPADIC-compatible schema
 const schema = Schema.createDefault();

--- a/docs/src/lindera-nodejs/installation.md
+++ b/docs/src/lindera-nodejs/installation.md
@@ -5,7 +5,7 @@
 Pre-built packages will be available on npm:
 
 ```bash
-npm install lindera-nodejs
+npm install lindera
 ```
 
 > [!NOTE]
@@ -97,14 +97,14 @@ npm run build -- --features "train,embed-ipadic,embed-ko-dic"
 After installation, verify that lindera is available in Node.js:
 
 ```javascript
-const lindera = require("lindera-nodejs");
+const lindera = require("lindera");
 
 console.log(lindera.version());
 ```
 
 > [!NOTE]
-> `lindera-nodejs`'s `package.json` currently declares only a `require` condition in its
-> `exports` map (no `import` condition), so `import { version } from "lindera-nodejs"` fails
+> The `lindera` npm package's `package.json` currently declares only a `require` condition in its
+> `exports` map (no `import` condition), so `import { version } from "lindera"` fails
 > with `ERR_PACKAGE_PATH_NOT_EXPORTED`. From an ES module, load it with Node's `createRequire`
 > instead:
 
@@ -112,7 +112,7 @@ console.log(lindera.version());
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const lindera = require("lindera-nodejs");
+const lindera = require("lindera");
 
 console.log(lindera.version());
 ```

--- a/docs/src/lindera-nodejs/quickstart.md
+++ b/docs/src/lindera-nodejs/quickstart.md
@@ -7,7 +7,7 @@ This guide shows how to tokenize text using lindera-nodejs.
 The recommended way to create a tokenizer is through `TokenizerBuilder`:
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const builder = new TokenizerBuilder();
 builder.setMode("normal");
@@ -35,7 +35,7 @@ Expected output:
 `TokenizerBuilder` supports method chaining for concise configuration:
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setMode("normal")
@@ -53,7 +53,7 @@ for (const token of tokens) {
 Each token exposes the following properties:
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setDictionary("/path/to/ipadic")
@@ -76,7 +76,7 @@ for (const token of tokens) {
 Retrieve multiple tokenization candidates ranked by cost:
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setDictionary("/path/to/ipadic")
@@ -94,14 +94,14 @@ for (const { tokens, cost } of results) {
 Lindera Node.js includes TypeScript type definitions. All classes and functions are fully typed:
 
 ```typescript
-import type { Token } from "lindera-nodejs";
+import type { Token } from "lindera";
 import { createRequire } from "node:module";
 
-// `lindera-nodejs` only exposes a CommonJS `require` entry point (see Installation),
+// The `lindera` npm package only exposes a CommonJS `require` entry point (see Installation),
 // so ESM projects load the runtime values through `createRequire` while still getting
 // full type information via `import type`.
 const require = createRequire(import.meta.url);
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setMode("normal")

--- a/docs/src/lindera-nodejs/text_processing_pipeline.md
+++ b/docs/src/lindera-nodejs/text_processing_pipeline.md
@@ -25,7 +25,7 @@ Character filters transform the input text before tokenization.
 Applies Unicode normalization to the input text.
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setDictionary("embedded://ipadic")
@@ -122,7 +122,7 @@ const tokenizer = new TokenizerBuilder()
 The following example combines multiple character filters and token filters into a single pipeline:
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const tokenizer = new TokenizerBuilder()
   .setMode("normal")

--- a/docs/src/lindera-nodejs/tokenizer_api.md
+++ b/docs/src/lindera-nodejs/tokenizer_api.md
@@ -11,7 +11,7 @@
 Creates a new builder with default configuration.
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const builder = new TokenizerBuilder();
 ```
@@ -106,7 +106,7 @@ const tokenizer = builder.build();
 Creates a tokenizer directly from a loaded dictionary.
 
 ```javascript
-const { Tokenizer, loadDictionary } = require("lindera-nodejs");
+const { Tokenizer, loadDictionary } = require("lindera");
 
 const dictionary = loadDictionary("embedded://ipadic");
 const tokenizer = new Tokenizer(dictionary, "normal");
@@ -208,7 +208,7 @@ The structure of `details` depends on the dictionary:
 
 ## Mode and Penalty
 
-`Mode` and `Penalty` are exported from `lindera-nodejs`, but they are **not currently wired into
+`Mode` and `Penalty` are exported from the `lindera` npm package, but they are **not currently wired into
 any public API**: `TokenizerBuilder.setMode()` / `Tokenizer`'s constructor accept only a plain
 mode string (`"normal"` or `"decompose"`), and decompose mode always uses the default penalty
 configuration internally. These types are documented here for completeness; they cannot yet be

--- a/docs/src/lindera-nodejs/training.md
+++ b/docs/src/lindera-nodejs/training.md
@@ -22,7 +22,7 @@ npm run build -- --features train
 Use `train()` to train a CRF model from a seed lexicon and annotated corpus:
 
 ```javascript
-const { train } = require("lindera-nodejs");
+const { train } = require("lindera");
 
 train({
   seed: "resources/training/seed.csv",
@@ -58,7 +58,7 @@ train({
 After training, export the model to dictionary source files using `exportModel()`:
 
 ```javascript
-const { exportModel } = require("lindera-nodejs");
+const { exportModel } = require("lindera");
 
 exportModel({
   model: "/tmp/model.dat",
@@ -94,7 +94,7 @@ const {
   buildDictionary,
   Metadata,
   TokenizerBuilder,
-} = require("lindera-nodejs");
+} = require("lindera");
 
 // Step 1: Train the CRF model
 train({

--- a/docs/src/lindera-python/installation.md
+++ b/docs/src/lindera-python/installation.md
@@ -2,10 +2,10 @@
 
 ## Installing from PyPI
 
-Pre-built wheels are available on [PyPI](https://pypi.org/project/lindera-python/):
+Pre-built wheels are available on [PyPI](https://pypi.org/project/lindera/):
 
 ```bash
-pip install lindera-python
+pip install lindera
 ```
 
 > [!NOTE]

--- a/docs/src/lindera-wasm/browser_usage.md
+++ b/docs/src/lindera-wasm/browser_usage.md
@@ -7,8 +7,8 @@ In browser environments, you must initialize the WASM module before using any Li
 The recommended approach is to load dictionaries from OPFS rather than embedding them in the WASM binary:
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm/opfs';
 
 async function main() {
     // Initialize the WASM module (must be called once before using any API)
@@ -48,10 +48,10 @@ main();
 If you built with an `embed-*` feature flag, you can use embedded dictionaries instead of OPFS:
 
 > [!NOTE]
-> `lindera-wasm-web-ipadic` is an illustrative package name here, not something published to npm. Only `lindera-wasm-web` and `lindera-wasm-bundler` are actually published; see [NPM Package Naming Convention](./installation.md#npm-package-naming-convention) for how to build and name a package like this yourself.
+> `lindera-wasm-ipadic` is an illustrative package name here, not something published to npm. Only `lindera-wasm` is actually published; see [NPM Package Naming Convention](./installation.md#npm-package-naming-convention) for how to build and name a package like this yourself.
 
 ```javascript
-import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-web-ipadic';
+import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-ipadic';
 
 async function main() {
     await __wbg_init();
@@ -138,7 +138,9 @@ A minimal HTML page using lindera-wasm with OPFS dictionary loading:
 
 ## Webpack Configuration
 
-When using Webpack 5, enable the `asyncWebAssembly` experiment:
+The `lindera-wasm` package is built with wasm-pack's `web` target, and modern
+bundlers can consume it directly. When using Webpack 5, enable the
+`asyncWebAssembly` experiment:
 
 ```javascript
 // webpack.config.js
@@ -157,11 +159,14 @@ module.exports = {
 };
 ```
 
-Then import using the bundler target build:
+Then import the package and call the default-exported async init function
+once before using any API (the web-target build requires it, bundled or not):
 
 ```javascript
-import { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-bundler';
-import { loadDictionaryFiles } from 'lindera-wasm-bundler/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
+
+await __wbg_init();
 
 // Load dictionary from OPFS (see OPFS Dictionary Storage for setup)
 const files = await loadDictionaryFiles("ipadic");
@@ -176,11 +181,11 @@ builder.setMode("normal");
 const tokenizer = builder.build();
 ```
 
-With the bundler target, `__wbg_init()` is called automatically by the bundler.
-
 ## Vite / Rollup Setup
 
-Vite supports WASM out of the box with the web target. Place the built `pkg/` directory in your project and import directly:
+Vite supports the web-target WASM build out of the box. Install `lindera-wasm`
+from npm, or place a locally built `pkg/` directory in your project and import
+directly:
 
 ```javascript
 import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from './pkg/lindera_wasm.js';
@@ -190,14 +195,15 @@ await __wbg_init();
 // Load dictionary from OPFS and use TokenizerBuilder as shown above
 ```
 
-For the bundler target with Vite, you may need the [vite-plugin-wasm](https://github.com/nicolo-ribaudo/vite-plugin-wasm) plugin:
+When installing from npm, exclude the package from Vite's dependency
+pre-bundling:
 
 ```javascript
 // vite.config.js
-import wasm from 'vite-plugin-wasm';
-
 export default {
-    plugins: [wasm()],
+    optimizeDeps: {
+        exclude: ["lindera-wasm"],
+    },
 };
 ```
 

--- a/docs/src/lindera-wasm/dictionary_management.md
+++ b/docs/src/lindera-wasm/dictionary_management.md
@@ -23,8 +23,8 @@ Use `loadDictionaryFromBytes()` to construct a `Dictionary` from raw byte arrays
 - **Returns**: `Dictionary`
 
 ```javascript
-import { loadDictionaryFromBytes, TokenizerBuilder } from 'lindera-wasm-web';
-import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import { loadDictionaryFromBytes, TokenizerBuilder } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 // Load dictionary files from OPFS
 const files = await loadDictionaryFiles("ipadic");
@@ -56,12 +56,12 @@ See [OPFS Dictionary Storage](./opfs.md) for the full OPFS workflow including do
 If you built with an `embed-*` feature flag, you can load embedded dictionaries via the `embedded://` URI scheme. This increases the WASM binary size significantly.
 
 > [!NOTE]
-> `lindera-wasm-web-ipadic` in the examples below is an illustrative package name for a local build with the `embed-ipadic` feature, not something published to npm. Only `lindera-wasm-web` and `lindera-wasm-bundler` are actually published; see [NPM Package Naming Convention](./installation.md#npm-package-naming-convention).
+> `lindera-wasm-ipadic` in the examples below is an illustrative package name for a local build with the `embed-ipadic` feature, not something published to npm. Only `lindera-wasm` is actually published; see [NPM Package Naming Convention](./installation.md#npm-package-naming-convention).
 
 ### Loading an Embedded Dictionary
 
 ```javascript
-import { loadDictionary } from 'lindera-wasm-web-ipadic';
+import { loadDictionary } from 'lindera-wasm-ipadic';
 
 const dictionary = loadDictionary("embedded://ipadic");
 ```
@@ -88,7 +88,7 @@ const tokenizer = builder.build();
 ### Using with Tokenizer Constructor
 
 ```javascript
-import { loadDictionary, Tokenizer } from 'lindera-wasm-web-ipadic';
+import { loadDictionary, Tokenizer } from 'lindera-wasm-ipadic';
 
 const dictionary = loadDictionary("embedded://ipadic");
 const tokenizer = new Tokenizer(dictionary, "normal");
@@ -126,7 +126,7 @@ with (e.g. `dictionary.metadata`), so the CSV is interpreted with the right
 schema. The CSV content must be UTF-8.
 
 ```javascript
-import { loadUserDictionaryFromBytes } from 'lindera-wasm-web';
+import { loadUserDictionaryFromBytes } from 'lindera-wasm';
 
 const response = await fetch('/dictionaries/user_dict.csv');
 const csvBytes = new Uint8Array(await response.arrayBuffer());
@@ -147,7 +147,7 @@ const userDict = loadUserDictionaryFromBytes(csvBytes, dictionary.metadata);
 A user dictionary compiled with `lindera build --user` loads directly:
 
 ```javascript
-import { loadUserDictionaryBinFromBytes } from 'lindera-wasm-web';
+import { loadUserDictionaryBinFromBytes } from 'lindera-wasm';
 
 const response = await fetch('/dictionaries/user_dict.bin');
 const binBytes = new Uint8Array(await response.arrayBuffer());
@@ -157,8 +157,8 @@ const userDict = loadUserDictionaryBinFromBytes(binBytes);
 ### Using a User Dictionary with Tokenizer
 
 ```javascript
-import { loadDictionaryFromBytes, loadUserDictionaryFromBytes, Tokenizer } from 'lindera-wasm-web';
-import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import { loadDictionaryFromBytes, loadUserDictionaryFromBytes, Tokenizer } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 const files = await loadDictionaryFiles("ipadic");
 const dictionary = loadDictionaryFromBytes(

--- a/docs/src/lindera-wasm/installation.md
+++ b/docs/src/lindera-wasm/installation.md
@@ -14,7 +14,7 @@ Lindera WASM does not bundle dictionaries by default. The recommended approach f
 Pre-built dictionaries are available on the [GitHub Releases](https://github.com/lindera/lindera/releases) page. In browser environments, use the OPFS helpers to download and cache dictionaries:
 
 ```javascript
-import { downloadDictionary, hasDictionary } from 'lindera-wasm-web/opfs';
+import { downloadDictionary, hasDictionary } from 'lindera-wasm/opfs';
 
 if (!await hasDictionary("ipadic")) {
     await downloadDictionary(
@@ -28,21 +28,16 @@ See [OPFS Dictionary Storage](./opfs.md) for the full workflow.
 
 ## Building with wasm-pack
 
-Build the WASM package for your target environment:
-
-### Web (ES Modules for browsers)
+Build the WASM package (the published `lindera-wasm` npm package is built with
+the `web` target):
 
 ```bash
 wasm-pack build --target web
 ```
 
-### Bundler (Webpack, Vite, Rollup)
-
-```bash
-wasm-pack build --target bundler
-```
-
 The output is written to the `pkg/` directory inside the `lindera-wasm` crate.
+wasm-pack also supports other targets (e.g. `--target nodejs`) if you need a
+custom build, but the web-target build is what this documentation assumes.
 
 ## Available Feature Flags (Advanced)
 
@@ -65,38 +60,51 @@ wasm-pack build --target web --features embed-ipadic,embed-ko-dic
 
 ## NPM Package Naming Convention
 
-When publishing to npm, the recommended naming convention is:
+When publishing a custom build with embedded dictionaries to npm, the
+recommended naming convention is:
 
 ```text
-lindera-wasm-{target}
-lindera-wasm-{target}-{dict}
+lindera-wasm-{dict}
 ```
 
 Examples:
 
-- `lindera-wasm-web`
-- `lindera-wasm-web-ipadic`
-- `lindera-wasm-bundler-unidic`
-- `lindera-wasm-web-cjk`
+- `lindera-wasm-ipadic`
+- `lindera-wasm-unidic`
+- `lindera-wasm-cjk`
 
 To set the package name before publishing, edit the `name` field in the generated `pkg/package.json`.
 
 > [!NOTE]
-> This project's own release workflow (`.github/workflows/release.yml`) only builds and publishes two packages to npm -- `lindera-wasm-web` and `lindera-wasm-bundler` -- built without any `embed-*` feature. Dictionary-suffixed names such as `lindera-wasm-web-ipadic` are not published anywhere; they only illustrate what a local build with an `embed-*` feature (see [Available Feature Flags](#available-feature-flags-advanced) above) would produce after you rename the package yourself.
+> This project's own release workflow (`.github/workflows/release.yml`) only builds and publishes a single package to npm -- `lindera-wasm`, built with `wasm-pack --target web` and without any `embed-*` feature. Dictionary-suffixed names such as `lindera-wasm-ipadic` are not published anywhere; they only illustrate what a local build with an `embed-*` feature (see [Available Feature Flags](#available-feature-flags-advanced) above) would produce after you rename the package yourself.
 
 ## Installing from npm
 
-Pre-built packages are available on npm:
+The pre-built package is available on npm:
 
 ```bash
-npm install lindera-wasm-web
+npm install lindera-wasm
 ```
 
 Or with yarn:
 
 ```bash
-yarn add lindera-wasm-web
+yarn add lindera-wasm
 ```
+
+Because the package is a web-target build, call the default-exported async
+init function once before using any API:
+
+```javascript
+import __wbg_init, { TokenizerBuilder } from 'lindera-wasm';
+
+await __wbg_init();
+```
+
+This applies both in browsers (native ES modules) and when the package is
+consumed through a bundler -- modern bundlers such as Vite or Webpack 5 (with
+the `asyncWebAssembly` experiment) handle the web-target build directly; see
+[Browser Usage](./browser_usage.md) for bundler configuration.
 
 > [!NOTE]
 > The npm package does not include dictionaries. Use the OPFS helpers to download dictionaries at runtime. See [OPFS Dictionary Storage](./opfs.md).

--- a/docs/src/lindera-wasm/opfs.md
+++ b/docs/src/lindera-wasm/opfs.md
@@ -12,7 +12,7 @@ Dictionaries are stored under the OPFS path `lindera/dictionaries/<name>/`.
 
 ```javascript
 import { downloadDictionary, loadDictionaryFiles, removeDictionary,
-         listDictionaries, hasDictionary } from 'lindera-wasm-web/opfs';
+         listDictionaries, hasDictionary } from 'lindera-wasm/opfs';
 ```
 
 ## Functions
@@ -133,8 +133,8 @@ if (await hasDictionary("ipadic")) {
 A typical workflow for using OPFS-based dictionaries:
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm/opfs';
 
 async function main() {
     await __wbg_init();

--- a/docs/src/lindera-wasm/quickstart.md
+++ b/docs/src/lindera-wasm/quickstart.md
@@ -5,8 +5,8 @@
 The recommended approach is to download dictionaries at runtime using the OPFS helpers:
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { downloadDictionary, loadDictionaryFiles, hasDictionary } from 'lindera-wasm/opfs';
 
 async function main() {
     await __wbg_init();
@@ -56,10 +56,10 @@ Expected output:
 If you built with an `embed-*` feature flag, you can use embedded dictionaries:
 
 > [!NOTE]
-> `lindera-wasm-web-ipadic` is an illustrative package name here, not something published to npm. Only `lindera-wasm-web` and `lindera-wasm-bundler` are actually published; see [NPM Package Naming Convention](./installation.md#npm-package-naming-convention) for how to build and name a package like this yourself.
+> `lindera-wasm-ipadic` is an illustrative package name here, not something published to npm. Only `lindera-wasm` is actually published; see [NPM Package Naming Convention](./installation.md#npm-package-naming-convention) for how to build and name a package like this yourself.
 
 ```javascript
-import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-web-ipadic';
+import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-ipadic';
 
 async function main() {
     await __wbg_init();
@@ -83,8 +83,8 @@ main();
 You can add character filters and token filters to the tokenization pipeline:
 
 ```javascript
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 async function main() {
     await __wbg_init();

--- a/docs/src/lindera-wasm/tokenizer_api.md
+++ b/docs/src/lindera-wasm/tokenizer_api.md
@@ -47,8 +47,8 @@ Use this when the dictionary has been loaded from bytes (e.g., via `loadDictiona
 - **Returns**: void
 
 ```javascript
-import { loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import { loadDictionaryFromBytes } from 'lindera-wasm';
+import { loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 const files = await loadDictionaryFiles("ipadic");
 const dictionary = loadDictionaryFromBytes(
@@ -212,7 +212,7 @@ console.log(JSON.stringify(token, null, 2));
 ## Helper Functions
 
 > [!NOTE]
-> The examples below import from `lindera-wasm-web-ipadic`, an illustrative package name for a local build with the `embed-ipadic` feature -- it is not published to npm. Only `lindera-wasm-web` and `lindera-wasm-bundler` are actually published; see [NPM Package Naming Convention](./installation.md#npm-package-naming-convention).
+> The examples below import from `lindera-wasm-ipadic`, an illustrative package name for a local build with the `embed-ipadic` feature -- it is not published to npm. Only `lindera-wasm` is actually published; see [NPM Package Naming Convention](./installation.md#npm-package-naming-convention).
 
 ### `loadDictionary(uri)`
 
@@ -222,7 +222,7 @@ Loads a dictionary from the specified URI.
 - **Returns**: `Dictionary`
 
 ```javascript
-import { loadDictionary } from 'lindera-wasm-web-ipadic';
+import { loadDictionary } from 'lindera-wasm-ipadic';
 
 const dict = loadDictionary("embedded://ipadic");
 ```
@@ -250,7 +250,7 @@ Returns the version string of the lindera-wasm package.
 - **Returns**: `string`
 
 ```javascript
-import { version } from 'lindera-wasm-web-ipadic';
+import { version } from 'lindera-wasm-ipadic';
 
 console.log(version()); // e.g., "5.3.0"
 ```

--- a/docs/src/migration_v5_to_v6.md
+++ b/docs/src/migration_v5_to_v6.md
@@ -3,7 +3,8 @@
 Lindera v6.0.0 rebuilds prebuilt user dictionaries, changes tokenization
 output in two targeted ways (a Decompose-mode accuracy fix and a new
 default-on unknown-word feature), reshapes the JavaScript bindings' token
-type, and renames several `lindera-dictionary` Rust APIs. Most users only
+type, renames the published binding packages on npm and PyPI to bare names,
+and renames several `lindera-dictionary` Rust APIs. Most users only
 need to rebuild their dictionaries; direct users of
 `lindera_dictionary::viterbi`/`mode` types, JavaScript users, and anyone
 relying on exact legacy output for out-of-vocabulary text have more to check.
@@ -17,6 +18,7 @@ it does require rebuilding user dictionaries, for an unrelated reason.
 
 | Change | Affects | What you do |
 | --- | --- | --- |
+| **Published package names change on npm and PyPI** | npm users of `lindera-nodejs` / `lindera-wasm-web` / `lindera-wasm-bundler`, PyPI users of `lindera-python` | Install `lindera` (npm, PyPI) or `lindera-wasm` (npm, WASM) and update `require`/`import` specifiers — see the next section |
 | **Prebuilt user-dictionary `.bin` files no longer load** | Anyone loading a user dictionary from `.bin` | Rebuild from the CSV source with `lindera build --user` |
 | **Trained `model.dat` files no longer load** | Anyone re-using a `model.dat` produced by an earlier build | Re-run `lindera train` |
 | Decompose-mode length penalty is now exact for non-3-byte characters | `Mode::Decompose` output on text with 1-, 2-, or 4-byte UTF-8 characters | Nothing — this is a correctness fix; re-check Decompose output if you pin it exactly |
@@ -27,6 +29,93 @@ it does require rebuilding user dictionaries, for an unrelated reason.
 | Built dictionary format is version 2 (`dict.da` → `dict.trie` + `dict.valsidx`) — **shipped in v5.3.0** | Self-built system dictionaries created by **v5.2 or earlier** | Rebuild with `lindera build`, or re-download with `lindera download` |
 | `loadDictionaryFromBytes()` takes 9 arguments — **shipped in v5.3.0** | WASM users loading dictionaries from bytes, upgrading from **v5.2 or earlier** | Pass `dictTrie` and `dictValsIdx` instead of `dictDa` |
 | OPFS `DictionaryFiles` replaces `dictDa` with `dictTrie` + `dictValsIdx` — **shipped in v5.3.0** | WASM users of the `opfs` helpers, upgrading from **v5.2 or earlier** | Re-download OPFS-cached dictionaries |
+
+## Package renames on npm, PyPI, and crates.io
+
+Starting with v6.0.0, the language bindings are published under bare names —
+the registry already scopes the package to its ecosystem, so the
+`-nodejs`/`-python` suffixes carried no information:
+
+| Registry | v5 name | v6 name |
+| --- | --- | --- |
+| npm (Node.js) | `lindera-nodejs` | `lindera` |
+| npm (Node.js platform packages) | `lindera-nodejs-<platform>` (e.g. `lindera-nodejs-darwin-arm64`) | `lindera-<platform>` (e.g. `lindera-darwin-arm64`) |
+| npm (WASM) | `lindera-wasm-web` and `lindera-wasm-bundler` | `lindera-wasm` |
+| PyPI | `lindera-python` | `lindera` |
+
+The RubyGems gem name (`lindera`) and the core Rust crates on crates.io are
+unchanged.
+
+### Node.js
+
+Update the dependency and the module specifier; the API itself is unaffected:
+
+```javascript
+// v5
+const { TokenizerBuilder } = require("lindera-nodejs");
+
+// v6
+const { TokenizerBuilder } = require("lindera");
+```
+
+The platform packages (`lindera-darwin-arm64`, `lindera-linux-x64-gnu`, …)
+are `optionalDependencies` of the main package, so npm selects the right one
+automatically — you never install them by name.
+
+The old `lindera-nodejs` and `lindera-nodejs-*` packages are npm-deprecated:
+they remain installable at their last v5 versions but receive no further
+releases.
+
+### Python
+
+Only the install name changes — the import name was always `lindera` and
+stays that way:
+
+```sh
+# v5
+pip install lindera-python
+
+# v6
+pip install lindera
+```
+
+A final `lindera-python` release is published as a transition stub that
+depends on `lindera`, so an unchanged `pip install lindera-python` still
+ends up with the real package during the transition. Update your
+requirements to `lindera` anyway — the stub will not be maintained.
+
+### WASM
+
+The two v5 packages are consolidated into a single `lindera-wasm` package,
+built with `wasm-pack --target web`. A web-target build requires calling the
+default-exported async init function once before using any API:
+
+```javascript
+import __wbg_init, { TokenizerBuilder } from "lindera-wasm";
+
+await __wbg_init();
+```
+
+- Coming from `lindera-wasm-web`: only the package name changes — your code
+  already calls the init function.
+- Coming from `lindera-wasm-bundler`: install `lindera-wasm` and **add the
+  init call** — the bundler-target build initialized implicitly, the
+  web-target build does not. Modern bundlers consume the web-target build
+  directly (Vite out of the box; Webpack 5 with the `asyncWebAssembly`
+  experiment). See [Browser Usage](./lindera-wasm/browser_usage.md) for
+  bundler configuration.
+
+The old `lindera-wasm-web` and `lindera-wasm-bundler` packages are
+npm-deprecated at their last v5 versions.
+
+### crates.io
+
+The binding crates (`lindera-python`, `lindera-nodejs`, `lindera-ruby`,
+`lindera-wasm`) are no longer published to crates.io — they were never
+usable as Rust dependencies, only as sources for the registry packages
+above. The existing 5.3.0 releases remain available there. The core crates
+(`lindera`, `lindera-dictionary`, the dictionary crates, and so on) continue
+to be published as before.
 
 ## Prebuilt user dictionaries must be rebuilt
 
@@ -300,7 +389,7 @@ same `tokens` and `cost` properties.
 
 Because neither is a class any more, they are no longer exported from the
 package. `Token`, `JsToken`, `NbestResult`, and `JsNbestResult` are all gone
-from `index.js`, so `require("lindera-nodejs").Token` is `undefined` and
+from `index.js`, so `require("lindera").Token` is `undefined` and
 `instanceof` checks against them no longer compile or run:
 
 ```javascript
@@ -343,7 +432,7 @@ const data = token; // already plain
 ```
 
 `Token` is also no longer exported from the module, so
-`import { Token } from 'lindera-wasm-...'` fails. There is nothing to import
+`import { Token } from 'lindera-wasm'` fails. There is nothing to import
 in its place — `tokenize` hands back plain objects directly.
 
 `tokenizeNbest` in WASM already returned plain objects in v5 and is
@@ -379,6 +468,18 @@ Everyone:
   text, re-check it — the Decompose penalty fix and the unknown-word ladder
   (default on) can both change it. Set `unknown_word_ladder(false)` if you
   need v5-identical unknown-word output.
+
+Package names (see
+[Package renames on npm, PyPI, and crates.io](#package-renames-on-npm-pypi-and-cratesio)):
+
+- npm: depend on `lindera` instead of `lindera-nodejs`, and on `lindera-wasm`
+  instead of `lindera-wasm-web` / `lindera-wasm-bundler`; update
+  `require`/`import` specifiers to match.
+- PyPI: `pip install lindera` instead of `lindera-python`; `import lindera`
+  is unchanged.
+- Former `lindera-wasm-bundler` users: add `await __wbg_init()` before the
+  first API call — the consolidated package is a web-target build and does
+  not initialize implicitly.
 
 JavaScript (Node.js and WASM):
 

--- a/lindera-nodejs/Cargo.toml
+++ b/lindera-nodejs/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "lindera-nodejs"
+# Distributed via npm, not crates.io.
+publish = false
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/lindera-nodejs/README.md
+++ b/lindera-nodejs/README.md
@@ -81,13 +81,13 @@ The examples below use CommonJS. The package is also importable from ESM — the
 same named exports are available:
 
 ```javascript
-import { loadDictionary, Tokenizer } from "lindera-nodejs";
+import { loadDictionary, Tokenizer } from "lindera";
 ```
 
 ### Basic Tokenization
 
 ```javascript
-const { loadDictionary, Tokenizer } = require("lindera-nodejs");
+const { loadDictionary, Tokenizer } = require("lindera");
 
 // Load dictionary
 // Load dictionary from a local path (download from GitHub Releases)
@@ -130,7 +130,7 @@ instances (out-of-range reads now yield `undefined` rather than `null`).
 ### Using Character Filters
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 // Create tokenizer builder
 const builder = new TokenizerBuilder();
@@ -150,7 +150,7 @@ const tokens = tokenizer.tokenize(text); // Will apply filters automatically
 ### Using Token Filters
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 // Create tokenizer builder
 const builder = new TokenizerBuilder();
@@ -170,7 +170,7 @@ const tokens = tokenizer.tokenize("テキストの解析");
 ### Integrated Pipeline
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 // Build tokenizer with integrated filters
 const builder = new TokenizerBuilder();
@@ -193,7 +193,7 @@ const tokens = tokenizer.tokenize("コーヒーショップ");
 ### Working with Metadata
 
 ```javascript
-const { Metadata } = require("lindera-nodejs");
+const { Metadata } = require("lindera");
 
 // Create metadata with default values
 const metadata = new Metadata();
@@ -212,7 +212,7 @@ console.log(loaded.toObject());
 Character filters and token filters accept configuration as object arguments:
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const builder = new TokenizerBuilder();
 builder.setDictionary("/path/to/ipadic");
@@ -282,7 +282,7 @@ npm run build -- --features train
 ### Training a Model
 
 ```javascript
-const { train } = require("lindera-nodejs");
+const { train } = require("lindera");
 
 // Train a model from corpus
 train({
@@ -301,7 +301,7 @@ train({
 ### Exporting Dictionary Files
 
 ```javascript
-const { exportModel } = require("lindera-nodejs");
+const { exportModel } = require("lindera");
 
 // Export trained model to dictionary files
 exportModel({

--- a/lindera-nodejs/README_ja.md
+++ b/lindera-nodejs/README_ja.md
@@ -81,13 +81,13 @@ npm run build
 インポートできます:
 
 ```javascript
-import { loadDictionary, Tokenizer } from "lindera-nodejs";
+import { loadDictionary, Tokenizer } from "lindera";
 ```
 
 ### 基本的なトークナイズ
 
 ```javascript
-const { loadDictionary, Tokenizer } = require("lindera-nodejs");
+const { loadDictionary, Tokenizer } = require("lindera");
 
 // Load dictionary
 // Load dictionary from a local path (download from GitHub Releases)
@@ -131,7 +131,7 @@ structuredClone(tokens);  // worker へ安全に送れる
 ### 文字フィルタの使用
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 // Create tokenizer builder
 const builder = new TokenizerBuilder();
@@ -151,7 +151,7 @@ const tokens = tokenizer.tokenize(text); // Will apply filters automatically
 ### トークンフィルタの使用
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 // Create tokenizer builder
 const builder = new TokenizerBuilder();
@@ -171,7 +171,7 @@ const tokens = tokenizer.tokenize("テキストの解析");
 ### 統合パイプライン
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 // Build tokenizer with integrated filters
 const builder = new TokenizerBuilder();
@@ -194,7 +194,7 @@ const tokens = tokenizer.tokenize("コーヒーショップ");
 ### メタデータの操作
 
 ```javascript
-const { Metadata } = require("lindera-nodejs");
+const { Metadata } = require("lindera");
 
 // Create metadata with default values
 const metadata = new Metadata();
@@ -213,7 +213,7 @@ console.log(loaded.toObject());
 文字フィルタとトークンフィルタは、オブジェクト型の引数で設定を受け取ります:
 
 ```javascript
-const { TokenizerBuilder } = require("lindera-nodejs");
+const { TokenizerBuilder } = require("lindera");
 
 const builder = new TokenizerBuilder();
 builder.setDictionary("/path/to/ipadic");
@@ -283,7 +283,7 @@ npm run build -- --features train
 ### モデルの学習
 
 ```javascript
-const { train } = require("lindera-nodejs");
+const { train } = require("lindera");
 
 // Train a model from corpus
 train({
@@ -302,7 +302,7 @@ train({
 ### 辞書ファイルのエクスポート
 
 ```javascript
-const { exportModel } = require("lindera-nodejs");
+const { exportModel } = require("lindera");
 
 // Export trained model to dictionary files
 exportModel({

--- a/lindera-nodejs/index.js
+++ b/lindera-nodejs/index.js
@@ -70,13 +70,13 @@ function requireNative() {
   } else if (process.platform === 'android') {
     if (process.arch === 'arm64') {
       try {
-        return require('./lindera-nodejs.android-arm64.node')
+        return require('./lindera.android-arm64.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-android-arm64')
-        const bindingPackageVersion = require('lindera-nodejs-android-arm64/package.json').version
+        const binding = require('lindera-android-arm64')
+        const bindingPackageVersion = require('lindera-android-arm64/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -86,13 +86,13 @@ function requireNative() {
       }
     } else if (process.arch === 'arm') {
       try {
-        return require('./lindera-nodejs.android-arm-eabi.node')
+        return require('./lindera.android-arm-eabi.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-android-arm-eabi')
-        const bindingPackageVersion = require('lindera-nodejs-android-arm-eabi/package.json').version
+        const binding = require('lindera-android-arm-eabi')
+        const bindingPackageVersion = require('lindera-android-arm-eabi/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -107,13 +107,13 @@ function requireNative() {
     if (process.arch === 'x64') {
       if ((process.config && process.config.variables && process.config.variables.shlib_suffix === 'dll.a') || (process.config && process.config.variables && process.config.variables.node_target_type === 'shared_library')) {
         try {
-        return require('./lindera-nodejs.win32-x64-gnu.node')
+        return require('./lindera.win32-x64-gnu.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-win32-x64-gnu')
-        const bindingPackageVersion = require('lindera-nodejs-win32-x64-gnu/package.json').version
+        const binding = require('lindera-win32-x64-gnu')
+        const bindingPackageVersion = require('lindera-win32-x64-gnu/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -123,13 +123,13 @@ function requireNative() {
       }
       } else {
         try {
-        return require('./lindera-nodejs.win32-x64-msvc.node')
+        return require('./lindera.win32-x64-msvc.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-win32-x64-msvc')
-        const bindingPackageVersion = require('lindera-nodejs-win32-x64-msvc/package.json').version
+        const binding = require('lindera-win32-x64-msvc')
+        const bindingPackageVersion = require('lindera-win32-x64-msvc/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -140,13 +140,13 @@ function requireNative() {
       }
     } else if (process.arch === 'ia32') {
       try {
-        return require('./lindera-nodejs.win32-ia32-msvc.node')
+        return require('./lindera.win32-ia32-msvc.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-win32-ia32-msvc')
-        const bindingPackageVersion = require('lindera-nodejs-win32-ia32-msvc/package.json').version
+        const binding = require('lindera-win32-ia32-msvc')
+        const bindingPackageVersion = require('lindera-win32-ia32-msvc/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -156,13 +156,13 @@ function requireNative() {
       }
     } else if (process.arch === 'arm64') {
       try {
-        return require('./lindera-nodejs.win32-arm64-msvc.node')
+        return require('./lindera.win32-arm64-msvc.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-win32-arm64-msvc')
-        const bindingPackageVersion = require('lindera-nodejs-win32-arm64-msvc/package.json').version
+        const binding = require('lindera-win32-arm64-msvc')
+        const bindingPackageVersion = require('lindera-win32-arm64-msvc/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -175,13 +175,13 @@ function requireNative() {
     }
   } else if (process.platform === 'darwin') {
     try {
-      return require('./lindera-nodejs.darwin-universal.node')
+      return require('./lindera.darwin-universal.node')
     } catch (e) {
       loadErrors.push(e)
     }
     try {
-      const binding = require('lindera-nodejs-darwin-universal')
-      const bindingPackageVersion = require('lindera-nodejs-darwin-universal/package.json').version
+      const binding = require('lindera-darwin-universal')
+      const bindingPackageVersion = require('lindera-darwin-universal/package.json').version
       if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
@@ -191,13 +191,13 @@ function requireNative() {
     }
     if (process.arch === 'x64') {
       try {
-        return require('./lindera-nodejs.darwin-x64.node')
+        return require('./lindera.darwin-x64.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-darwin-x64')
-        const bindingPackageVersion = require('lindera-nodejs-darwin-x64/package.json').version
+        const binding = require('lindera-darwin-x64')
+        const bindingPackageVersion = require('lindera-darwin-x64/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -207,13 +207,13 @@ function requireNative() {
       }
     } else if (process.arch === 'arm64') {
       try {
-        return require('./lindera-nodejs.darwin-arm64.node')
+        return require('./lindera.darwin-arm64.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-darwin-arm64')
-        const bindingPackageVersion = require('lindera-nodejs-darwin-arm64/package.json').version
+        const binding = require('lindera-darwin-arm64')
+        const bindingPackageVersion = require('lindera-darwin-arm64/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -227,13 +227,13 @@ function requireNative() {
   } else if (process.platform === 'freebsd') {
     if (process.arch === 'x64') {
       try {
-        return require('./lindera-nodejs.freebsd-x64.node')
+        return require('./lindera.freebsd-x64.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-freebsd-x64')
-        const bindingPackageVersion = require('lindera-nodejs-freebsd-x64/package.json').version
+        const binding = require('lindera-freebsd-x64')
+        const bindingPackageVersion = require('lindera-freebsd-x64/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -243,13 +243,13 @@ function requireNative() {
       }
     } else if (process.arch === 'arm64') {
       try {
-        return require('./lindera-nodejs.freebsd-arm64.node')
+        return require('./lindera.freebsd-arm64.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-freebsd-arm64')
-        const bindingPackageVersion = require('lindera-nodejs-freebsd-arm64/package.json').version
+        const binding = require('lindera-freebsd-arm64')
+        const bindingPackageVersion = require('lindera-freebsd-arm64/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -264,13 +264,13 @@ function requireNative() {
     if (process.arch === 'x64') {
       if (isMusl()) {
         try {
-          return require('./lindera-nodejs.linux-x64-musl.node')
+          return require('./lindera.linux-x64-musl.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-x64-musl')
-          const bindingPackageVersion = require('lindera-nodejs-linux-x64-musl/package.json').version
+          const binding = require('lindera-linux-x64-musl')
+          const bindingPackageVersion = require('lindera-linux-x64-musl/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -280,13 +280,13 @@ function requireNative() {
         }
       } else {
         try {
-          return require('./lindera-nodejs.linux-x64-gnu.node')
+          return require('./lindera.linux-x64-gnu.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-x64-gnu')
-          const bindingPackageVersion = require('lindera-nodejs-linux-x64-gnu/package.json').version
+          const binding = require('lindera-linux-x64-gnu')
+          const bindingPackageVersion = require('lindera-linux-x64-gnu/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -298,13 +298,13 @@ function requireNative() {
     } else if (process.arch === 'arm64') {
       if (isMusl()) {
         try {
-          return require('./lindera-nodejs.linux-arm64-musl.node')
+          return require('./lindera.linux-arm64-musl.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-arm64-musl')
-          const bindingPackageVersion = require('lindera-nodejs-linux-arm64-musl/package.json').version
+          const binding = require('lindera-linux-arm64-musl')
+          const bindingPackageVersion = require('lindera-linux-arm64-musl/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -314,13 +314,13 @@ function requireNative() {
         }
       } else {
         try {
-          return require('./lindera-nodejs.linux-arm64-gnu.node')
+          return require('./lindera.linux-arm64-gnu.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-arm64-gnu')
-          const bindingPackageVersion = require('lindera-nodejs-linux-arm64-gnu/package.json').version
+          const binding = require('lindera-linux-arm64-gnu')
+          const bindingPackageVersion = require('lindera-linux-arm64-gnu/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -332,13 +332,13 @@ function requireNative() {
     } else if (process.arch === 'arm') {
       if (isMusl()) {
         try {
-          return require('./lindera-nodejs.linux-arm-musleabihf.node')
+          return require('./lindera.linux-arm-musleabihf.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-arm-musleabihf')
-          const bindingPackageVersion = require('lindera-nodejs-linux-arm-musleabihf/package.json').version
+          const binding = require('lindera-linux-arm-musleabihf')
+          const bindingPackageVersion = require('lindera-linux-arm-musleabihf/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -348,13 +348,13 @@ function requireNative() {
         }
       } else {
         try {
-          return require('./lindera-nodejs.linux-arm-gnueabihf.node')
+          return require('./lindera.linux-arm-gnueabihf.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-arm-gnueabihf')
-          const bindingPackageVersion = require('lindera-nodejs-linux-arm-gnueabihf/package.json').version
+          const binding = require('lindera-linux-arm-gnueabihf')
+          const bindingPackageVersion = require('lindera-linux-arm-gnueabihf/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -366,13 +366,13 @@ function requireNative() {
     } else if (process.arch === 'loong64') {
       if (isMusl()) {
         try {
-          return require('./lindera-nodejs.linux-loong64-musl.node')
+          return require('./lindera.linux-loong64-musl.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-loong64-musl')
-          const bindingPackageVersion = require('lindera-nodejs-linux-loong64-musl/package.json').version
+          const binding = require('lindera-linux-loong64-musl')
+          const bindingPackageVersion = require('lindera-linux-loong64-musl/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -382,13 +382,13 @@ function requireNative() {
         }
       } else {
         try {
-          return require('./lindera-nodejs.linux-loong64-gnu.node')
+          return require('./lindera.linux-loong64-gnu.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-loong64-gnu')
-          const bindingPackageVersion = require('lindera-nodejs-linux-loong64-gnu/package.json').version
+          const binding = require('lindera-linux-loong64-gnu')
+          const bindingPackageVersion = require('lindera-linux-loong64-gnu/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -400,13 +400,13 @@ function requireNative() {
     } else if (process.arch === 'riscv64') {
       if (isMusl()) {
         try {
-          return require('./lindera-nodejs.linux-riscv64-musl.node')
+          return require('./lindera.linux-riscv64-musl.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-riscv64-musl')
-          const bindingPackageVersion = require('lindera-nodejs-linux-riscv64-musl/package.json').version
+          const binding = require('lindera-linux-riscv64-musl')
+          const bindingPackageVersion = require('lindera-linux-riscv64-musl/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -416,13 +416,13 @@ function requireNative() {
         }
       } else {
         try {
-          return require('./lindera-nodejs.linux-riscv64-gnu.node')
+          return require('./lindera.linux-riscv64-gnu.node')
         } catch (e) {
           loadErrors.push(e)
         }
         try {
-          const binding = require('lindera-nodejs-linux-riscv64-gnu')
-          const bindingPackageVersion = require('lindera-nodejs-linux-riscv64-gnu/package.json').version
+          const binding = require('lindera-linux-riscv64-gnu')
+          const bindingPackageVersion = require('lindera-linux-riscv64-gnu/package.json').version
           if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -433,13 +433,13 @@ function requireNative() {
       }
     } else if (process.arch === 'ppc64') {
       try {
-        return require('./lindera-nodejs.linux-ppc64-gnu.node')
+        return require('./lindera.linux-ppc64-gnu.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-linux-ppc64-gnu')
-        const bindingPackageVersion = require('lindera-nodejs-linux-ppc64-gnu/package.json').version
+        const binding = require('lindera-linux-ppc64-gnu')
+        const bindingPackageVersion = require('lindera-linux-ppc64-gnu/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -449,13 +449,13 @@ function requireNative() {
       }
     } else if (process.arch === 's390x') {
       try {
-        return require('./lindera-nodejs.linux-s390x-gnu.node')
+        return require('./lindera.linux-s390x-gnu.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-linux-s390x-gnu')
-        const bindingPackageVersion = require('lindera-nodejs-linux-s390x-gnu/package.json').version
+        const binding = require('lindera-linux-s390x-gnu')
+        const bindingPackageVersion = require('lindera-linux-s390x-gnu/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -469,13 +469,13 @@ function requireNative() {
   } else if (process.platform === 'openharmony') {
     if (process.arch === 'arm64') {
       try {
-        return require('./lindera-nodejs.openharmony-arm64.node')
+        return require('./lindera.openharmony-arm64.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-openharmony-arm64')
-        const bindingPackageVersion = require('lindera-nodejs-openharmony-arm64/package.json').version
+        const binding = require('lindera-openharmony-arm64')
+        const bindingPackageVersion = require('lindera-openharmony-arm64/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -485,13 +485,13 @@ function requireNative() {
       }
     } else if (process.arch === 'x64') {
       try {
-        return require('./lindera-nodejs.openharmony-x64.node')
+        return require('./lindera.openharmony-x64.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-openharmony-x64')
-        const bindingPackageVersion = require('lindera-nodejs-openharmony-x64/package.json').version
+        const binding = require('lindera-openharmony-x64')
+        const bindingPackageVersion = require('lindera-openharmony-x64/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -501,13 +501,13 @@ function requireNative() {
       }
     } else if (process.arch === 'arm') {
       try {
-        return require('./lindera-nodejs.openharmony-arm.node')
+        return require('./lindera.openharmony-arm.node')
       } catch (e) {
         loadErrors.push(e)
       }
       try {
-        const binding = require('lindera-nodejs-openharmony-arm')
-        const bindingPackageVersion = require('lindera-nodejs-openharmony-arm/package.json').version
+        const binding = require('lindera-openharmony-arm')
+        const bindingPackageVersion = require('lindera-openharmony-arm/package.json').version
         if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -623,10 +623,10 @@ if (!nativeBinding || forceWasi) {
     let candidateError = null
     let candidateFailed = false
     try {
-      candidateError = __napiWasiResolveCandidate('./lindera-nodejs.wasi.cjs', false, ["./lindera-nodejs.wasm32-wasi.debug.wasm","./lindera-nodejs.wasm32-wasi.wasm"])
+      candidateError = __napiWasiResolveCandidate('./lindera.wasi.cjs', false, ["./lindera.wasm32-wasi.debug.wasm","./lindera.wasm32-wasi.wasm"])
       candidateFailed = candidateError !== null
       if (!candidateFailed) {
-        wasiBinding = require('./lindera-nodejs.wasi.cjs')
+        wasiBinding = require('./lindera.wasi.cjs')
         nativeBinding = wasiBinding
         wasiBindingLoaded = true
       }
@@ -643,16 +643,16 @@ if (!nativeBinding || forceWasi) {
     let candidateError = null
     let candidateFailed = false
     try {
-      candidateError = __napiWasiResolveCandidate('lindera-nodejs-wasm32-wasi', true, undefined)
+      candidateError = __napiWasiResolveCandidate('lindera-wasm32-wasi', true, undefined)
       candidateFailed = candidateError !== null
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          const bindingPackageVersion = require('lindera-nodejs-wasm32-wasi/package.json').version
+          const bindingPackageVersion = require('lindera-wasm32-wasi/package.json').version
           if (bindingPackageVersion !== '5.3.0') {
             throw new Error(`WASI binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
-        wasiBinding = require('lindera-nodejs-wasm32-wasi')
+        wasiBinding = require('lindera-wasm32-wasi')
         nativeBinding = wasiBinding
         wasiBindingLoaded = true
       }

--- a/lindera-nodejs/package.json
+++ b/lindera-nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lindera-nodejs",
+  "name": "lindera",
   "version": "5.3.0",
   "description": "Node.js bindings for Lindera morphological analysis engine",
   "main": "index.js",
@@ -16,9 +16,9 @@
     "node": "^20.17.0 || ^22.13.0 || >= 23.5.0"
   },
   "napi": {
-    "binaryName": "lindera-nodejs",
+    "binaryName": "lindera",
     "package": {
-      "name": "lindera-nodejs"
+      "name": "lindera"
     },
     "targets": [
       "x86_64-apple-darwin",
@@ -42,12 +42,12 @@
     "index.d.ts"
   ],
   "optionalDependencies": {
-    "lindera-nodejs-darwin-arm64": "0.0.0",
-    "lindera-nodejs-darwin-x64": "0.0.0",
-    "lindera-nodejs-linux-arm64-gnu": "0.0.0",
-    "lindera-nodejs-linux-x64-gnu": "0.0.0",
-    "lindera-nodejs-win32-arm64-msvc": "0.0.0",
-    "lindera-nodejs-win32-x64-msvc": "0.0.0"
+    "lindera-darwin-arm64": "0.0.0",
+    "lindera-darwin-x64": "0.0.0",
+    "lindera-linux-arm64-gnu": "0.0.0",
+    "lindera-linux-x64-gnu": "0.0.0",
+    "lindera-win32-arm64-msvc": "0.0.0",
+    "lindera-win32-x64-msvc": "0.0.0"
   },
   "repository": {
     "type": "git",

--- a/lindera-php/Cargo.toml
+++ b/lindera-php/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "lindera-php"
+# Distributed as a PHP extension, not via crates.io.
+publish = false
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/lindera-php/composer.json
+++ b/lindera-php/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "lindera/lindera-php",
+  "name": "lindera/lindera",
   "description": "PHP bindings for the Lindera morphological analysis library",
   "type": "php-ext",
   "license": "MIT",

--- a/lindera-python/Cargo.toml
+++ b/lindera-python/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "lindera-python"
+# Distributed via PyPI, not crates.io.
+publish = false
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/lindera-python/pyproject.toml
+++ b/lindera-python/pyproject.toml
@@ -3,7 +3,7 @@ module-name = "lindera"
 features = ["pyo3/abi3-py310", "pyo3/generate-import-lib"]
 
 [project]
-name = "lindera-python"
+name = "lindera"
 dynamic = ["version"]
 description = "Python binding for Lindera (no embedded dictionaries)"
 authors = [{ name = "Minoru Osuka", email = "minoru.osuka@gmail.com" }]

--- a/lindera-ruby/Cargo.toml
+++ b/lindera-ruby/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "lindera-ruby"
+# Distributed via RubyGems, not crates.io.
+publish = false
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/lindera-wasm/Cargo.toml
+++ b/lindera-wasm/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "lindera-wasm"
+# Distributed via npm, not crates.io.
+publish = false
 version = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/lindera-wasm/README.md
+++ b/lindera-wasm/README.md
@@ -10,8 +10,7 @@ WebAssembly of Lindera
 
 ## npm
 
-- <https://www.npmjs.com/package/lindera-wasm-web> — Lindera WASM for Web
-- <https://www.npmjs.com/package/lindera-wasm-bundler> — Lindera WASM for Bundler
+- <https://www.npmjs.com/package/lindera-wasm> — Lindera WASM
 
 ## Dictionary
 
@@ -23,12 +22,13 @@ See the [example application](example/) for a working demo of downloading and lo
 
 ### Web Usage
 
-Use the `lindera-wasm-web` package for browser environments.
+The `lindera-wasm` package is built with wasm-pack's `web` target. Call the
+default-exported async init function (`__wbg_init`) once before using any API.
 Dictionaries are loaded at runtime from a local path or downloaded from [GitHub Releases](https://github.com/lindera/lindera/releases) using the OPFS API.
 
 ```js
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { downloadDictionary, loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { downloadDictionary, loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 async function main() {
     await __wbg_init();
@@ -59,8 +59,10 @@ main();
 
 ### Bundler Usage (Webpack, Rollup, etc.)
 
-Use the `lindera-wasm-bundler` package for bundler environments.
-The dictionary loading approach is the same as the web usage above.
+Bundlers use the same `lindera-wasm` package. Modern bundlers (Vite, Webpack 5
+with the `asyncWebAssembly` experiment) can consume the web-target build
+directly; call `await __wbg_init()` before using any API, exactly as in the
+web usage above. The dictionary loading approach is also the same.
 
 ### Token Properties
 
@@ -90,7 +92,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   optimizeDeps: {
     exclude: [
-      "lindera-wasm-web"
+      "lindera-wasm"
     ]
   },
 })

--- a/lindera-wasm/README_ja.md
+++ b/lindera-wasm/README_ja.md
@@ -10,8 +10,7 @@ Lindera の WebAssembly 版
 
 ## npm
 
-- <https://www.npmjs.com/package/lindera-wasm-web> — Web 向け Lindera WASM
-- <https://www.npmjs.com/package/lindera-wasm-bundler> — バンドラ向け Lindera WASM
+- <https://www.npmjs.com/package/lindera-wasm> — Lindera WASM（`web` ターゲットでビルド）
 
 ## 辞書
 
@@ -23,12 +22,14 @@ Lindera の WebAssembly 版
 
 ### Web での使用
 
-ブラウザ環境では `lindera-wasm-web` パッケージを使用します。
+ブラウザ環境では `lindera-wasm` パッケージを使用します。
 辞書はローカルパスまたは [GitHub Releases](https://github.com/lindera/lindera/releases) から OPFS API を使用してダウンロードし、ランタイムで読み込みます。
 
+パッケージは `web` ターゲットでビルドされているため、使用前にデフォルトエクスポートの非同期初期化関数（下記の `__wbg_init`）を必ず呼び出してください。
+
 ```js
-import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm-web';
-import { downloadDictionary, loadDictionaryFiles } from 'lindera-wasm-web/opfs';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes } from 'lindera-wasm';
+import { downloadDictionary, loadDictionaryFiles } from 'lindera-wasm/opfs';
 
 async function main() {
     await __wbg_init();
@@ -57,9 +58,11 @@ async function main() {
 main();
 ```
 
-### バンドラでの使用（Webpack、Rollup など）
+### バンドラでの使用（Vite、Webpack など）
 
-バンドラ環境では `lindera-wasm-bundler` パッケージを使用します。
+バンドラ環境でも同じ `lindera-wasm` パッケージを使用します。
+モダンなバンドラ（Vite、Webpack 5 の `asyncWebAssembly` など）は `web` ターゲットのビルドをそのまま扱えます。
+上記と同様に、使用前にデフォルトエクスポートの初期化関数を呼び出してください。
 辞書の読み込み方法は上記の Web での使用と同じです。
 
 ### トークンのプロパティ
@@ -90,7 +93,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   optimizeDeps: {
     exclude: [
-      "lindera-wasm-web"
+      "lindera-wasm"
     ]
   },
 })

--- a/scripts/pypi-stub/README.md
+++ b/scripts/pypi-stub/README.md
@@ -1,0 +1,19 @@
+# lindera-python is now lindera
+
+As of v6.0.0, Lindera's Python binding is published on PyPI as
+[`lindera`](https://pypi.org/project/lindera/). The `lindera-python`
+distribution is no longer updated.
+
+Installing this package pulls in `lindera` automatically, but please switch
+your dependency declarations to the new name:
+
+```bash
+pip uninstall lindera-python
+pip install lindera
+```
+
+Your code does not change — the import name has always been `lindera`:
+
+```python
+import lindera
+```

--- a/scripts/pypi-stub/pyproject.toml
+++ b/scripts/pypi-stub/pyproject.toml
@@ -1,0 +1,33 @@
+# Transition stub for the old PyPI distribution name.
+#
+# Lindera's Python binding was renamed from `lindera-python` to `lindera` in
+# v6.0.0. This stub is published once as the final `lindera-python` release so
+# that existing users are pulled forward to the new name via the dependency.
+#
+# It deliberately ships NO Python modules: the real `lindera` wheel provides
+# the `lindera` package, and shipping any files here would collide with it
+# when both distributions are installed side by side.
+#
+# Publish manually after the v6.0.0 release:
+#   cd scripts/pypi-stub && python -m build && twine upload dist/*
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lindera-python"
+version = "6.0.0"
+description = "Renamed to 'lindera'. This stub only depends on the new name."
+readme = "README.md"
+license = "MIT"
+authors = [{ name = "Minoru Osuka", email = "minoru.osuka@gmail.com" }]
+requires-python = ">=3.10"
+dependencies = ["lindera>=6.0.0"]
+classifiers = ["Development Status :: 7 - Inactive"]
+
+[project.urls]
+Repository = "https://github.com/lindera/lindera"
+
+[tool.setuptools]
+# An empty package list makes this a metadata-only distribution.
+packages = []


### PR DESCRIPTION
Refs #987

## Summary

Applies litsea's naming rule to every registry: the package is named after the project itself, with no binding-language suffix. Ships in v6.0.0 as a breaking change.

| Registry | Old | New |
| --- | --- | --- |
| npm (Node.js) | `lindera-nodejs` | `lindera` |
| npm (platform) | `lindera-nodejs-<platform>` | `lindera-<platform>` |
| npm (WASM) | `lindera-wasm-web` + `lindera-wasm-bundler` | `lindera-wasm` (single package, `wasm-pack --target web`) |
| PyPI | `lindera-python` | `lindera` (import name unchanged) |
| Composer (unpublished) | `lindera/lindera-php` | `lindera/lindera` |
| RubyGems / crates.io core | `lindera` | unchanged |

## Changes

- **lindera-nodejs**: `package.json` renames (`name`, `napi.binaryName`, `napi.package.name`, `optionalDependencies`); `index.js` regenerated via `napi build` so the loader resolves `lindera.<platform>.node` / `lindera-<platform>`.
- **lindera-python**: `[project] name` in pyproject.toml only — maturin's `module-name` was already `lindera`, so user code is unaffected.
- **release.yml**: WASM build/publish jobs collapsed from a web/bundler matrix to a single `--target web` build (wasm-pack derives the `lindera-wasm` package name from the crate, so the jq rename is gone); binding crates (`lindera-python`, `lindera-nodejs`, `lindera-ruby`, `lindera-wasm`) removed from the crates.io publish loop.
- **Binding crates** (python / nodejs / ruby / php / wasm): explicit `publish = false` so they can never be cargo-published by accident.
- **dependabot.yml**: napi platform-package ignore rule updated to `lindera-*`.
- **scripts/pypi-stub/**: metadata-only `lindera-python==6.0.0` stub depending on `lindera>=6.0.0`, to be published manually once after the release (ships no modules, so it cannot collide with the real `lindera` wheel).
- **Docs**: 35 files (en/ja READMEs + mdBook) updated to the new install/import names; the v5→v6 migration guide gains a "Package renames" section with per-ecosystem migration steps, including the explicit `await __wbg_init()` call for former `lindera-wasm-bundler` users.

## Verification

- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets`: clean
- lindera-nodejs: `npm test` 17 pass (via the regenerated index.js), `npm run test:types` clean
- lindera-python: maturin develop + pytest, 10 passed
- `wasm-pack build --release --target web`: succeeds; generated `package.json` name verified as `lindera-wasm`
- PyPI stub: `python -m build` succeeds; wheel contains dist-info only (no modules)
- `markdownlint-cli2` on `docs/src` and `docs/ja/src`: 0 errors; `mdbook build docs` succeeds
- Residual grep for old names outside the migration guide: 0 hits

## Post-release follow-up (tracked in #987)

- `npm deprecate` the old packages (`lindera-nodejs`, six `lindera-nodejs-*` platform packages, `lindera-wasm-web`, `lindera-wasm-bundler`)
- Publish the `lindera-python` transition stub to PyPI

## Notes for reviewers

- The bare npm name `lindera` is unclaimed; `lindera-<platform>` (v3.0.0, 2026-04) and `lindera-wasm` (v2.1.0) already exist under the maintainer's account and are reused — v6.0.0 will supersede both.
- litsea's own release workflow was deliberately NOT copied: its npm publish is currently incomplete (no main `litsea` package, no win32 packages at 0.13.0). This PR only renames within Lindera's proven workflow.