### PR TITLE
docs(wasm): direct custom embedded builds to scoped npm names

### DIFF
--- a/docs/ja/src/lindera-wasm/installation.md
+++ b/docs/ja/src/lindera-wasm/installation.md
@@ -68,24 +68,22 @@ wasm-pack build --target web --features embed-ipadic,embed-ko-dic
 
 ## npm パッケージの命名規則
 
-辞書を埋め込んだパッケージを自分で公開する際の推奨命名規則は以下の通りです：
+スコープなしの `lindera-wasm-*` プレフィックスは Lindera プロジェクトの名前空間です。辞書を埋め込んだ独自ビルドを npm に公開する場合は、公式パッケージとの誤認を避けるため、必ず自分のスコープ配下の名前で公開してください：
 
 ```text
-lindera-wasm
-lindera-wasm-{dict}
+@your-scope/lindera-wasm-{dict}
 ```
 
 例：
 
-- `lindera-wasm`
-- `lindera-wasm-ipadic`
-- `lindera-wasm-unidic`
-- `lindera-wasm-cjk`
+- `@your-scope/lindera-wasm-ipadic`
+- `@your-scope/lindera-wasm-unidic`
+- `@your-scope/lindera-wasm-cjk`
 
-公開前にパッケージ名を設定するには、生成された `pkg/package.json` の `name` フィールドを編集します。
+公開前にパッケージ名を設定するには、生成された `pkg/package.json` の `name` フィールドを編集します。なお、辞書を埋め込んだパッケージは辞書の再配布にあたるため、各辞書のライセンス条件（帰属表示など）にも従ってください。
 
 > [!NOTE]
-> 本プロジェクトのリリースワークフロー（`.github/workflows/release.yml`）が実際にビルドして npm に公開しているのは、`embed-*` feature を一切使わずに `web` ターゲットでビルドした `lindera-wasm` という汎用パッケージのみです。`lindera-wasm-ipadic` のような辞書名付きのパッケージ名はどこにも公開されていません。これは、対応する `embed-*` feature（上記の[利用可能な Feature フラグ](#利用可能な-feature-フラグ上級者向け)を参照）でローカルビルドし、自分でパッケージ名をリネームした場合に得られる名前の例に過ぎません。
+> 本プロジェクトのリリースワークフロー（`.github/workflows/release.yml`）が実際にビルドして npm に公開しているのは、`embed-*` feature を一切使わずに `web` ターゲットでビルドした `lindera-wasm` という汎用パッケージのみです。`lindera-wasm-ipadic` のようなスコープなしの辞書名付きパッケージ名は、v3 以前のリリースの名残としてプロジェクトが確保しているもので、現在は更新されていません。第三者がこれらの名前で公開することはできません（しないでください）。本ドキュメント内でのこれらの名前は、対応する `embed-*` feature（上記の[利用可能な Feature フラグ](#利用可能な-feature-フラグ上級者向け)を参照）でローカルビルドした場合の説明用の例に過ぎません。
 
 ## npm からのインストール
 

--- a/docs/src/lindera-wasm/installation.md
+++ b/docs/src/lindera-wasm/installation.md
@@ -90,23 +90,27 @@ wasm-pack build --target web --features embed-ipadic,embed-ko-dic
 
 ## NPM Package Naming Convention
 
-When publishing a custom build with embedded dictionaries to npm, the
-recommended naming convention is:
+The unscoped `lindera-wasm-*` prefix is the Lindera project's namespace. If you
+publish a custom build with embedded dictionaries to npm, use a name under your
+own scope so it cannot be mistaken for an official package:
 
 ```text
-lindera-wasm-{dict}
+@your-scope/lindera-wasm-{dict}
 ```
 
 Examples:
 
-- `lindera-wasm-ipadic`
-- `lindera-wasm-unidic`
-- `lindera-wasm-cjk`
+- `@your-scope/lindera-wasm-ipadic`
+- `@your-scope/lindera-wasm-unidic`
+- `@your-scope/lindera-wasm-cjk`
 
-To set the package name before publishing, edit the `name` field in the generated `pkg/package.json`.
+To set the package name before publishing, edit the `name` field in the
+generated `pkg/package.json`. Note that a package with an embedded dictionary
+redistributes that dictionary, so follow the dictionary's license terms
+(attribution and so on) as well.
 
 > [!NOTE]
-> This project's own release workflow (`.github/workflows/release.yml`) only builds and publishes a single package to npm -- `lindera-wasm`, built with `wasm-pack --target web` and without any `embed-*` feature. Dictionary-suffixed names such as `lindera-wasm-ipadic` are not published anywhere; they only illustrate what a local build with an `embed-*` feature (see [Available Feature Flags](#available-feature-flags-advanced) above) would produce after you rename the package yourself.
+> This project's own release workflow (`.github/workflows/release.yml`) only builds and publishes a single package to npm -- `lindera-wasm`, built with `wasm-pack --target web` and without any `embed-*` feature. Unscoped dictionary-suffixed names such as `lindera-wasm-ipadic` are reserved by the project (leftovers from pre-v3 releases, no longer updated) and must not be claimed by third parties; in this documentation they only illustrate what a local build with an `embed-*` feature (see [Available Feature Flags](#available-feature-flags-advanced) above) would produce.
 
 ## Installing from npm
 


### PR DESCRIPTION
## Summary

The "NPM Package Naming Convention" section in the WASM installation guide (en/ja) recommended that users publish their own dictionary-embedded builds under the unscoped `lindera-wasm-{dict}` prefix. This had two problems:

1. **Impersonation / supply-chain risk**: it invites third-party packages that look official but are not controlled by the project. Most of the listed names (`lindera-wasm-ipadic` / `-unidic` / `-cjk` / `-ko-dic` / `-cc-cedict`) are de-facto protected because the project still owns them from the pre-v3 era, but `lindera-wasm-jieba` — and any other suffix — is claimable by anyone today.
2. **The advice could not even be followed**: the example names are already taken by the project, so publishing under them would fail.

## Changes

- Recommend `@your-scope/lindera-wasm-{dict}` for custom embedded builds and state that the unscoped `lindera-wasm-*` prefix is the project's namespace, off-limits to third parties. This matches the standard npm practice of official bare names vs. community builds under the author's scope. The project's own package stays the unscoped `lindera-wasm` (bare-name policy from #987, unchanged).
- Note that a package embedding a dictionary redistributes it, so the dictionary's license terms (attribution, etc.) apply.
- Update the note to explain that the unscoped dictionary-suffixed names are reserved pre-v3 leftovers, no longer updated, and illustrative-only in these docs.
- Section headings are unchanged, so the anchors referenced from seven other doc pages keep working.

## Verification

- `markdownlint-cli2` on both edited files: 0 errors; `mdbook build docs` succeeds
- Confirmed current npm ownership: the five example names are held by the maintainer (2.1.0-era), `lindera-wasm-jieba` is unclaimed

## Follow-up (not in this PR)

Whether to defensively claim the free `lindera-wasm-jieba` name and/or deprecate the 2.x-era `lindera-wasm-<dict>` packages will be decided together with the post-v6.0.0 `npm deprecate` operations tracked in #987.