### PR TITLE
docs: fix broken and inaccurate code samples across binding docs

### DIFF
--- a/docs/ja/src/lindera-analysis/filters.md
+++ b/docs/ja/src/lindera-analysis/filters.md
@@ -191,6 +191,8 @@
 
 品詞タグが`tags`のいずれかに一致するトークンのみを保持し、それ以外を除去します。
 
+タグは 4 階層のカンマ区切りに正規化され（不足分は `*` で補完）、各トークンの先頭 4 つの品詞詳細と完全一致で比較されます。IPADIC の助詞トークンは必ず `助詞,係助詞` のようにサブカテゴリを持つため、`助詞` 単独では一致しません。一方、助動詞はサブカテゴリを持たないため（`助動詞,*,*,*`）、`助動詞` 単独で一致します。この動作は `japanese_stop_tags` も同様です。
+
 **パラメータ:**
 
 | パラメータ | 型 | 必須 | 説明 |
@@ -204,9 +206,7 @@
   "kind": "japanese_keep_tags",
   "args": {
     "tags": [
-      "名詞",
-      "名詞,一般",
-      "名詞,固有名詞"
+      "名詞,一般"
     ]
   }
 }
@@ -266,9 +266,10 @@
   "kind": "japanese_stop_tags",
   "args": {
     "tags": [
-      "助詞",
-      "助動詞",
-      "記号"
+      "助詞,格助詞,一般",
+      "助詞,係助詞",
+      "助詞,連体化",
+      "助動詞"
     ]
   }
 }
@@ -497,9 +498,10 @@ token_filters:
   - kind: "japanese_stop_tags"
     args:
       tags:
-        - "助詞"
+        - "助詞,格助詞,一般"
+        - "助詞,係助詞"
+        - "助詞,連体化"
         - "助動詞"
-        - "記号"
   - kind: "japanese_katakana_stem"
     args:
       min: 3
