### PR TITLE
feat(bindings): return the builder from TokenizerBuilder setters

### DIFF
--- a/docs/ja/src/lindera-nodejs/quickstart.md
+++ b/docs/ja/src/lindera-nodejs/quickstart.md
@@ -30,6 +30,26 @@ for (const token of tokens) {
 トートバッグ    名詞,一般,*,*,*,*,*,*,*
 ```
 
+## メソッドチェーン
+
+すべてのセッターはビルダー自身（`this`）を返すため、設定をチェーンして記述できます：
+
+```javascript
+const { TokenizerBuilder } = require("lindera");
+
+const tokenizer = new TokenizerBuilder()
+  .setMode("normal")
+  .setDictionary("/path/to/ipadic")
+  .build();
+
+const tokens = tokenizer.tokenize("すもももももももものうち");
+for (const token of tokens) {
+  console.log(`${token.surface}\t${token.details[0]}`);
+}
+```
+
+1 文ずつセッターを呼び出すスタイルもそのまま使えます。どちらのスタイルでも同じビルダーを設定します。
+
 ## トークンプロパティへのアクセス
 
 各トークンは以下のプロパティを公開しています：

--- a/docs/ja/src/lindera-nodejs/tokenizer_api.md
+++ b/docs/ja/src/lindera-nodejs/tokenizer_api.md
@@ -30,7 +30,7 @@ const builder = new TokenizerBuilder().fromFile("lindera.yml");
 
 ### 設定メソッド
 
-セッターメソッドは `this` ではなく `undefined` を返すため、メソッドチェーンはできません。ビルダーインスタンスに対して個別に呼び出してください。
+すべてのセッターメソッドはビルダー自身（`this`）を返すため、メソッドチェーンでも 1 文ずつの呼び出しでも設定できます。
 
 #### `setMode(mode)`
 

--- a/docs/ja/src/lindera-wasm/tokenizer_api.md
+++ b/docs/ja/src/lindera-wasm/tokenizer_api.md
@@ -16,6 +16,10 @@ const builder = new TokenizerBuilder();
 
 ### メソッド
 
+すべてのセッターは同じ設定を共有するビルダーハンドルを返すため、
+`builder.setMode("normal").setDictionary(...)` のようにチェーンでも、1 文ずつでも記述できます。
+返されるハンドルは新しいオブジェクトですが、設定先は同一のビルダーです。
+
 #### `setMode(mode)`
 
 トークナイズモードを設定します。
@@ -108,7 +112,7 @@ builder.appendTokenFilter("japanese_stop_tags", {
 
 #### `build()`
 
-設定済みの `Tokenizer` インスタンスをビルドして返します。ビルダーは消費されます。
+設定済みの `Tokenizer` インスタンスをビルドして返します。ビルド後もビルダーはそのまま使えるため、同じ設定から複数のトークナイザーをビルドできます。
 
 - **戻り値**: `Tokenizer`
 

--- a/docs/src/lindera-nodejs/quickstart.md
+++ b/docs/src/lindera-nodejs/quickstart.md
@@ -30,6 +30,28 @@ Expected output:
 トートバッグ    名詞,一般,*,*,*,*,*,*,*
 ```
 
+## Method Chaining
+
+Every setter returns the builder itself (`this`), so the configuration can be
+chained:
+
+```javascript
+const { TokenizerBuilder } = require("lindera");
+
+const tokenizer = new TokenizerBuilder()
+  .setMode("normal")
+  .setDictionary("/path/to/ipadic")
+  .build();
+
+const tokens = tokenizer.tokenize("すもももももももものうち");
+for (const token of tokens) {
+  console.log(`${token.surface}\t${token.details[0]}`);
+}
+```
+
+Calling the setters one statement at a time works just as well — both styles
+configure the same builder.
+
 ## Accessing Token Properties
 
 Each token exposes the following properties:

--- a/docs/src/lindera-nodejs/tokenizer_api.md
+++ b/docs/src/lindera-nodejs/tokenizer_api.md
@@ -28,7 +28,7 @@ See [`lindera-nodejs/resources/lindera.yml`](https://github.com/lindera/lindera/
 
 ### Configuration Methods
 
-Setter methods return `undefined` (not `this`), so they cannot be chained — call them individually on the builder instance.
+All setter methods return the builder itself (`this`), so they can be chained or called one statement at a time.
 
 #### `setMode(mode)`
 

--- a/docs/src/lindera-wasm/tokenizer_api.md
+++ b/docs/src/lindera-wasm/tokenizer_api.md
@@ -16,6 +16,11 @@ Creates a new builder with default settings.
 
 ### Methods
 
+Every setter returns a builder handle that shares the same configuration, so
+the calls can be chained (`builder.setMode("normal").setDictionary(...)`) or
+made one statement at a time. The returned handle is a new object, but it
+configures the same underlying builder.
+
 #### `setMode(mode)`
 
 Sets the tokenization mode.
@@ -107,7 +112,9 @@ builder.appendTokenFilter("japanese_stop_tags", {
 
 #### `build()`
 
-Builds and returns a configured `Tokenizer` instance. Consumes the builder.
+Builds and returns a configured `Tokenizer` instance. The builder remains
+usable afterwards, so multiple tokenizers can be built from the same
+configuration.
 
 - **Returns**: `Tokenizer`
 

--- a/lindera-nodejs/index.d.ts
+++ b/lindera-nodejs/index.d.ts
@@ -282,32 +282,48 @@ export declare class TokenizerBuilder {
    * # Arguments
    *
    * * `mode` - Mode string ("normal" or "decompose").
+   *
+   * # Returns
+   *
+   * The builder itself (`this`), enabling method chaining.
    */
-  setMode(mode: string): void
+  setMode(mode: string): this
   /**
    * Sets the dictionary path or URI.
    *
    * # Arguments
    *
    * * `path` - Path to the dictionary directory or embedded URI (e.g. "embedded://ipadic").
+   *
+   * # Returns
+   *
+   * The builder itself (`this`), enabling method chaining.
    */
-  setDictionary(path: string): void
+  setDictionary(path: string): this
   /**
    * Sets the user dictionary URI.
    *
    * # Arguments
    *
    * * `uri` - URI to the user dictionary.
+   *
+   * # Returns
+   *
+   * The builder itself (`this`), enabling method chaining.
    */
-  setUserDictionary(uri: string): void
+  setUserDictionary(uri: string): this
   /**
    * Sets whether to keep whitespace in tokenization results.
    *
    * # Arguments
    *
    * * `keep_whitespace` - If true, whitespace tokens will be included in results.
+   *
+   * # Returns
+   *
+   * The builder itself (`this`), enabling method chaining.
    */
-  setKeepWhitespace(keepWhitespace: boolean): void
+  setKeepWhitespace(keepWhitespace: boolean): this
   /**
    * Appends a character filter to the preprocessing pipeline.
    *
@@ -315,8 +331,12 @@ export declare class TokenizerBuilder {
    *
    * * `kind` - Type of character filter to add (e.g. "unicode_normalize", "mapping").
    * * `args` - Optional filter arguments as a JSON-compatible object.
+   *
+   * # Returns
+   *
+   * The builder itself (`this`), enabling method chaining.
    */
-  appendCharacterFilter(kind: string, args?: any | undefined | null): void
+  appendCharacterFilter(kind: string, args?: any | undefined | null): this
   /**
    * Appends a token filter to the postprocessing pipeline.
    *
@@ -324,8 +344,12 @@ export declare class TokenizerBuilder {
    *
    * * `kind` - Type of token filter to add (e.g. "lowercase", "japanese_stop_tags").
    * * `args` - Optional filter arguments as a JSON-compatible object.
+   *
+   * # Returns
+   *
+   * The builder itself (`this`), enabling method chaining.
    */
-  appendTokenFilter(kind: string, args?: any | undefined | null): void
+  appendTokenFilter(kind: string, args?: any | undefined | null): this
   /**
    * Builds the tokenizer with the configured settings.
    *

--- a/lindera-nodejs/src/tokenizer.rs
+++ b/lindera-nodejs/src/tokenizer.rs
@@ -140,11 +140,7 @@ impl JsTokenizerBuilder {
     ///
     /// The builder itself (`this`), enabling method chaining.
     #[napi]
-    pub fn append_token_filter(
-        &mut self,
-        kind: String,
-        args: Option<serde_json::Value>,
-    ) -> &Self {
+    pub fn append_token_filter(&mut self, kind: String, args: Option<serde_json::Value>) -> &Self {
         let filter_args = js_value_to_serde_value(args);
         self.inner.append_token_filter(&kind, &filter_args);
         self

--- a/lindera-nodejs/src/tokenizer.rs
+++ b/lindera-nodejs/src/tokenizer.rs
@@ -53,10 +53,14 @@ impl JsTokenizerBuilder {
     /// # Arguments
     ///
     /// * `mode` - Mode string ("normal" or "decompose").
+    ///
+    /// # Returns
+    ///
+    /// The builder itself (`this`), enabling method chaining.
     #[napi]
-    pub fn set_mode(&mut self, mode: String) -> napi::Result<()> {
+    pub fn set_mode(&mut self, mode: String) -> napi::Result<&Self> {
         self.inner.set_mode(&mode).map_err(to_napi_error)?;
-        Ok(())
+        Ok(self)
     }
 
     /// Sets the dictionary path or URI.
@@ -64,9 +68,14 @@ impl JsTokenizerBuilder {
     /// # Arguments
     ///
     /// * `path` - Path to the dictionary directory or embedded URI (e.g. "embedded://ipadic").
+    ///
+    /// # Returns
+    ///
+    /// The builder itself (`this`), enabling method chaining.
     #[napi]
-    pub fn set_dictionary(&mut self, path: String) {
+    pub fn set_dictionary(&mut self, path: String) -> &Self {
         self.inner.set_dictionary(&path);
+        self
     }
 
     /// Sets the user dictionary URI.
@@ -74,9 +83,14 @@ impl JsTokenizerBuilder {
     /// # Arguments
     ///
     /// * `uri` - URI to the user dictionary.
+    ///
+    /// # Returns
+    ///
+    /// The builder itself (`this`), enabling method chaining.
     #[napi]
-    pub fn set_user_dictionary(&mut self, uri: String) {
+    pub fn set_user_dictionary(&mut self, uri: String) -> &Self {
         self.inner.set_user_dictionary(&uri);
+        self
     }
 
     /// Sets whether to keep whitespace in tokenization results.
@@ -84,9 +98,14 @@ impl JsTokenizerBuilder {
     /// # Arguments
     ///
     /// * `keep_whitespace` - If true, whitespace tokens will be included in results.
+    ///
+    /// # Returns
+    ///
+    /// The builder itself (`this`), enabling method chaining.
     #[napi]
-    pub fn set_keep_whitespace(&mut self, keep_whitespace: bool) {
+    pub fn set_keep_whitespace(&mut self, keep_whitespace: bool) -> &Self {
         self.inner.set_keep_whitespace(keep_whitespace);
+        self
     }
 
     /// Appends a character filter to the preprocessing pipeline.
@@ -95,15 +114,19 @@ impl JsTokenizerBuilder {
     ///
     /// * `kind` - Type of character filter to add (e.g. "unicode_normalize", "mapping").
     /// * `args` - Optional filter arguments as a JSON-compatible object.
+    ///
+    /// # Returns
+    ///
+    /// The builder itself (`this`), enabling method chaining.
     #[napi]
     pub fn append_character_filter(
         &mut self,
         kind: String,
         args: Option<serde_json::Value>,
-    ) -> napi::Result<()> {
+    ) -> &Self {
         let filter_args = js_value_to_serde_value(args);
         self.inner.append_character_filter(&kind, &filter_args);
-        Ok(())
+        self
     }
 
     /// Appends a token filter to the postprocessing pipeline.
@@ -112,15 +135,19 @@ impl JsTokenizerBuilder {
     ///
     /// * `kind` - Type of token filter to add (e.g. "lowercase", "japanese_stop_tags").
     /// * `args` - Optional filter arguments as a JSON-compatible object.
+    ///
+    /// # Returns
+    ///
+    /// The builder itself (`this`), enabling method chaining.
     #[napi]
     pub fn append_token_filter(
         &mut self,
         kind: String,
         args: Option<serde_json::Value>,
-    ) -> napi::Result<()> {
+    ) -> &Self {
         let filter_args = js_value_to_serde_value(args);
         self.inner.append_token_filter(&kind, &filter_args);
-        Ok(())
+        self
     }
 
     /// Builds the tokenizer with the configured settings.

--- a/lindera-nodejs/tests/test_builder_chaining.js
+++ b/lindera-nodejs/tests/test_builder_chaining.js
@@ -1,0 +1,59 @@
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+
+const { TokenizerBuilder, loadDictionary } = require("../index.js");
+
+// Matches the guard in test_tokenize_ipadic.js: the embedded dictionary is behind the
+// `embed-ipadic` feature, which is not on by default.
+const hasEmbeddedIpadic = (() => {
+  try {
+    loadDictionary("embedded://ipadic");
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe("TokenizerBuilder method chaining", () => {
+  it("every setter returns the same builder instance", () => {
+    const builder = new TokenizerBuilder();
+    assert.strictEqual(builder.setMode("normal"), builder);
+    assert.strictEqual(builder.setDictionary("/tmp/nonexistent"), builder);
+    assert.strictEqual(builder.setUserDictionary("/tmp/nonexistent"), builder);
+    assert.strictEqual(builder.setKeepWhitespace(true), builder);
+    assert.strictEqual(builder.appendCharacterFilter("unicode_normalize", { kind: "nfkc" }), builder);
+    assert.strictEqual(builder.appendTokenFilter("lowercase", {}), builder);
+  });
+
+  it("setMode rejects an invalid mode even when chained", () => {
+    const builder = new TokenizerBuilder();
+    assert.throws(() => builder.setMode("no_such_mode"));
+  });
+
+  it("builds and tokenizes through a full chain", {
+    skip: !hasEmbeddedIpadic && "embedded://ipadic not available"
+  }, () => {
+    const tokenizer = new TokenizerBuilder()
+      .setMode("normal")
+      .setDictionary("embedded://ipadic")
+      .appendTokenFilter("japanese_stop_tags", {
+        tags: ["助詞,係助詞", "助詞,連体化"],
+      })
+      .build();
+
+    const surfaces = tokenizer.tokenize("すもももももももものうち").map((t) => t.surface);
+    assert.deepStrictEqual(surfaces, ["すもも", "もも", "もも", "うち"]);
+  });
+
+  it("keeps the sequential (non-chained) style working", {
+    skip: !hasEmbeddedIpadic && "embedded://ipadic not available"
+  }, () => {
+    const builder = new TokenizerBuilder();
+    builder.setMode("normal");
+    builder.setDictionary("embedded://ipadic");
+    const tokenizer = builder.build();
+
+    const surfaces = tokenizer.tokenize("日本語").map((t) => t.surface);
+    assert.ok(surfaces.length > 0);
+  });
+});

--- a/lindera-wasm/src/lib.rs
+++ b/lindera-wasm/src/lib.rs
@@ -18,7 +18,7 @@
 //! ### Web (Browser)
 //!
 //! ```javascript
-//! import __wbg_init, { TokenizerBuilder } from 'lindera-wasm-web-ipadic';
+//! import __wbg_init, { TokenizerBuilder } from 'lindera-wasm';
 //!
 //! __wbg_init().then(() => {
 //!     const builder = new TokenizerBuilder();

--- a/lindera-wasm/src/tokenizer.rs
+++ b/lindera-wasm/src/tokenizer.rs
@@ -154,7 +154,10 @@ impl TokenizerBuilder {
     ///
     /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "setUserDictionaryInstance")]
-    pub fn set_user_dictionary_instance(&self, user_dictionary: JsUserDictionary) -> TokenizerBuilder {
+    pub fn set_user_dictionary_instance(
+        &self,
+        user_dictionary: JsUserDictionary,
+    ) -> TokenizerBuilder {
         self.state.borrow_mut().user_dictionary_instance = Some(user_dictionary);
 
         self.share()
@@ -174,9 +177,16 @@ impl TokenizerBuilder {
     ///
     /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "appendCharacterFilter")]
-    pub fn append_character_filter(&self, name: &str, args: JsValue) -> Result<TokenizerBuilder, JsValue> {
+    pub fn append_character_filter(
+        &self,
+        name: &str,
+        args: JsValue,
+    ) -> Result<TokenizerBuilder, JsValue> {
         let a = parse_filter_args(args)?;
-        self.state.borrow_mut().inner.append_character_filter(name, &a);
+        self.state
+            .borrow_mut()
+            .inner
+            .append_character_filter(name, &a);
 
         Ok(self.share())
     }
@@ -185,7 +195,11 @@ impl TokenizerBuilder {
     ///
     /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "appendTokenFilter")]
-    pub fn append_token_filter(&self, name: &str, args: JsValue) -> Result<TokenizerBuilder, JsValue> {
+    pub fn append_token_filter(
+        &self,
+        name: &str,
+        args: JsValue,
+    ) -> Result<TokenizerBuilder, JsValue> {
         let a = parse_filter_args(args)?;
         self.state.borrow_mut().inner.append_token_filter(name, &a);
 
@@ -479,7 +493,9 @@ mod tests {
             .build()
             .unwrap();
 
-        let surfaces = tokenizer.tokenize_surfaces("すもももももももものうち").unwrap();
+        let surfaces = tokenizer
+            .tokenize_surfaces("すもももももももものうち")
+            .unwrap();
         assert_eq!(surfaces.len(), 7);
         assert_eq!(surfaces[0], "すもも");
     }

--- a/lindera-wasm/src/tokenizer.rs
+++ b/lindera-wasm/src/tokenizer.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use serde_json::Value;
 use wasm_bindgen::prelude::*;
 
@@ -15,14 +18,8 @@ fn parse_filter_args(args: JsValue) -> Result<Value, JsValue> {
     }
 }
 
-/// Builder for creating a [`Tokenizer`] instance.
-///
-/// `TokenizerBuilder` provides a fluent API for configuring and building a tokenizer
-/// with various options such as dictionary selection, tokenization mode, character filters,
-/// and token filters. The build-flow orchestration is delegated to
-/// [`lindera_binding_core::CoreTokenizerBuilder`].
-#[wasm_bindgen]
-pub struct TokenizerBuilder {
+/// Mutable builder configuration shared between chained builder handles.
+struct BuilderState {
     /// The backing binding-core builder (used for URI-based dictionary loading).
     inner: CoreTokenizerBuilder,
     /// Pre-loaded dictionary instance, used instead of URI-based loading.
@@ -33,6 +30,23 @@ pub struct TokenizerBuilder {
     mode_for_instance: Option<String>,
 }
 
+/// Builder for creating a [`Tokenizer`] instance.
+///
+/// `TokenizerBuilder` provides a fluent API for configuring and building a tokenizer
+/// with various options such as dictionary selection, tokenization mode, character filters,
+/// and token filters. The build-flow orchestration is delegated to
+/// [`lindera_binding_core::CoreTokenizerBuilder`].
+///
+/// Setters return a builder handle sharing the same configuration, so both the
+/// chained style (`builder.setMode(...).setDictionary(...).build()`) and the
+/// sequential style (one call per statement) work. wasm-bindgen cannot return
+/// the borrowed JS `this`, hence the shared-state handle instead.
+#[wasm_bindgen]
+pub struct TokenizerBuilder {
+    /// Configuration shared by every handle returned from the setters.
+    state: Rc<RefCell<BuilderState>>,
+}
+
 #[wasm_bindgen]
 impl TokenizerBuilder {
     /// Creates a new `TokenizerBuilder` instance.
@@ -41,10 +55,12 @@ impl TokenizerBuilder {
         let inner = CoreTokenizerBuilder::new().map_err(|e| JsValue::from_str(&e.to_string()))?;
 
         Ok(Self {
-            inner,
-            dictionary_instance: None,
-            user_dictionary_instance: None,
-            mode_for_instance: None,
+            state: Rc::new(RefCell::new(BuilderState {
+                inner,
+                dictionary_instance: None,
+                user_dictionary_instance: None,
+                mode_for_instance: None,
+            })),
         })
     }
 
@@ -52,12 +68,17 @@ impl TokenizerBuilder {
     ///
     /// If a dictionary instance was set via `setDictionaryInstance()`,
     /// it will be used directly instead of loading from a URI.
-    pub fn build(self) -> Result<Tokenizer, JsValue> {
-        if let Some(dict) = self.dictionary_instance {
-            // Build tokenizer using the pre-loaded dictionary instance.
-            let user_dict = self.user_dictionary_instance.map(|d| d.inner);
+    ///
+    /// The builder remains usable afterwards, so multiple tokenizers can be
+    /// built from the same configuration.
+    pub fn build(&self) -> Result<Tokenizer, JsValue> {
+        let state = self.state.borrow();
+        if let Some(dict) = state.dictionary_instance.clone() {
+            // Build tokenizer using the pre-loaded dictionary instance
+            // (dictionaries are cheap to clone: their payload is shared).
+            let user_dict = state.user_dictionary_instance.clone().map(|d| d.inner);
             let inner = CoreTokenizer::from_segmenter(
-                self.mode_for_instance.as_deref().unwrap_or("normal"),
+                state.mode_for_instance.as_deref().unwrap_or("normal"),
                 dict.inner,
                 user_dict,
             )
@@ -65,7 +86,7 @@ impl TokenizerBuilder {
 
             Ok(Tokenizer { inner })
         } else {
-            let inner = self
+            let inner = state
                 .inner
                 .build()
                 .map_err(|e| JsValue::from_str(&e.to_string()))?;
@@ -74,33 +95,55 @@ impl TokenizerBuilder {
         }
     }
 
-    /// Sets the tokenization mode.
-    #[wasm_bindgen(js_name = "setMode")]
-    pub fn set_mode(&mut self, mode: &str) -> Result<(), JsValue> {
-        self.inner
-            .set_mode(mode)
-            .map_err(|e| JsValue::from_str(&e.to_string()))?;
-        self.mode_for_instance = Some(mode.to_string());
+    /// Returns a new handle sharing this builder's configuration.
+    fn share(&self) -> TokenizerBuilder {
+        TokenizerBuilder {
+            state: Rc::clone(&self.state),
+        }
+    }
 
-        Ok(())
+    /// Sets the tokenization mode.
+    ///
+    /// Returns a builder handle sharing this configuration, enabling method chaining.
+    #[wasm_bindgen(js_name = "setMode")]
+    pub fn set_mode(&self, mode: &str) -> Result<TokenizerBuilder, JsValue> {
+        {
+            let mut state = self.state.borrow_mut();
+            state
+                .inner
+                .set_mode(mode)
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            state.mode_for_instance = Some(mode.to_string());
+        }
+
+        Ok(self.share())
     }
 
     /// Sets the dictionary to use for tokenization by URI.
+    ///
+    /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "setDictionary")]
-    pub fn set_dictionary(&mut self, uri: &str) -> Result<(), JsValue> {
-        self.inner.set_dictionary(uri);
-        self.dictionary_instance = None;
+    pub fn set_dictionary(&self, uri: &str) -> TokenizerBuilder {
+        {
+            let mut state = self.state.borrow_mut();
+            state.inner.set_dictionary(uri);
+            state.dictionary_instance = None;
+        }
 
-        Ok(())
+        self.share()
     }
 
     /// Sets a pre-loaded dictionary instance for tokenization.
     ///
     /// Use this method when the dictionary has been loaded from bytes
     /// (e.g., via `loadDictionaryFromBytes()`) instead of from a URI.
+    ///
+    /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "setDictionaryInstance")]
-    pub fn set_dictionary_instance(&mut self, dictionary: JsDictionary) {
-        self.dictionary_instance = Some(dictionary);
+    pub fn set_dictionary_instance(&self, dictionary: JsDictionary) -> TokenizerBuilder {
+        self.state.borrow_mut().dictionary_instance = Some(dictionary);
+
+        self.share()
     }
 
     /// Sets a pre-loaded user dictionary instance.
@@ -108,70 +151,99 @@ impl TokenizerBuilder {
     /// Use this method with a user dictionary loaded from bytes via
     /// `loadUserDictionaryFromBytes()` or `loadUserDictionaryBinFromBytes()`;
     /// URI-based user dictionaries are not available on WebAssembly (#972).
+    ///
+    /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "setUserDictionaryInstance")]
-    pub fn set_user_dictionary_instance(&mut self, user_dictionary: JsUserDictionary) {
-        self.user_dictionary_instance = Some(user_dictionary);
+    pub fn set_user_dictionary_instance(&self, user_dictionary: JsUserDictionary) -> TokenizerBuilder {
+        self.state.borrow_mut().user_dictionary_instance = Some(user_dictionary);
+
+        self.share()
     }
 
     /// Sets whether to keep whitespace tokens in the output.
+    ///
+    /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "setKeepWhitespace")]
-    pub fn set_keep_whitespace(&mut self, keep: bool) -> Result<(), JsValue> {
-        self.inner.set_keep_whitespace(keep);
+    pub fn set_keep_whitespace(&self, keep: bool) -> TokenizerBuilder {
+        self.state.borrow_mut().inner.set_keep_whitespace(keep);
 
-        Ok(())
+        self.share()
     }
 
     /// Appends a character filter to the tokenization pipeline.
+    ///
+    /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "appendCharacterFilter")]
-    pub fn append_character_filter(&mut self, name: &str, args: JsValue) -> Result<(), JsValue> {
+    pub fn append_character_filter(&self, name: &str, args: JsValue) -> Result<TokenizerBuilder, JsValue> {
         let a = parse_filter_args(args)?;
-        self.inner.append_character_filter(name, &a);
+        self.state.borrow_mut().inner.append_character_filter(name, &a);
 
-        Ok(())
+        Ok(self.share())
     }
 
     /// Appends a token filter to the tokenization pipeline.
+    ///
+    /// Returns a builder handle sharing this configuration, enabling method chaining.
     #[wasm_bindgen(js_name = "appendTokenFilter")]
-    pub fn append_token_filter(&mut self, name: &str, args: JsValue) -> Result<(), JsValue> {
+    pub fn append_token_filter(&self, name: &str, args: JsValue) -> Result<TokenizerBuilder, JsValue> {
         let a = parse_filter_args(args)?;
-        self.inner.append_token_filter(name, &a);
+        self.state.borrow_mut().inner.append_token_filter(name, &a);
 
-        Ok(())
+        Ok(self.share())
     }
 
     // Python-style aliases (snake_case)
+
+    /// Sets the tokenization mode (snake_case alias).
     #[wasm_bindgen(js_name = "set_mode")]
-    pub fn py_set_mode(&mut self, mode: &str) -> Result<(), JsValue> {
+    pub fn py_set_mode(&self, mode: &str) -> Result<TokenizerBuilder, JsValue> {
         self.set_mode(mode)
     }
 
+    /// Sets the dictionary by URI (snake_case alias).
     #[wasm_bindgen(js_name = "set_dictionary")]
-    pub fn py_set_dictionary(&mut self, uri: &str) -> Result<(), JsValue> {
+    pub fn py_set_dictionary(&self, uri: &str) -> TokenizerBuilder {
         self.set_dictionary(uri)
     }
 
+    /// Sets a pre-loaded dictionary instance (snake_case alias).
     #[wasm_bindgen(js_name = "set_dictionary_instance")]
-    pub fn py_set_dictionary_instance(&mut self, dictionary: JsDictionary) {
+    pub fn py_set_dictionary_instance(&self, dictionary: JsDictionary) -> TokenizerBuilder {
         self.set_dictionary_instance(dictionary)
     }
 
+    /// Sets a pre-loaded user dictionary instance (snake_case alias).
     #[wasm_bindgen(js_name = "set_user_dictionary_instance")]
-    pub fn py_set_user_dictionary_instance(&mut self, user_dictionary: JsUserDictionary) {
+    pub fn py_set_user_dictionary_instance(
+        &self,
+        user_dictionary: JsUserDictionary,
+    ) -> TokenizerBuilder {
         self.set_user_dictionary_instance(user_dictionary)
     }
 
+    /// Sets whether to keep whitespace tokens (snake_case alias).
     #[wasm_bindgen(js_name = "set_keep_whitespace")]
-    pub fn py_set_keep_whitespace(&mut self, keep: bool) -> Result<(), JsValue> {
+    pub fn py_set_keep_whitespace(&self, keep: bool) -> TokenizerBuilder {
         self.set_keep_whitespace(keep)
     }
 
+    /// Appends a character filter (snake_case alias).
     #[wasm_bindgen(js_name = "append_character_filter")]
-    pub fn py_append_character_filter(&mut self, name: &str, args: JsValue) -> Result<(), JsValue> {
+    pub fn py_append_character_filter(
+        &self,
+        name: &str,
+        args: JsValue,
+    ) -> Result<TokenizerBuilder, JsValue> {
         self.append_character_filter(name, args)
     }
 
+    /// Appends a token filter (snake_case alias).
     #[wasm_bindgen(js_name = "append_token_filter")]
-    pub fn py_append_token_filter(&mut self, name: &str, args: JsValue) -> Result<(), JsValue> {
+    pub fn py_append_token_filter(
+        &self,
+        name: &str,
+        args: JsValue,
+    ) -> Result<TokenizerBuilder, JsValue> {
         self.append_token_filter(name, args)
     }
 }
@@ -330,9 +402,9 @@ mod tests {
     fn test_tokenize() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -350,9 +422,9 @@ mod tests {
     fn test_tokenize_surfaces_matches_tokenize() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -380,9 +452,9 @@ mod tests {
     fn test_tokenize_with_ipadic() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -395,12 +467,52 @@ mod tests {
 
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen_test]
+    fn test_builder_method_chaining() {
+        use crate::TokenizerBuilder;
+
+        // Chained style: every setter returns a handle sharing the same state.
+        let tokenizer = TokenizerBuilder::new()
+            .unwrap()
+            .set_mode("normal")
+            .unwrap()
+            .set_dictionary("embedded://ipadic")
+            .build()
+            .unwrap();
+
+        let surfaces = tokenizer.tokenize_surfaces("すもももももももものうち").unwrap();
+        assert_eq!(surfaces.len(), 7);
+        assert_eq!(surfaces[0], "すもも");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_builder_handles_share_state() {
+        use crate::TokenizerBuilder;
+
+        // A setter called on a returned handle must affect the original builder,
+        // and the builder must remain usable after `build()`.
+        let builder = TokenizerBuilder::new().unwrap();
+        let handle = builder.set_mode("normal").unwrap();
+        handle.set_dictionary("embedded://ipadic");
+
+        let first = builder.build().unwrap();
+        assert!(!first.tokenize_surfaces("日本語").unwrap().is_empty());
+
+        let second = builder.build().unwrap();
+        assert_eq!(
+            first.tokenize_surfaces("日本語").unwrap(),
+            second.tokenize_surfaces("日本語").unwrap()
+        );
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
     fn test_token_properties() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -426,9 +538,9 @@ mod tests {
     fn test_token_details_by_index() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -453,9 +565,9 @@ mod tests {
     fn test_token_is_plain_serializable_object() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -489,9 +601,9 @@ mod tests {
     fn test_tokenize_decompose_mode() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("decompose").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -508,9 +620,9 @@ mod tests {
     fn test_tokenize_empty_string() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -524,9 +636,9 @@ mod tests {
     fn test_tokenize_nbest() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
-        builder.set_dictionary("embedded://ipadic").unwrap();
+        builder.set_dictionary("embedded://ipadic");
 
         let tokenizer = builder.build().unwrap();
 
@@ -543,7 +655,7 @@ mod tests {
     fn test_builder_set_mode_invalid() {
         use crate::TokenizerBuilder;
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         let result = builder.set_mode("invalid_mode");
 
         assert!(result.is_err());
@@ -572,7 +684,7 @@ mod tests {
 
         let dict = load_dictionary("embedded://ipadic").unwrap();
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("normal").unwrap();
         builder.set_dictionary_instance(dict);
 
@@ -591,7 +703,7 @@ mod tests {
 
         let dict = load_dictionary("embedded://ipadic").unwrap();
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_mode("decompose").unwrap();
         builder.set_dictionary_instance(dict);
 
@@ -611,7 +723,7 @@ mod tests {
 
         let dict = load_dictionary("embedded://ipadic").unwrap();
 
-        let mut builder = TokenizerBuilder::new().unwrap();
+        let builder = TokenizerBuilder::new().unwrap();
         builder.set_dictionary_instance(dict);
 
         let tokenizer = builder.build().unwrap();


### PR DESCRIPTION
Closes #993

## Summary

Brings the Node.js and WASM bindings up to parity with Python, whose `TokenizerBuilder` setters already return `self`: the builder can now be configured with method chaining in every binding, while the sequential one-call-per-statement style keeps working unchanged.

```javascript
const tokenizer = new TokenizerBuilder()
  .setMode("normal")
  .setDictionary("/path/to/ipadic")
  .appendTokenFilter("japanese_stop_tags", { tags: ["助詞,係助詞", "助詞,連体化"] })
  .build();
```

## Design

- **Node.js (napi-rs 3.x)**: the six setters return `&Self` (`Result<&Self>` where fallible). napi maps this to the same JS object — `builder.setMode("normal") === builder` — and the generated `index.d.ts` types every setter as `: this`.
- **WASM (wasm-bindgen)**: borrowed returns are impossible, so the builder state moves into `Rc<RefCell<BuilderState>>`; every setter (camelCase and the snake_case aliases) returns a new handle sharing that state. The returned handle is a different JS object, but it configures the same underlying builder — both styles behave identically. As a side effect, `build()` now takes `&self` and clones the (Arc-backed, cheap) dictionary instances, so **the builder remains usable after `build()`** — previously it was consumed and the JS handle became unusable. Documented in the API reference.
- Backward compatible: existing sequential callers discard the return value; TS `void` → `this`/`TokenizerBuilder` is caller-compatible. Ships in the unreleased v6.0.0.

## Changes

- `lindera-nodejs/src/tokenizer.rs`: setter return types + doc comments; `index.d.ts` regenerated (`index.js` is unchanged — the loader does not depend on return types)
- `lindera-nodejs/tests/test_builder_chaining.js` (new): identity (`r === b`), error propagation mid-chain, full-chain build→tokenize, sequential style
- `lindera-wasm/src/tokenizer.rs`: `Rc<RefCell<BuilderState>>` refactor; 14 setters return state-sharing handles; `build(&self)`; two new wasm tests (chained build, handle state sharing + building twice); existing tests updated to the new signatures
- `lindera-wasm/src/lib.rs`: stale `lindera-wasm-web-ipadic` package name in the crate docs corrected to `lindera-wasm`
- Docs (en/ja): Method Chaining section restored in the Node.js quickstart (correct this time), tokenizer_api notes updated, WASM API reference documents the shared-handle semantics and builder reuse

## Verification

- Node.js: `npm test` 22 tests — 19 pass, 0 fail, 3 skipped (embedded-dictionary guards); `npm run test:types` clean
- Node.js end-to-end: packed the main + platform tarballs (`napi create-npm-dirs` + `npm pack`), installed them into a scratch project, and ran the chained sample against downloaded IPADIC — identity `true`, chained build→tokenize produces the expected surfaces
- WASM: `make test-lindera-wasm` — host 24 tests + `wasm-pack test --node` 35 tests, all pass (includes the new chaining tests)
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `markdownlint-cli2` (docs/src + docs/ja/src): 208 files, 0 errors; `mdbook build docs` succeeds