### PR TITLE
docs(wasm): explain why only the web target is published

### DIFF
--- a/docs/ja/src/lindera-wasm/installation.md
+++ b/docs/ja/src/lindera-wasm/installation.md
@@ -38,6 +38,15 @@ wasm-pack build --target web
 
 `web` ターゲットのビルドは、ブラウザからネイティブ ES モジュールとして直接利用できるほか、モダンなバンドラー（Vite、Webpack 5 の `asyncWebAssembly` など）からもそのまま利用できます。バンドラー専用のビルドを別途用意する必要はありません。
 
+## なぜ web ターゲットのみなのか（bundler ではなく）
+
+wasm-pack のデフォルトの `--target` は `bundler` ですが、公開されている `lindera-wasm` パッケージは意図的に `--target web` でビルドしています。ターゲット名はやや誤解を招きやすいため、それぞれの実態を説明します：
+
+- `--target bundler`（wasm-pack のデフォルト）は、`.wasm` ファイルを ES モジュールとして直接 `import` する JavaScript を生成します。これはまだ標準化が完了していない WebAssembly ESM integration 提案に依存しており、実際にこの出力を解釈できるのは事実上 `asyncWebAssembly` experiment を有効にした Webpack だけです。このデフォルトは Webpack が支配的だった時代の名残であり、「bundler 汎用」という名前に反して実態は Webpack 専用に近い出力です。たとえば Vite で利用するには追加プラグイン（`vite-plugin-wasm` と top-level-await 対応）が必要です。
+- `--target web` は標準技術のみで構成されたコードを生成します。`.wasm` ファイルは `new URL('lindera_wasm_bg.wasm', import.meta.url)` で解決され、明示的な非同期 init 関数の中で `fetch` + `WebAssembly.instantiateStreaming` により読み込まれます。ビルドステップなしでブラウザのネイティブ ES モジュールとして動作するほか、モダンなバンドラー（Vite、Webpack 5、Rollup）は `new URL(..., import.meta.url)` パターンを認識して `.wasm` ファイルをアセットとして配置します。唯一のコストは、API を使う前に一度 `await __wbg_init()` を呼ぶ必要があることです。
+
+まとめると、bundler ターゲットは Webpack に限ればゼロコンフィグですが、web ターゲットは明示的な init 呼び出し 1 回のコストでどこでも動きます。v5 までは両方のビルド（`lindera-wasm-web` と `lindera-wasm-bundler`）を公開していましたが、v6 からは可搬性の高い単一ビルドに統合しました。`lindera-wasm-bundler` からの移行は [v5 から v6 への移行ガイド](../migration_v5_to_v6.md)を参照してください。
+
 ## 利用可能な Feature フラグ（上級者向け）
 
 辞書を WASM バイナリに直接埋め込みたい上級者向けに、以下の feature フラグが利用できます。バイナリサイズが大幅に増加しますが、実行時の辞書ダウンロードが不要になります。

--- a/docs/src/lindera-wasm/installation.md
+++ b/docs/src/lindera-wasm/installation.md
@@ -39,6 +39,36 @@ The output is written to the `pkg/` directory inside the `lindera-wasm` crate.
 wasm-pack also supports other targets (e.g. `--target nodejs`) if you need a
 custom build, but the web-target build is what this documentation assumes.
 
+## Why the web Target (and Not bundler)?
+
+wasm-pack's default `--target` is `bundler`, yet the published `lindera-wasm`
+package is deliberately built with `--target web`. The target names are
+somewhat misleading, so here is what each one actually produces:
+
+- `--target bundler` (the wasm-pack default) emits JavaScript that imports
+  the `.wasm` file as an ES module. This relies on the WebAssembly ESM
+  integration proposal, which is not yet a finalized web standard; in
+  practice the only bundler that understands the output is Webpack with the
+  `asyncWebAssembly` experiment enabled. The default dates from the era when
+  Webpack was the dominant bundler -- despite the generic name, the output is
+  effectively Webpack-specific. Vite, for example, needs extra plugins
+  (`vite-plugin-wasm` plus top-level-await support) to consume it.
+- `--target web` emits standards-based code only: the `.wasm` file is
+  resolved via `new URL('lindera_wasm_bg.wasm', import.meta.url)` and loaded
+  with `fetch` + `WebAssembly.instantiateStreaming` inside an explicit async
+  init function. This runs in browsers as native ES modules with no build
+  step at all, and modern bundlers (Vite, Webpack 5, Rollup) recognize the
+  `new URL(..., import.meta.url)` pattern and ship the `.wasm` file as an
+  asset. The one cost is that you must call `await __wbg_init()` once before
+  using the API.
+
+In short, the bundler target is zero-config for Webpack only, while the web
+target runs everywhere at the cost of one explicit init call. Up to v5,
+Lindera published both variants (`lindera-wasm-web` and
+`lindera-wasm-bundler`); v6 consolidates on the single portable build. If you
+are migrating from `lindera-wasm-bundler`, see the
+[v5 to v6 migration guide](../migration_v5_to_v6.md).
+
 ## Available Feature Flags (Advanced)
 
 For advanced users who want to embed dictionaries directly into the WASM binary, the following feature flags are available. This increases the binary size significantly but eliminates the need to download dictionaries at runtime.


### PR DESCRIPTION
Refs #987

## Summary

v6.0.0 consolidated the WASM npm packages into a single `lindera-wasm` built with `wasm-pack --target web` (#988). This PR records the rationale in the WASM installation guide (English and Japanese) so the decision is discoverable by users and future maintainers.

## What the new section says

- `--target bundler` (wasm-pack's default) imports the `.wasm` file as an ES module, relying on the not-yet-finalized WebAssembly ESM integration proposal; in practice only Webpack with the `asyncWebAssembly` experiment understands the output. The default dates from the Webpack-dominant era and is effectively Webpack-specific (Vite needs `vite-plugin-wasm` + top-level-await plugins).
- `--target web` uses standards-based loading only (`new URL(..., import.meta.url)` + `fetch` + `WebAssembly.instantiateStreaming`): it runs as native browser ES modules and is handled as an asset by Vite, Webpack 5, and Rollup. The one cost is a single explicit `await __wbg_init()` call.
- Notes that v5 published both variants and v6 consolidated on the portable build, with a link to the v5→v6 migration guide.

## Verification

- `markdownlint-cli2`: 0 errors (docs/src full sweep + the edited ja file)
- `mdbook build docs`: succeeds