@@ -540,9 +542,10 @@ fn main() -> LinderaResult<()> {
     // トークンフィルタを追加
     let stop_tags_filter = JapaneseStopTagsTokenFilter::new(
         vec![
-            "助詞".to_string(),
+            "助詞,格助詞,一般".to_string(),
+            "助詞,係助詞".to_string(),
+            "助詞,連体化".to_string(),
             "助動詞".to_string(),
-            "記号".to_string(),
         ]
         .into_iter()
         .collect(),

--- a/docs/ja/src/lindera-cli/tutorial.md
+++ b/docs/ja/src/lindera-cli/tutorial.md
@@ -105,7 +105,7 @@ Unicode正規化を行い、一般名詞のみを保持します：
 % echo "Ｌｉｎｄｅｒａは形態素解析ｴﾝｼﾞﾝです。" | lindera tokenize \
   --dict ipadic \
   --char-filter 'unicode_normalize:{"kind":"nfkc"}' \
-  --token-filter 'japanese_keep_tags:{"tags":["名詞,一般","名詞,固有名詞,組織"]}'
+  --token-filter 'japanese_keep_tags:{"tags":["名詞,一般","名詞,サ変接続","名詞,固有名詞,組織"]}'
 ```
 
 期待される出力：
@@ -125,7 +125,7 @@ Unicode正規化により全角文字が半角に変換され、Token Filter に
 ```shell
 % echo "すもももももももものうち" | lindera tokenize \
   --dict ipadic \
-  --token-filter 'japanese_stop_tags:{"tags":["助詞","助詞,係助詞","助詞,連体化"]}'
+  --token-filter 'japanese_stop_tags:{"tags":["助詞,格助詞,一般","助詞,係助詞","助詞,連体化","助動詞"]}'
 ```
 
 ## 7. ユーザー辞書の使用

--- a/docs/ja/src/lindera-nodejs/dictionary_management.md
+++ b/docs/ja/src/lindera-nodejs/dictionary_management.md
@@ -58,10 +58,10 @@ const tokenizer = new Tokenizer(dictionary, "normal", userDict);
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("/path/to/ipadic")
-  .setUserDictionary("/path/to/user_dictionary")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("/path/to/ipadic");
+builder.setUserDictionary("/path/to/user_dictionary");
+const tokenizer = builder.build();
 ```
 
 ## 辞書のビルド

--- a/docs/ja/src/lindera-nodejs/installation.md
+++ b/docs/ja/src/lindera-nodejs/installation.md
@@ -103,16 +103,14 @@ console.log(lindera.version());
 ```
 
 > [!NOTE]
-> npm パッケージ `lindera` の `package.json` は現状、`exports` マップに `require` 条件のみを定義しており
-> （`import` 条件はありません）、そのため `import { version } from "lindera";` は
-> `ERR_PACKAGE_PATH_NOT_EXPORTED` で失敗します。ES modules から利用する場合は、Node.js の
-> `createRequire` を使用してください：
+> npm パッケージ `lindera` の `exports` マップは `types` / `import` / `require` の各条件を宣言しているため、
+> CommonJS（`require("lindera")`）からも ES モジュール（`import { TokenizerBuilder } from "lindera"`）からも
+> そのまま読み込めます。
+
+最小の ESM の例：
 
 ```javascript
-import { createRequire } from "node:module";
+import { TokenizerBuilder } from "lindera";
 
-const require = createRequire(import.meta.url);
-const lindera = require("lindera");
-
-console.log(lindera.version());
+console.log(typeof TokenizerBuilder); // "function"
 ```

--- a/docs/ja/src/lindera-nodejs/quickstart.md
+++ b/docs/ja/src/lindera-nodejs/quickstart.md
@@ -27,25 +27,7 @@ for (const token of tokens) {
 ```text
 関西国際空港    名詞,固有名詞,組織,*,*,*,関西国際空港,カンサイコクサイクウコウ,カンサイコクサイクーコー
 限定    名詞,サ変接続,*,*,*,*,限定,ゲンテイ,ゲンテイ
-トートバッグ    UNK
-```
-
-## メソッドチェーン
-
-`TokenizerBuilder` は簡潔な設定のためにメソッドチェーンをサポートしています：
-
-```javascript
-const { TokenizerBuilder } = require("lindera");
-
-const tokenizer = new TokenizerBuilder()
-  .setMode("normal")
-  .setDictionary("/path/to/ipadic")
-  .build();
-
-const tokens = tokenizer.tokenize("すもももももももものうち");
-for (const token of tokens) {
-  console.log(`${token.surface}\t${token.details[0]}`);
-}
+トートバッグ    名詞,一般,*,*,*,*,*,*,*
 ```
 
 ## トークンプロパティへのアクセス
@@ -55,9 +37,9 @@ for (const token of tokens) {
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("/path/to/ipadic")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("/path/to/ipadic");
+const tokenizer = builder.build();
 
 const tokens = tokenizer.tokenize("東京タワー");
 for (const token of tokens) {
@@ -78,9 +60,9 @@ for (const token of tokens) {
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("/path/to/ipadic")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("/path/to/ipadic");
+const tokenizer = builder.build();
 
 const results = tokenizer.tokenizeNbest("すもももももももものうち", 3);
 for (const { tokens, cost } of results) {
@@ -91,22 +73,16 @@ for (const { tokens, cost } of results) {
 
 ## TypeScript
 
-Lindera Node.js には TypeScript の型定義が含まれています。すべてのクラスと関数に完全な型が付いています：
+Lindera Node.js には TypeScript の型定義が同梱されています。すべてのクラスと関数に完全な型が付いています。npm パッケージ `lindera` の `exports` マップは `require` / `import` の両方の条件を宣言しているため、CommonJS からも ES モジュールからもそのまま読み込めます。以下のサンプルは `moduleResolution: node16` + `strict` でコンパイルできることを確認済みです：
 
 ```typescript
 import type { Token } from "lindera";
-import { createRequire } from "node:module";
+import { TokenizerBuilder } from "lindera";
 
-// npm パッケージ lindera は CommonJS の require エントリポイントのみを公開しているため
-// （「インストール」を参照）、ESM プロジェクトでは createRequire で実行時の値を
-// 読み込みつつ、import type で型情報を取得します。
-const require = createRequire(import.meta.url);
-const { TokenizerBuilder } = require("lindera");
-
-const tokenizer = new TokenizerBuilder()
-  .setMode("normal")
-  .setDictionary("/path/to/ipadic")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setMode("normal");
+builder.setDictionary("/path/to/ipadic");
+const tokenizer = builder.build();
 
 const tokens: Token[] = tokenizer.tokenize("形態素解析");
 for (const token of tokens) {

--- a/docs/ja/src/lindera-nodejs/text_processing_pipeline.md
+++ b/docs/ja/src/lindera-nodejs/text_processing_pipeline.md
@@ -26,10 +26,10 @@ Input Text
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendCharacterFilter("unicode_normalize", { kind: "nfkc" })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendCharacterFilter("unicode_normalize", { kind: "nfkc" });
+const tokenizer = builder.build();
 ```
 
 サポートされる正規化形式: `"nfc"`、`"nfkc"`、`"nfd"`、`"nfkd"`。
@@ -39,15 +39,15 @@ const tokenizer = new TokenizerBuilder()
 マッピングテーブルに従って文字や文字列を置換します。
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendCharacterFilter("mapping", {
-    mapping: {
-      "\u30fc": "-",
-      "\uff5e": "~",
-    },
-  })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendCharacterFilter("mapping", {
+  mapping: {
+    "\u30fc": "-",
+    "\uff5e": "~",
+  },
+});
+const tokenizer = builder.build();
 ```
 
 ### japanese_iteration_mark
@@ -55,13 +55,13 @@ const tokenizer = new TokenizerBuilder()
 日本語の踊り字（繰り返し記号）を完全な形に展開します。
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendCharacterFilter("japanese_iteration_mark", {
-    normalize_kanji: true,
-    normalize_kana: true,
-  })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendCharacterFilter("japanese_iteration_mark", {
+  normalize_kanji: true,
+  normalize_kana: true,
+});
+const tokenizer = builder.build();
 ```
 
 ## トークンフィルタ
@@ -73,10 +73,10 @@ const tokenizer = new TokenizerBuilder()
 トークンの表層形を小文字に変換します。
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendTokenFilter("lowercase", {})
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendTokenFilter("lowercase", {});
+const tokenizer = builder.build();
 ```
 
 ### japanese_base_form
@@ -84,10 +84,10 @@ const tokenizer = new TokenizerBuilder()
 辞書の形態素情報を使用して、活用形を基本形（辞書形）に置換します。
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendTokenFilter("japanese_base_form", {})
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendTokenFilter("japanese_base_form", {});
+const tokenizer = builder.build();
 ```
 
 ### japanese_stop_tags
@@ -95,25 +95,30 @@ const tokenizer = new TokenizerBuilder()
 指定されたタグに一致する品詞のトークンを除去します。
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendTokenFilter("japanese_stop_tags", {
-    tags: ["助詞", "助動詞"],
-  })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendTokenFilter("japanese_stop_tags", {
+  tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"],
+});
+const tokenizer = builder.build();
 ```
+
+> [!NOTE]
+> タグは 4 階層のカンマ区切りに正規化され（不足分は `*` で補完）、各トークンの先頭 4 つの品詞詳細と完全一致で比較されます。
+> IPADIC の助詞トークンは必ず `助詞,係助詞` のようにサブカテゴリを持つため、`助詞` 単独では一致しません。
+> 一方、助動詞はサブカテゴリを持たないため（`助動詞,*,*,*`）、`助動詞` 単独で一致します。
 
 ### japanese_keep_tags
 
 指定されたタグに一致する品詞のトークンのみを保持します。その他のトークンはすべて除去されます。
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendTokenFilter("japanese_keep_tags", {
-    tags: ["名詞"],
-  })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendTokenFilter("japanese_keep_tags", {
+  tags: ["名詞,一般"],
+});
+const tokenizer = builder.build();
 ```
 
 ## パイプラインの完全な例
@@ -123,22 +128,22 @@ const tokenizer = new TokenizerBuilder()
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setMode("normal")
-  .setDictionary("embedded://ipadic")
-  // Preprocessing
-  .appendCharacterFilter("unicode_normalize", { kind: "nfkc" })
-  .appendCharacterFilter("japanese_iteration_mark", {
-    normalize_kanji: true,
-    normalize_kana: true,
-  })
-  // Postprocessing
-  .appendTokenFilter("japanese_base_form", {})
-  .appendTokenFilter("japanese_stop_tags", {
-    tags: ["助詞", "助動詞", "記号"],
-  })
-  .appendTokenFilter("lowercase", {})
-  .build();
+const builder = new TokenizerBuilder();
+builder.setMode("normal");
+builder.setDictionary("embedded://ipadic");
+// Preprocessing
+builder.appendCharacterFilter("unicode_normalize", { kind: "nfkc" });
+builder.appendCharacterFilter("japanese_iteration_mark", {
+  normalize_kanji: true,
+  normalize_kana: true,
+});
+// Postprocessing
+builder.appendTokenFilter("japanese_base_form", {});
+builder.appendTokenFilter("japanese_stop_tags", {
+  tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"],
+});
+builder.appendTokenFilter("lowercase", {});
+const tokenizer = builder.build();
 
 const tokens = tokenizer.tokenize("Ｌｉｎｄｅｒａは形態素解析を行うライブラリです。");
 for (const token of tokens) {
@@ -151,5 +156,5 @@ for (const token of tokens) {
 1. `unicode_normalize` が全角文字を半角に変換（NFKC 正規化）
 2. `japanese_iteration_mark` が踊り字を展開
 3. `japanese_base_form` が活用形のトークンを基本形に変換
-4. `japanese_stop_tags` が助詞、助動詞、記号を除去
+4. `japanese_stop_tags` が助詞（格助詞・係助詞・連体化）・助動詞・句読点を除去
 5. `lowercase` がアルファベットを小文字に正規化

--- a/docs/ja/src/lindera-nodejs/tokenizer_api.md
+++ b/docs/ja/src/lindera-nodejs/tokenizer_api.md
@@ -30,7 +30,7 @@ const builder = new TokenizerBuilder().fromFile("lindera.yml");
 
 ### 設定メソッド
 
-すべてのセッターメソッドはメソッドチェーンのために `this` を返します。
+セッターメソッドは `this` ではなく `undefined` を返すため、メソッドチェーンはできません。ビルダーインスタンスに対して個別に呼び出してください。
 
 #### `setMode(mode)`
 

--- a/docs/ja/src/lindera-nodejs/training.md
+++ b/docs/ja/src/lindera-nodejs/training.md
@@ -121,10 +121,10 @@ const metadata = Metadata.fromJsonFile("/tmp/dictionary_source/metadata.json");
 buildDictionary("/tmp/dictionary_source", "/tmp/dictionary", metadata);
 
 // Step 4: Use the trained dictionary
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("/tmp/dictionary")
-  .setMode("normal")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("/tmp/dictionary");
+builder.setMode("normal");
+const tokenizer = builder.build();
 
 const tokens = tokenizer.tokenize("形態素解析のテスト");
 for (const token of tokens) {

--- a/docs/ja/src/lindera-php/text_processing_pipeline.md
+++ b/docs/ja/src/lindera-php/text_processing_pipeline.md
@@ -115,10 +115,12 @@ $tokenizer = $builder->build();
 $builder = new Lindera\TokenizerBuilder();
 $builder->setDictionary('embedded://ipadic');
 $builder->appendTokenFilter('japanese_stop_tags', [
-    'tags' => ['助詞', '助動詞', '記号'],
+    'tags' => ['助詞,格助詞,一般', '助詞,係助詞', '助詞,連体化', '助動詞'],
 ]);
 $tokenizer = $builder->build();
 ```
+
+タグは 4 階層のカンマ区切りに正規化され（不足分は `*` で補完）、各トークンの先頭 4 つの品詞詳細と完全一致で比較されます。IPADIC の助詞トークンは必ず `助詞,係助詞` のようにサブカテゴリを持つため、`助詞` 単独では一致しません。一方、助動詞はサブカテゴリを持たないため（`助動詞,*,*,*`）、`助動詞` 単独で一致します。
 
 ### japanese_keep_tags
 
@@ -130,7 +132,7 @@ $tokenizer = $builder->build();
 $builder = new Lindera\TokenizerBuilder();
 $builder->setDictionary('embedded://ipadic');
 $builder->appendTokenFilter('japanese_keep_tags', [
-    'tags' => ['名詞'],
+    'tags' => ['名詞,一般'],
 ]);
 $tokenizer = $builder->build();
 ```
@@ -161,8 +163,7 @@ $builder->appendTokenFilter('japanese_katakana_stem', ['min' => 3]);
 $builder->appendTokenFilter('japanese_stop_tags', [
     'tags' => [
         '接続詞',
-        '助詞',
-        '助詞,格助詞',
+        '助詞,格助詞,一般',
         '助詞,格助詞,一般',
         '助詞,係助詞',
         '助詞,副助詞',

--- a/docs/ja/src/lindera-php/tokenizer_api.md
+++ b/docs/ja/src/lindera-php/tokenizer_api.md
@@ -71,7 +71,9 @@ $builder->appendCharacterFilter('unicode_normalize', ['kind' => 'nfkc']);
 
 ```php
 $builder->appendTokenFilter('lowercase');
-$builder->appendTokenFilter('japanese_stop_tags', ['tags' => ['助詞', '助動詞']]);
+$builder->appendTokenFilter('japanese_stop_tags', [
+    'tags' => ['助詞,格助詞,一般', '助詞,係助詞', '助詞,連体化', '助動詞'],
+]);
 ```
 
 ### ビルド

--- a/docs/ja/src/lindera-python/text_processing_pipeline.md
+++ b/docs/ja/src/lindera-python/text_processing_pipeline.md
@@ -104,11 +104,13 @@ tokenizer = (
     TokenizerBuilder()
     .set_dictionary("embedded://ipadic")
     .append_token_filter("japanese_stop_tags", {
-        "tags": ["助詞", "助動詞"],
+        "tags": ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"],
     })
     .build()
 )
 ```
+
+タグは 4 階層のカンマ区切りに正規化され（不足分は `*` で補完）、各トークンの先頭 4 つの品詞詳細と完全一致で比較されます。IPADIC の助詞トークンは必ず `助詞,係助詞` のようにサブカテゴリを持つため、`助詞` 単独では一致しません。一方、助動詞はサブカテゴリを持たないため（`助動詞,*,*,*`）、`助動詞` 単独で一致します。
 
 ### japanese_keep_tags
 
@@ -119,7 +121,7 @@ tokenizer = (
     TokenizerBuilder()
     .set_dictionary("embedded://ipadic")
     .append_token_filter("japanese_keep_tags", {
-        "tags": ["名詞"],
+        "tags": ["名詞,一般"],
     })
     .build()
 )
@@ -145,7 +147,7 @@ tokenizer = (
     # Postprocessing
     .append_token_filter("japanese_base_form", {})
     .append_token_filter("japanese_stop_tags", {
-        "tags": ["助詞", "助動詞", "記号"],
+        "tags": ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"],
     })
     .append_token_filter("lowercase", {})
     .build()
@@ -161,5 +163,5 @@ for token in tokens:
 1. `unicode_normalize` が全角文字を半角に変換（NFKC 正規化）
 2. `japanese_iteration_mark` が踊り字を展開
 3. `japanese_base_form` が活用形のトークンを基本形に変換
-4. `japanese_stop_tags` が助詞、助動詞、記号を除去
+4. `japanese_stop_tags` が助詞（格助詞・係助詞・連体化）・助動詞・句読点を除去
 5. `lowercase` がアルファベットを小文字に正規化

--- a/docs/ja/src/lindera-ruby/text_processing_pipeline.md
+++ b/docs/ja/src/lindera-ruby/text_processing_pipeline.md
@@ -98,10 +98,15 @@ tokenizer = builder.build
 builder = Lindera::TokenizerBuilder.new
 builder.set_dictionary('embedded://ipadic')
 builder.append_token_filter('japanese_stop_tags', {
-  'tags' => ['助詞', '助動詞']
+  'tags' => ['助詞,格助詞,一般', '助詞,係助詞', '助詞,連体化', '助動詞']
 })
 tokenizer = builder.build
 ```
+
+> [!NOTE]
+> タグは 4 階層のカンマ区切りに正規化され（不足分は `*` で補完）、各トークンの先頭 4 つの品詞詳細と完全一致で比較されます。
+> IPADIC の助詞トークンは必ず `助詞,係助詞` のようにサブカテゴリを持つため、`助詞` 単独では一致しません。
+> 一方、助動詞はサブカテゴリを持たないため（`助動詞,*,*,*`）、`助動詞` 単独で一致します。
 
 ### japanese_keep_tags
 
@@ -111,7 +116,7 @@ tokenizer = builder.build
 builder = Lindera::TokenizerBuilder.new
 builder.set_dictionary('embedded://ipadic')
 builder.append_token_filter('japanese_keep_tags', {
-  'tags' => ['名詞']
+  'tags' => ['名詞,一般']
 })
 tokenizer = builder.build
 ```
@@ -148,7 +153,7 @@ builder.append_character_filter('japanese_iteration_mark', {
 # Postprocessing
 builder.append_token_filter('japanese_base_form', nil)
 builder.append_token_filter('japanese_stop_tags', {
-  'tags' => ['助詞', '助動詞', '記号']
+  'tags' => ['助詞,格助詞,一般', '助詞,係助詞', '助詞,連体化', '助動詞', '記号,句点', '記号,読点']
 })
 builder.append_token_filter('lowercase', nil)
 
@@ -165,5 +170,5 @@ end
 1. `unicode_normalize` が全角文字を半角に変換（NFKC 正規化）
 2. `japanese_iteration_mark` が踊り字を展開
 3. `japanese_base_form` が活用形のトークンを基本形に変換
-4. `japanese_stop_tags` が助詞、助動詞、記号を除去
+4. `japanese_stop_tags` が助詞（格助詞・係助詞・連体化）・助動詞・句読点を除去
 5. `lowercase` がアルファベットを小文字に正規化

--- a/docs/ja/src/lindera-wasm/quickstart.md
+++ b/docs/ja/src/lindera-wasm/quickstart.md
@@ -107,7 +107,7 @@ async function main() {
 
     // Add a stop-tags filter to remove particles and auxiliary verbs
     builder.appendTokenFilter("japanese_stop_tags", {
-        tags: ["助詞", "助動詞"]
+        tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"]
     });
 
     const tokenizer = builder.build();

--- a/docs/ja/src/lindera-wasm/tokenizer_api.md
+++ b/docs/ja/src/lindera-wasm/tokenizer_api.md
@@ -102,7 +102,7 @@ builder.appendCharacterFilter("unicode_normalize", { kind: "nfkc" });
 
 ```javascript
 builder.appendTokenFilter("japanese_stop_tags", {
-    tags: ["助詞", "助動詞", "記号"]
+    tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"]
 });
 ```
 

--- a/docs/src/lindera-analysis/filters.md
+++ b/docs/src/lindera-analysis/filters.md
@@ -204,9 +204,8 @@ Keeps only tokens whose part-of-speech tag matches one of `tags`, removing all o
   "kind": "japanese_keep_tags",
   "args": {
     "tags": [
-      "名詞",
       "名詞,一般",
-      "名詞,固有名詞"
+      "名詞,固有名詞,一般"
     ]
   }
 }
@@ -266,13 +265,16 @@ Removes tokens whose part-of-speech tag matches one of `tags`.
   "kind": "japanese_stop_tags",
   "args": {
     "tags": [
-      "助詞",
-      "助動詞",
-      "記号"
+      "助詞,格助詞,一般",
+      "助詞,係助詞",
+      "助詞,連体化",
+      "助動詞"
     ]
   }
 }
 ```
+
+Tags are normalized to exactly four comma-separated levels (missing levels are padded with `*`) and compared for exact equality against the first four part-of-speech details of each token. A bare `助詞` therefore never matches IPADIC particle tokens — they always carry a subcategory such as `助詞,係助詞` — while a bare `助動詞` does match, because auxiliary verbs have no subcategory (`助動詞,*,*,*`). The same matching rule applies to `japanese_keep_tags`.
 
 ### keep_words
 
@@ -497,9 +499,10 @@ token_filters:
   - kind: "japanese_stop_tags"
     args:
       tags:
-        - "助詞"
+        - "助詞,格助詞,一般"
+        - "助詞,係助詞"
+        - "助詞,連体化"
         - "助動詞"
-        - "記号"
   - kind: "japanese_katakana_stem"
     args:
       min: 3
@@ -540,9 +543,10 @@ fn main() -> LinderaResult<()> {
     // Add token filters
     let stop_tags_filter = JapaneseStopTagsTokenFilter::new(
         vec![
-            "助詞".to_string(),
+            "助詞,格助詞,一般".to_string(),
+            "助詞,係助詞".to_string(),
+            "助詞,連体化".to_string(),
             "助動詞".to_string(),
-            "記号".to_string(),
         ]
         .into_iter()
         .collect(),

--- a/docs/src/lindera-cli/tutorial.md
+++ b/docs/src/lindera-cli/tutorial.md
@@ -105,7 +105,7 @@ Use Unicode normalization and keep only common nouns:
 % echo "Ｌｉｎｄｅｒａは形態素解析ｴﾝｼﾞﾝです。" | lindera tokenize \
   --dict ipadic \
   --char-filter 'unicode_normalize:{"kind":"nfkc"}' \
-  --token-filter 'japanese_keep_tags:{"tags":["名詞,一般","名詞,固有名詞,組織"]}'
+  --token-filter 'japanese_keep_tags:{"tags":["名詞,一般","名詞,サ変接続","名詞,固有名詞,組織"]}'
 ```
 
 Expected output:
@@ -125,7 +125,7 @@ You can also combine multiple filters:
 ```shell
 % echo "すもももももももものうち" | lindera tokenize \
   --dict ipadic \
-  --token-filter 'japanese_stop_tags:{"tags":["助詞","助詞,係助詞","助詞,連体化"]}'
+  --token-filter 'japanese_stop_tags:{"tags":["助詞,格助詞,一般","助詞,係助詞","助詞,連体化","助動詞"]}'
 ```
 
 ## 7. Use user dictionary

--- a/docs/src/lindera-nodejs/dictionary_management.md
+++ b/docs/src/lindera-nodejs/dictionary_management.md
@@ -58,10 +58,10 @@ Or via the builder:
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("/path/to/ipadic")
-  .setUserDictionary("/path/to/user_dictionary")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("/path/to/ipadic");
+builder.setUserDictionary("/path/to/user_dictionary");
+const tokenizer = builder.build();
 ```
 
 ## Building Dictionaries

--- a/docs/src/lindera-nodejs/installation.md
+++ b/docs/src/lindera-nodejs/installation.md
@@ -103,16 +103,13 @@ console.log(lindera.version());
 ```
 
 > [!NOTE]
-> The `lindera` npm package's `package.json` currently declares only a `require` condition in its
-> `exports` map (no `import` condition), so `import { version } from "lindera"` fails
-> with `ERR_PACKAGE_PATH_NOT_EXPORTED`. From an ES module, load it with Node's `createRequire`
-> instead:
+> The `lindera` npm package's `exports` map declares `types`, `import`, and `require`
+> conditions, so the package loads from CommonJS
+> (`const { TokenizerBuilder } = require("lindera")`) and ES modules
+> (`import { TokenizerBuilder } from "lindera"`) alike:
 
 ```javascript
-import { createRequire } from "node:module";
+import { TokenizerBuilder } from "lindera";
 
-const require = createRequire(import.meta.url);
-const lindera = require("lindera");
-
-console.log(lindera.version());
+console.log(typeof TokenizerBuilder); // "function"
 ```

--- a/docs/src/lindera-nodejs/quickstart.md
+++ b/docs/src/lindera-nodejs/quickstart.md
@@ -27,25 +27,7 @@ Expected output:
 ```text
 関西国際空港    名詞,固有名詞,組織,*,*,*,関西国際空港,カンサイコクサイクウコウ,カンサイコクサイクーコー
 限定    名詞,サ変接続,*,*,*,*,限定,ゲンテイ,ゲンテイ
-トートバッグ    UNK
-```
-
-## Method Chaining
-
-`TokenizerBuilder` supports method chaining for concise configuration:
-
-```javascript
-const { TokenizerBuilder } = require("lindera");
-
-const tokenizer = new TokenizerBuilder()
-  .setMode("normal")
-  .setDictionary("/path/to/ipadic")
-  .build();
-
-const tokens = tokenizer.tokenize("すもももももももものうち");
-for (const token of tokens) {
-  console.log(`${token.surface}\t${token.details[0]}`);
-}
+トートバッグ    名詞,一般,*,*,*,*,*,*,*
 ```
 
 ## Accessing Token Properties
@@ -55,9 +37,9 @@ Each token exposes the following properties:
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("/path/to/ipadic")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("/path/to/ipadic");
+const tokenizer = builder.build();
 
 const tokens = tokenizer.tokenize("東京タワー");
 for (const token of tokens) {
@@ -78,9 +60,9 @@ Retrieve multiple tokenization candidates ranked by cost:
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("/path/to/ipadic")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("/path/to/ipadic");
+const tokenizer = builder.build();
 
 const results = tokenizer.tokenizeNbest("すもももももももものうち", 3);
 for (const { tokens, cost } of results) {
@@ -91,22 +73,16 @@ for (const { tokens, cost } of results) {
 
 ## TypeScript
 
-Lindera Node.js includes TypeScript type definitions. All classes and functions are fully typed:
+Lindera Node.js includes TypeScript type definitions, so all classes and functions are fully typed. The package's `exports` map serves both `require` and `import`, and the following sample compiles under `moduleResolution: node16` with `strict` enabled:
 
 ```typescript
 import type { Token } from "lindera";
-import { createRequire } from "node:module";
+import { TokenizerBuilder } from "lindera";
 
-// The `lindera` npm package only exposes a CommonJS `require` entry point (see Installation),
-// so ESM projects load the runtime values through `createRequire` while still getting
-// full type information via `import type`.
-const require = createRequire(import.meta.url);
-const { TokenizerBuilder } = require("lindera");
-
-const tokenizer = new TokenizerBuilder()
-  .setMode("normal")
-  .setDictionary("/path/to/ipadic")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setMode("normal");
+builder.setDictionary("/path/to/ipadic");
+const tokenizer = builder.build();
 
 const tokens: Token[] = tokenizer.tokenize("形態素解析");
 for (const token of tokens) {

--- a/docs/src/lindera-nodejs/text_processing_pipeline.md
+++ b/docs/src/lindera-nodejs/text_processing_pipeline.md
@@ -27,10 +27,10 @@ Applies Unicode normalization to the input text.
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendCharacterFilter("unicode_normalize", { kind: "nfkc" })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendCharacterFilter("unicode_normalize", { kind: "nfkc" });
+const tokenizer = builder.build();
 ```
 
 Supported normalization forms: `"nfc"`, `"nfkc"`, `"nfd"`, `"nfkd"`.
@@ -40,15 +40,15 @@ Supported normalization forms: `"nfc"`, `"nfkc"`, `"nfd"`, `"nfkd"`.
 Replaces characters or strings according to a mapping table.
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendCharacterFilter("mapping", {
-    mapping: {
-      "\u30fc": "-",
-      "\uff5e": "~",
-    },
-  })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendCharacterFilter("mapping", {
+  mapping: {
+    "\u30fc": "-",
+    "\uff5e": "~",
+  },
+});
+const tokenizer = builder.build();
 ```
 
 ### japanese_iteration_mark
@@ -56,13 +56,13 @@ const tokenizer = new TokenizerBuilder()
 Resolves Japanese iteration marks (odoriji) into their full forms.
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendCharacterFilter("japanese_iteration_mark", {
-    normalize_kanji: true,
-    normalize_kana: true,
-  })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendCharacterFilter("japanese_iteration_mark", {
+  normalize_kanji: true,
+  normalize_kana: true,
+});
+const tokenizer = builder.build();
 ```
 
 ## Token Filters
@@ -74,10 +74,10 @@ Token filters transform or remove tokens after tokenization.
 Converts token surface forms to lowercase.
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendTokenFilter("lowercase", {})
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendTokenFilter("lowercase", {});
+const tokenizer = builder.build();
 ```
 
 ### japanese_base_form
@@ -85,10 +85,10 @@ const tokenizer = new TokenizerBuilder()
 Replaces inflected forms with their base (dictionary) form using the morphological details from the dictionary.
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendTokenFilter("japanese_base_form", {})
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendTokenFilter("japanese_base_form", {});
+const tokenizer = builder.build();
 ```
 
 ### japanese_stop_tags
@@ -96,25 +96,32 @@ const tokenizer = new TokenizerBuilder()
 Removes tokens whose part-of-speech matches any of the specified tags.
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendTokenFilter("japanese_stop_tags", {
-    tags: ["助詞", "助動詞"],
-  })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendTokenFilter("japanese_stop_tags", {
+  tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"],
+});
+const tokenizer = builder.build();
 ```
+
+> [!NOTE]
+> Tags are normalized to exactly four comma-separated levels (missing levels are padded with `*`)
+> and compared for exact equality against the first four part-of-speech details of each token.
+> A bare `助詞` therefore never matches IPADIC particle tokens — they always carry a subcategory
+> such as `助詞,係助詞` — while a bare `助動詞` does match, because auxiliary verbs have no
+> subcategory (`助動詞,*,*,*`).
 
 ### japanese_keep_tags
 
-Keeps only tokens whose part-of-speech matches one of the specified tags. All other tokens are removed.
+Keeps only tokens whose part-of-speech matches one of the specified tags. All other tokens are removed. The following keeps only general nouns:
 
 ```javascript
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("embedded://ipadic")
-  .appendTokenFilter("japanese_keep_tags", {
-    tags: ["名詞"],
-  })
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("embedded://ipadic");
+builder.appendTokenFilter("japanese_keep_tags", {
+  tags: ["名詞,一般"],
+});
+const tokenizer = builder.build();
 ```
 
 ## Complete Pipeline Example
@@ -124,22 +131,22 @@ The following example combines multiple character filters and token filters into
 ```javascript
 const { TokenizerBuilder } = require("lindera");
 
-const tokenizer = new TokenizerBuilder()
-  .setMode("normal")
-  .setDictionary("embedded://ipadic")
-  // Preprocessing
-  .appendCharacterFilter("unicode_normalize", { kind: "nfkc" })
-  .appendCharacterFilter("japanese_iteration_mark", {
-    normalize_kanji: true,
-    normalize_kana: true,
-  })
-  // Postprocessing
-  .appendTokenFilter("japanese_base_form", {})
-  .appendTokenFilter("japanese_stop_tags", {
-    tags: ["助詞", "助動詞", "記号"],
-  })
-  .appendTokenFilter("lowercase", {})
-  .build();
+const builder = new TokenizerBuilder();
+builder.setMode("normal");
+builder.setDictionary("embedded://ipadic");
+// Preprocessing
+builder.appendCharacterFilter("unicode_normalize", { kind: "nfkc" });
+builder.appendCharacterFilter("japanese_iteration_mark", {
+  normalize_kanji: true,
+  normalize_kana: true,
+});
+// Postprocessing
+builder.appendTokenFilter("japanese_base_form", {});
+builder.appendTokenFilter("japanese_stop_tags", {
+  tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"],
+});
+builder.appendTokenFilter("lowercase", {});
+const tokenizer = builder.build();
 
 const tokens = tokenizer.tokenize("Ｌｉｎｄｅｒａは形態素解析を行うライブラリです。");
 for (const token of tokens) {
@@ -152,5 +159,5 @@ In this pipeline:
 1. `unicode_normalize` converts full-width characters to half-width (NFKC normalization)
 2. `japanese_iteration_mark` resolves iteration marks
 3. `japanese_base_form` converts inflected tokens to base form
-4. `japanese_stop_tags` removes particles, auxiliary verbs, and symbols
+4. `japanese_stop_tags` removes particles, auxiliary verbs, and punctuation
 5. `lowercase` normalizes alphabetic characters to lowercase

--- a/docs/src/lindera-nodejs/tokenizer_api.md
+++ b/docs/src/lindera-nodejs/tokenizer_api.md
@@ -28,7 +28,7 @@ See [`lindera-nodejs/resources/lindera.yml`](https://github.com/lindera/lindera/
 
 ### Configuration Methods
 
-All setter methods return `this` for method chaining.
+Setter methods return `undefined` (not `this`), so they cannot be chained — call them individually on the builder instance.
 
 #### `setMode(mode)`
 

--- a/docs/src/lindera-nodejs/training.md
+++ b/docs/src/lindera-nodejs/training.md
@@ -121,10 +121,10 @@ const metadata = Metadata.fromJsonFile("/tmp/dictionary_source/metadata.json");
 buildDictionary("/tmp/dictionary_source", "/tmp/dictionary", metadata);
 
 // Step 4: Use the trained dictionary
-const tokenizer = new TokenizerBuilder()
-  .setDictionary("/tmp/dictionary")
-  .setMode("normal")
-  .build();
+const builder = new TokenizerBuilder();
+builder.setDictionary("/tmp/dictionary");
+builder.setMode("normal");
+const tokenizer = builder.build();
 
 const tokens = tokenizer.tokenize("形態素解析のテスト");
 for (const token of tokens) {

--- a/docs/src/lindera-php/text_processing_pipeline.md
+++ b/docs/src/lindera-php/text_processing_pipeline.md
@@ -121,14 +121,21 @@ Removes tokens whose part-of-speech matches any of the specified tags.
 $builder = new Lindera\TokenizerBuilder();
 $builder->setDictionary('embedded://ipadic');
 $builder->appendTokenFilter('japanese_stop_tags', [
-    'tags' => ['助詞', '助動詞'],
+    'tags' => ['助詞,格助詞,一般', '助詞,係助詞', '助詞,連体化', '助動詞'],
 ]);
 $tokenizer = $builder->build();
 ```
 
+> [!NOTE]
+> Tags are normalized to exactly four comma-separated levels (missing levels are padded with `*`)
+> and compared for exact equality against the first four part-of-speech details of each token.
+> A bare `助詞` therefore never matches IPADIC particle tokens — they always carry a subcategory
+> such as `助詞,係助詞` — while a bare `助動詞` does match, because auxiliary verbs have no
+> subcategory (`助動詞,*,*,*`).
+
 ### japanese_keep_tags
 
-Keeps only tokens whose part-of-speech matches one of the specified tags. All other tokens are removed.
+Keeps only tokens whose part-of-speech matches one of the specified tags. All other tokens are removed. The following keeps only general nouns:
 
 ```php
 <?php
@@ -136,7 +143,7 @@ Keeps only tokens whose part-of-speech matches one of the specified tags. All ot
 $builder = new Lindera\TokenizerBuilder();
 $builder->setDictionary('embedded://ipadic');
 $builder->appendTokenFilter('japanese_keep_tags', [
-    'tags' => ['名詞'],
+    'tags' => ['名詞,一般'],
 ]);
 $tokenizer = $builder->build();
 ```
@@ -168,7 +175,7 @@ $builder->appendTokenFilter('japanese_stop_tags', [
     'tags' => [
         '接続詞',
         '助詞',
-        '助詞,格助詞',
+        '助詞,格助詞,一般',
         '助詞,格助詞,一般',
         '助詞,係助詞',
         '助詞,副助詞',

--- a/docs/src/lindera-python/text_processing_pipeline.md
+++ b/docs/src/lindera-python/text_processing_pipeline.md
@@ -104,22 +104,24 @@ tokenizer = (
     TokenizerBuilder()
     .set_dictionary("embedded://ipadic")
     .append_token_filter("japanese_stop_tags", {
-        "tags": ["助詞", "助動詞"],
+        "tags": ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"],
     })
     .build()
 )
 ```
 
+Tags are normalized to exactly four comma-separated levels (missing levels are padded with `*`) and compared for exact equality against the first four part-of-speech details of each token. A bare `助詞` therefore never matches IPADIC particle tokens — they always carry a subcategory such as `助詞,係助詞` — while a bare `助動詞` does match, because auxiliary verbs have no subcategory (`助動詞,*,*,*`).
+
 ### japanese_keep_tags
 
-Keeps only tokens whose part-of-speech matches one of the specified tags. All other tokens are removed.
+Keeps only tokens whose part-of-speech matches one of the specified tags. All other tokens are removed. The following keeps only general nouns:
 
 ```python
 tokenizer = (
     TokenizerBuilder()
     .set_dictionary("embedded://ipadic")
     .append_token_filter("japanese_keep_tags", {
-        "tags": ["名詞"],
+        "tags": ["名詞,一般"],
     })
     .build()
 )
@@ -145,7 +147,7 @@ tokenizer = (
     # Postprocessing
     .append_token_filter("japanese_base_form", {})
     .append_token_filter("japanese_stop_tags", {
-        "tags": ["助詞", "助動詞", "記号"],
+        "tags": ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"],
     })
     .append_token_filter("lowercase", {})
     .build()
@@ -161,5 +163,5 @@ In this pipeline:
 1. `unicode_normalize` converts full-width characters to half-width (NFKC normalization)
 2. `japanese_iteration_mark` resolves iteration marks
 3. `japanese_base_form` converts inflected tokens to base form
-4. `japanese_stop_tags` removes particles, auxiliary verbs, and symbols
+4. `japanese_stop_tags` removes particles, auxiliary verbs, and punctuation
 5. `lowercase` normalizes alphabetic characters to lowercase

--- a/docs/src/lindera-ruby/text_processing_pipeline.md
+++ b/docs/src/lindera-ruby/text_processing_pipeline.md
@@ -99,20 +99,27 @@ Removes tokens whose part-of-speech matches any of the specified tags.
 builder = Lindera::TokenizerBuilder.new
 builder.set_dictionary('embedded://ipadic')
 builder.append_token_filter('japanese_stop_tags', {
-  'tags' => ['助詞', '助動詞']
+  'tags' => ['助詞,格助詞,一般', '助詞,係助詞', '助詞,連体化', '助動詞']
 })
 tokenizer = builder.build
 ```
 
+> [!NOTE]
+> Tags are normalized to exactly four comma-separated levels (missing levels are padded with `*`)
+> and compared for exact equality against the first four part-of-speech details of each token.
+> A bare `助詞` therefore never matches IPADIC particle tokens — they always carry a subcategory
+> such as `助詞,係助詞` — while a bare `助動詞` does match, because auxiliary verbs have no
+> subcategory (`助動詞,*,*,*`).
+
 ### japanese_keep_tags
 
-Keeps only tokens whose part-of-speech matches one of the specified tags. All other tokens are removed.
+Keeps only tokens whose part-of-speech matches one of the specified tags. All other tokens are removed. The following keeps only general nouns:
 
 ```ruby
 builder = Lindera::TokenizerBuilder.new
 builder.set_dictionary('embedded://ipadic')
 builder.append_token_filter('japanese_keep_tags', {
-  'tags' => ['名詞']
+  'tags' => ['名詞,一般']
 })
 tokenizer = builder.build
 ```
@@ -149,7 +156,7 @@ builder.append_character_filter('japanese_iteration_mark', {
 # Postprocessing
 builder.append_token_filter('japanese_base_form', nil)
 builder.append_token_filter('japanese_stop_tags', {
-  'tags' => ['助詞', '助動詞', '記号']
+  'tags' => ['助詞,格助詞,一般', '助詞,係助詞', '助詞,連体化', '助動詞', '記号,句点', '記号,読点']
 })
 builder.append_token_filter('lowercase', nil)
 
@@ -166,5 +173,5 @@ In this pipeline:
 1. `unicode_normalize` converts full-width characters to half-width (NFKC normalization)
 2. `japanese_iteration_mark` resolves iteration marks
 3. `japanese_base_form` converts inflected tokens to base form
-4. `japanese_stop_tags` removes particles, auxiliary verbs, and symbols
+4. `japanese_stop_tags` removes particles, auxiliary verbs, and punctuation
 5. `lowercase` normalizes alphabetic characters to lowercase

--- a/docs/src/lindera-wasm/quickstart.md
+++ b/docs/src/lindera-wasm/quickstart.md
@@ -105,7 +105,7 @@ async function main() {
 
     // Add a stop-tags filter to remove particles and auxiliary verbs
     builder.appendTokenFilter("japanese_stop_tags", {
-        tags: ["助詞", "助動詞"]
+        tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"]
     });
 
     const tokenizer = builder.build();

--- a/docs/src/lindera-wasm/tokenizer_api.md
+++ b/docs/src/lindera-wasm/tokenizer_api.md
@@ -101,7 +101,7 @@ Appends a token filter to the postprocessing pipeline.
 
 ```javascript
 builder.appendTokenFilter("japanese_stop_tags", {
-    tags: ["助詞", "助動詞", "記号"]
+    tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"]
 });
 ```
 

--- a/lindera-nodejs/README.md
+++ b/lindera-nodejs/README.md
@@ -160,7 +160,9 @@ builder.setDictionary("/path/to/ipadic");
 // Add token filters
 builder.appendTokenFilter("lowercase");
 builder.appendTokenFilter("length", { min: 2, max: 10 });
-builder.appendTokenFilter("japanese_stop_tags", { tags: ["助詞", "助動詞"] });
+builder.appendTokenFilter("japanese_stop_tags", {
+  tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"],
+});
 
 // Build tokenizer with filters
 const tokenizer = builder.build();
@@ -231,7 +233,7 @@ builder.appendCharacterFilter("mapping", {
 builder.appendTokenFilter("japanese_katakana_stem", { min: 3 });
 builder.appendTokenFilter("length", { min: 2, max: 10 });
 builder.appendTokenFilter("japanese_stop_tags", {
-  tags: ["助詞", "助動詞", "記号"],
+  tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"],
 });
 
 // Filters without configuration can omit the object

--- a/lindera-nodejs/README_ja.md
+++ b/lindera-nodejs/README_ja.md
@@ -161,7 +161,9 @@ builder.setDictionary("/path/to/ipadic");
 // Add token filters
 builder.appendTokenFilter("lowercase");
 builder.appendTokenFilter("length", { min: 2, max: 10 });
-builder.appendTokenFilter("japanese_stop_tags", { tags: ["助詞", "助動詞"] });
+builder.appendTokenFilter("japanese_stop_tags", {
+  tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"],
+});
 
 // Build tokenizer with filters
 const tokenizer = builder.build();
@@ -232,7 +234,7 @@ builder.appendCharacterFilter("mapping", {
 builder.appendTokenFilter("japanese_katakana_stem", { min: 3 });
 builder.appendTokenFilter("length", { min: 2, max: 10 });
 builder.appendTokenFilter("japanese_stop_tags", {
-  tags: ["助詞", "助動詞", "記号"],
+  tags: ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"],
 });
 
 // Filters without configuration can omit the object

--- a/lindera-php/README.md
+++ b/lindera-php/README.md
@@ -89,7 +89,7 @@ $tokenizer = $builder->build();
 $builder = new Lindera\TokenizerBuilder();
 $builder->set_mode("normal");
 $builder->append_character_filter("unicode_normalize", ["kind" => "nfkc"]);
-$builder->append_token_filter("japanese_stop_tags", ["tags" => ["助詞"]]);
+$builder->append_token_filter("japanese_stop_tags", ["tags" => ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"]]);
 $tokenizer = $builder->build();
 ```
 

--- a/lindera-php/README_ja.md
+++ b/lindera-php/README_ja.md
@@ -89,7 +89,9 @@ $tokenizer = $builder->build();
 $builder = new Lindera\TokenizerBuilder();
 $builder->set_mode("normal");
 $builder->append_character_filter("unicode_normalize", ["kind" => "nfkc"]);
-$builder->append_token_filter("japanese_stop_tags", ["tags" => ["助詞"]]);
+$builder->append_token_filter("japanese_stop_tags", [
+    "tags" => ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"],
+]);
 $tokenizer = $builder->build();
 ```
 

--- a/lindera-python/README.md
+++ b/lindera-python/README.md
@@ -155,7 +155,9 @@ builder.set_dictionary("/path/to/ipadic")
 # Add token filters
 builder.append_token_filter("lowercase")
 builder.append_token_filter("length", {"min": 2, "max": 10})
-builder.append_token_filter("japanese_stop_tags", {"tags": ["助詞", "助動詞"]})
+builder.append_token_filter("japanese_stop_tags", {
+    "tags": ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"]
+})
 
 # Build tokenizer with filters
 tokenizer = builder.build()
@@ -227,7 +229,7 @@ builder.append_character_filter("mapping", {
 builder.append_token_filter("japanese_katakana_stem", {"min": 3})
 builder.append_token_filter("length", {"min": 2, "max": 10})
 builder.append_token_filter("japanese_stop_tags", {
-    "tags": ["助詞", "助動詞", "記号"]
+    "tags": ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"]
 })
 
 # Filters without configuration can omit the dict

--- a/lindera-python/README_ja.md
+++ b/lindera-python/README_ja.md
@@ -155,7 +155,9 @@ builder.set_dictionary("/path/to/ipadic")
 # Add token filters
 builder.append_token_filter("lowercase")
 builder.append_token_filter("length", {"min": 2, "max": 10})
-builder.append_token_filter("japanese_stop_tags", {"tags": ["助詞", "助動詞"]})
+builder.append_token_filter("japanese_stop_tags", {
+    "tags": ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"]
+})
 
 # Build tokenizer with filters
 tokenizer = builder.build()
@@ -227,7 +229,7 @@ builder.append_character_filter("mapping", {
 builder.append_token_filter("japanese_katakana_stem", {"min": 3})
 builder.append_token_filter("length", {"min": 2, "max": 10})
 builder.append_token_filter("japanese_stop_tags", {
-    "tags": ["助詞", "助動詞", "記号"]
+    "tags": ["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞", "記号,句点", "記号,読点"]
 })
 
 # Filters without configuration can omit the dict


### PR DESCRIPTION
Closes #992
Refs #993

## Summary

While verifying the v6.0.0 package renames (#987) by executing the documentation samples, several pre-existing documentation bugs surfaced. This PR fixes all of them (33 files, en + ja). Every fixed sample was verified by execution: Node.js against a locally packed npm install (`napi create-npm-dirs` + `npm pack` + tarball install), Python in the maturin-develop venv, TypeScript with `tsc --moduleResolution node16 --strict`, and the CLI with the release binary against downloaded IPADIC.

## Fixes

1. **Node.js method chaining does not exist** — setters return `undefined` (`()` / `Result<()>`), so chained samples throw `TypeError`. Rewrote 15 snippets per language to sequential calls, removed the quickstart "Method Chaining" section, and corrected the `tokenizer_api.md` claim that setters return `this`. Python setters DO return `self` (verified), so Python samples are untouched; chaining parity for Node.js/WASM is proposed in #993.
2. **Stale unknown-word output** — quickstart claimed `トートバッグ` yields `UNK`; v6 emits the unk.def details (`名詞,一般,*,*,*,*,*,*,*`).
3. **Stale ESM guidance** — installation.md claimed the `exports` map has no `import` condition and prescribed `createRequire`; the map now declares `types`/`import`/`require`, and `import { TokenizerBuilder } from "lindera"` works at runtime and type-checks strict under node16 resolution (both verified). Replaced with a plain-import sample.
4. **Ineffective `japanese_stop_tags` samples** — tags are normalized to exactly 4 comma-separated levels padded with `*` and compared for exact equality against the token's first 4 POS details. Bare `助詞` never matches (particles always carry a subcategory) and neither does the two-level `助詞,格助詞` (case particles carry a third level, e.g. `助詞,格助詞,一般`). Replaced with verified working sets (e.g. `["助詞,格助詞,一般", "助詞,係助詞", "助詞,連体化", "助動詞"]`, plus `記号,句点`/`記号,読点` in the pipeline examples) and added a note documenting the matching semantics next to the filter references.
5. **Destructive `japanese_keep_tags` samples** — `["名詞"]` matches no IPADIC token, so the sample removed every token (verified: empty output). Replaced with `["名詞,一般"]` and friends.
6. **Stale CLI tutorial expected output** (found during verification) — the keep_tags example's documented output included `解析 (名詞,サ変接続)`, which the tags did not keep; added `名詞,サ変接続` so the real CLI output matches the doc byte-for-byte (verified).

Deliberately unchanged: `resources/config/lindera.yml` and its `configuration.md` mirror (the Kuromoji-style list carries full paths alongside redundant prefix entries, so it works as shipped); `korean_stop_tags`/`korean_keep_tags` samples (that filter compares only the first POS field — different, working semantics); Python chained builders.

## Verification

- Node.js: every quickstart code block and the stop/keep/pipeline samples extracted verbatim from the updated docs and executed — outputs match the documented expected outputs; TypeScript sample compiles under `--strict` + node16 and runs
- Python: fixed tag sets + chained builder verified in the venv
- CLI: both tutorial commands executed; output matches the documented blocks exactly
- `markdownlint-cli2` on docs/src + docs/ja/src: 208 files, 0 errors; `mdbook build docs` succeeds